### PR TITLE
feat(upgrade): accept branch / SHA refs as --target (untagged-target)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -770,6 +770,74 @@ EOF
   check "rc-track final migration ran" \
     test -f "$target_rc_track/docs/glossary/FINAL-MIGRATION-SMOKE.md"
 
+  # 2026-05-15: --target accepts non-tag refs (branch / SHA). Cases:
+  #   1. Branch target → succeeds, TEMPLATE_VERSION carries untagged-<short>.
+  #   2. Short SHA target → same.
+  #   3. Invalid ref → fails with "is not a known tag, branch, or commit".
+  #   4. version-check.sh recognises untagged state and emits WARN.
+  echo "-- upgrade --target accepts non-tag refs (branch / SHA) --"
+  bootstrap_default_branch="$(git -C "$bootstrap_upstream" symbolic-ref --short HEAD 2>/dev/null || echo main)"
+  bootstrap_head_sha="$(git -C "$bootstrap_upstream" rev-parse HEAD)"
+  bootstrap_head_short="${bootstrap_head_sha:0:7}"
+
+  target_branch="$tmp/target-untagged-branch"
+  ./scripts/scaffold.sh "$target_branch" "Untagged Branch Smoke" >/dev/null
+  printf '%s\nunknown\n2026-01-01\n' "$stable_fixture_version" > "$target_branch/TEMPLATE_VERSION"
+  branch_upgrade_rc=0
+  (
+    cd "$target_branch"
+    SWDT_UPSTREAM_URL="$bootstrap_upstream" ./scripts/upgrade.sh --target "$bootstrap_default_branch"
+  ) > "$tmp/upgrade-untagged-branch.log" 2>&1 || branch_upgrade_rc=$?
+  check "branch target upgrade exits 0" \
+    bash -c "[ $branch_upgrade_rc -eq 0 ]"
+  check "branch target log notes branch resolution" \
+    bash -c "grep -q 'Pinning upgrade to --target $bootstrap_default_branch (branch' '$tmp/upgrade-untagged-branch.log'"
+  check "branch target log notes conservative full-walk migrations" \
+    bash -c "grep -q 'conservative full-walk' '$tmp/upgrade-untagged-branch.log'"
+  branch_post_version="$(head -1 "$target_branch/TEMPLATE_VERSION" | tr -d '[:space:]')"
+  check "branch target stamps untagged-<short-sha>" \
+    bash -c "[ '$branch_post_version' = 'untagged-$bootstrap_head_short' ]"
+
+  target_sha="$tmp/target-untagged-sha"
+  ./scripts/scaffold.sh "$target_sha" "Untagged SHA Smoke" >/dev/null
+  printf '%s\nunknown\n2026-01-01\n' "$stable_fixture_version" > "$target_sha/TEMPLATE_VERSION"
+  sha_upgrade_rc=0
+  (
+    cd "$target_sha"
+    SWDT_UPSTREAM_URL="$bootstrap_upstream" ./scripts/upgrade.sh --target "$bootstrap_head_short"
+  ) > "$tmp/upgrade-untagged-sha.log" 2>&1 || sha_upgrade_rc=$?
+  check "short-SHA target upgrade exits 0" \
+    bash -c "[ $sha_upgrade_rc -eq 0 ]"
+  check "short-SHA target log notes commit resolution" \
+    bash -c "grep -q 'Pinning upgrade to --target $bootstrap_head_short (commit' '$tmp/upgrade-untagged-sha.log'"
+  sha_post_version="$(head -1 "$target_sha/TEMPLATE_VERSION" | tr -d '[:space:]')"
+  check "short-SHA target stamps untagged-<short-sha>" \
+    bash -c "[ '$sha_post_version' = 'untagged-$bootstrap_head_short' ]"
+
+  target_bogus="$tmp/target-untagged-bogus"
+  ./scripts/scaffold.sh "$target_bogus" "Untagged Bogus Smoke" >/dev/null
+  printf '%s\nunknown\n2026-01-01\n' "$stable_fixture_version" > "$target_bogus/TEMPLATE_VERSION"
+  bogus_target_rc=0
+  (
+    cd "$target_bogus"
+    SWDT_UPSTREAM_URL="$bootstrap_upstream" ./scripts/upgrade.sh --target no-such-ref-xyz
+  ) > "$tmp/upgrade-untagged-bogus.log" 2>&1 || bogus_target_rc=$?
+  check "invalid --target exits 2" \
+    bash -c "[ $bogus_target_rc -eq 2 ]"
+  check "invalid --target prints tag/branch/commit error" \
+    bash -c "grep -q 'is not a known tag, branch, or commit' '$tmp/upgrade-untagged-bogus.log'"
+
+  # version-check.sh: untagged state surfaces the WARN line and skips
+  # the tag-comparison block entirely (no network probe).
+  vc_untagged_output="$(
+    cd "$target_branch"
+    SWDT_UPSTREAM_URL="$bootstrap_upstream" ./scripts/version-check.sh 2>&1 || true
+  )"
+  check "version-check WARNs on untagged state" \
+    bash -c "echo '$vc_untagged_output' | grep -q 'WARN: Meta-project is on an untagged template state'"
+  check "version-check WARN names the untagged version" \
+    bash -c "echo '$vc_untagged_output' | grep -q 'untagged-$bootstrap_head_short'"
+
   # v0.14.3 / issue #63: atomic_install via tmp+mv must not leave
   # stale .tmp.* files after upgrade.
   check "no stale .tmp.* files after upgrade"               bash -c "[ \"\$(find '$target' -name '*.tmp.*' 2>/dev/null | wc -l)\" -eq 0 ]"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/upgrade.sh [--dry-run | --verify | --resolve | --target <ver> |
+Usage: scripts/upgrade.sh [--dry-run | --verify | --resolve | --target <ref> |
                           --self-test-semver | --help]
 
   --dry-run         Print the upgrade plan; change nothing.
@@ -49,14 +49,21 @@ Usage: scripts/upgrade.sh [--dry-run | --verify | --resolve | --target <ver> |
   --self-test-semver
                     Run the SemVer-sort regression guard for issue #108
                     and exit. No project state needed.
-  --target <ver>    Pin the upgrade to a specific upstream tag (e.g.
-                    v0.14.4). Validates the tag exists, checks it out
-                    in the upstream clone, runs migrations between
-                    current TEMPLATE_VERSION and the target, stamps
-                    target's tag. Without this flag, upgrade.sh
-                    targets the latest stable upstream tag for stable
-                    projects, or the latest upstream tag for projects
-                    already on a pre-release track. (Issues #60/#68.)
+  --target <ref>    Pin the upgrade to a specific upstream ref. Accepts:
+                      * a tag (e.g. v0.14.4)                — stamps the tag
+                      * a branch (e.g. main, feat/foo)      — stamps
+                          "untagged-<short-sha>"
+                      * a short or full commit SHA          — same
+                    Resolution priority: tags first (back-compat), then
+                    branches (refs/heads then refs/remotes/origin), then
+                    commit SHAs. For untagged targets, ALL migrations
+                    strictly greater than the project's current
+                    TEMPLATE_VERSION are run (semver progression
+                    unavailable; conservative full-walk). Without this
+                    flag, upgrade.sh targets the latest stable upstream
+                    tag for stable projects, or the latest upstream tag
+                    for projects already on a pre-release track.
+                    (Issues #60/#68; untagged refs added 2026-05-15.)
   --help, -h        Print this help and exit.
 
 With no flag, run the full upgrade. The script:
@@ -154,7 +161,7 @@ while [[ $# -gt 0 ]]; do
     "--verify")      verify_mode=1; shift ;;
     "--target")
       if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
-        echo "ERROR: --target requires a tag argument (e.g. --target v0.14.4)" >&2
+        echo "ERROR: --target requires a ref argument (tag, branch, or commit SHA — e.g. --target v0.14.4, --target main, --target b7aa9d3)" >&2
         usage >&2
         exit 2
       fi
@@ -365,19 +372,54 @@ else
 fi
 
 # --- Select upstream target before bootstrap ----------------------------------
-# Check out the intended upstream tag before any other steps run.
+# Check out the intended upstream ref before any other steps run.
 # Bootstrap, baseline-clone, and sync all see the selected target state.
-# VERSION inside the clone is the selected target's VERSION, so
-# new_version derived below picks up correctly.
+# VERSION inside the clone is the selected target's VERSION at that ref
+# — for tag targets new_version is derived from it; for untagged targets
+# (branch / SHA) we use a synthetic "untagged-<short-sha>" label instead
+# so the TEMPLATE_VERSION stamp is unambiguously distinct from semver.
+#
+# target_kind tracks how --target resolved: "tag" / "untagged" / "" (none).
+# Resolution priority for --target: tags first (back-compat), then
+# branches (refs/heads, then refs/remotes/origin/<ref>), then commit SHAs.
+target_kind=""
+target_resolved_sha=""
 if [[ -n "$target_version" ]]; then
-  if ! git -C "$workdir/new" rev-parse --verify --quiet "refs/tags/$target_version" >/dev/null; then
-    echo "ERROR: --target $target_version is not a known tag in $upstream." >&2
+  if git -C "$workdir/new" rev-parse --verify --quiet "refs/tags/$target_version" >/dev/null; then
+    target_kind="tag"
+    target_resolved_sha="$(git -C "$workdir/new" rev-parse --verify --quiet "refs/tags/$target_version^{commit}")"
+    echo "Pinning upgrade to --target $target_version (tag)" >&2
+    git -C "$workdir/new" checkout -q "$target_version"
+  elif git -C "$workdir/new" rev-parse --verify --quiet "refs/heads/$target_version" >/dev/null; then
+    target_kind="untagged"
+    target_resolved_sha="$(git -C "$workdir/new" rev-parse --verify --quiet "refs/heads/$target_version^{commit}")"
+    echo "Pinning upgrade to --target $target_version (branch → ${target_resolved_sha:0:7})" >&2
+    git -C "$workdir/new" checkout -q "$target_version"
+  elif git -C "$workdir/new" rev-parse --verify --quiet "refs/remotes/origin/$target_version" >/dev/null; then
+    target_kind="untagged"
+    target_resolved_sha="$(git -C "$workdir/new" rev-parse --verify --quiet "refs/remotes/origin/$target_version^{commit}")"
+    echo "Pinning upgrade to --target $target_version (remote branch → ${target_resolved_sha:0:7})" >&2
+    git -C "$workdir/new" checkout -q "refs/remotes/origin/$target_version"
+  elif git -C "$workdir/new" rev-parse --verify --quiet "${target_version}^{commit}" >/dev/null; then
+    # Bare SHA (short or full). Reject anything that *looks like* a tag
+    # syntactically (starts with v + digit) but did not match the tag
+    # branch above — that case is a typo, not a SHA.
+    if [[ "$target_version" =~ ^v[0-9] ]]; then
+      echo "ERROR: --target $target_version is not a known tag, branch, or commit in $upstream." >&2
+      echo "  Recent tags (last 10):" >&2
+      git -C "$workdir/new" tag -l 'v*' | semver_sort_tags | tail -10 | sed 's/^/    /' >&2
+      exit 2
+    fi
+    target_kind="untagged"
+    target_resolved_sha="$(git -C "$workdir/new" rev-parse --verify --quiet "${target_version}^{commit}")"
+    echo "Pinning upgrade to --target $target_version (commit → ${target_resolved_sha:0:7})" >&2
+    git -C "$workdir/new" checkout -q "$target_resolved_sha"
+  else
+    echo "ERROR: --target $target_version is not a known tag, branch, or commit in $upstream." >&2
     echo "  Recent tags (last 10):" >&2
     git -C "$workdir/new" tag -l 'v*' | semver_sort_tags | tail -10 | sed 's/^/    /' >&2
     exit 2
   fi
-  echo "Pinning upgrade to --target $target_version" >&2
-  git -C "$workdir/new" checkout -q "$target_version"
 else
   all_upstream_tags="$(git -C "$workdir/new" tag -l 'v*' 2>/dev/null | semver_sort_tags || true)"
   if [[ "$local_version" == *-* ]]; then
@@ -726,8 +768,17 @@ if declare -F first_actions_step0_warning >/dev/null; then
   first_actions_step0_warning "$project_root" "upgrade"
 fi
 
-new_version="$(tr -d '[:space:]' < "$workdir/new/VERSION")"
 new_sha="$(git -C "$workdir/new" rev-parse HEAD)"
+if [[ "$target_kind" == "untagged" ]]; then
+  # Synthetic version label for untagged targets (branch / SHA). The
+  # "untagged-" prefix makes the TEMPLATE_VERSION first line visually
+  # distinct from semver so operators recognise a pre-release /
+  # experimental state. version-check.sh prints a WARN line on this
+  # state. (2026-05-15.)
+  new_version="untagged-${new_sha:0:7}"
+else
+  new_version="$(tr -d '[:space:]' < "$workdir/new/VERSION")"
+fi
 
 if [[ "$local_version" == "$new_version" ]]; then
   # Stamp matches upstream. Closes the #61 bug: do not short-circuit
@@ -815,28 +866,53 @@ fi
 # project's current TEMPLATE_VERSION and less-than-or-equal-to the new one,
 # in ascending order. Migrations handle file moves / renames / reshapes that
 # the plain file-sync cannot. Most are no-ops.
+#
+# Untagged targets (branch / SHA): semver progression breaks because
+# new_version is a synthetic "untagged-<sha>" label. Run every migration
+# strictly greater than local_version (conservative full-walk). Migrations
+# are required to be idempotent per their contract, so re-running ones
+# that already applied is safe.
 all_tags=$(git -C "$workdir/new" tag -l 'v*' 2>/dev/null | semver_sort_tags || true)
 migrations_to_run=()
-past_local=0
-for tag in $all_tags; do
-  if [[ $past_local -eq 0 ]]; then
-    [[ "$tag" == "$local_version" ]] && past_local=1
-    continue
-  fi
-  migrations_to_run+=("$tag")
-  [[ "$tag" == "$new_version" ]] && break
-done
-
-# Edge case: local_version doesn't appear in the tag list (e.g., pre-release
-# or hand-stamped). In that case, past_local stays 0 and migrations_to_run is
-# empty. Fall back: run every migration ≤ new_version, letting idempotency
-# guards handle re-runs.
-if [[ $past_local -eq 0 && ${#migrations_to_run[@]} -eq 0 ]]; then
-  echo "NOTE: local_version $local_version does not match any upstream tag — running all migrations ≤ $new_version with idempotency guards." >&2
+if [[ "$target_kind" == "untagged" ]]; then
+  past_local=0
   for tag in $all_tags; do
+    if [[ $past_local -eq 0 ]]; then
+      [[ "$tag" == "$local_version" ]] && past_local=1
+      continue
+    fi
+    migrations_to_run+=("$tag")
+  done
+  # If local_version isn't a known tag (hand-stamped / itself untagged-*),
+  # walk every migration up to tip.
+  if [[ $past_local -eq 0 && ${#migrations_to_run[@]} -eq 0 ]]; then
+    for tag in $all_tags; do
+      migrations_to_run+=("$tag")
+    done
+  fi
+  echo "NOTE: Running all migrations from $local_version to $new_version (semver progression unavailable; conservative full-walk)." >&2
+else
+  past_local=0
+  for tag in $all_tags; do
+    if [[ $past_local -eq 0 ]]; then
+      [[ "$tag" == "$local_version" ]] && past_local=1
+      continue
+    fi
     migrations_to_run+=("$tag")
     [[ "$tag" == "$new_version" ]] && break
   done
+
+  # Edge case: local_version doesn't appear in the tag list (e.g., pre-release
+  # or hand-stamped). In that case, past_local stays 0 and migrations_to_run is
+  # empty. Fall back: run every migration ≤ new_version, letting idempotency
+  # guards handle re-runs.
+  if [[ $past_local -eq 0 && ${#migrations_to_run[@]} -eq 0 ]]; then
+    echo "NOTE: local_version $local_version does not match any upstream tag — running all migrations ≤ $new_version with idempotency guards." >&2
+    for tag in $all_tags; do
+      migrations_to_run+=("$tag")
+      [[ "$tag" == "$new_version" ]] && break
+    done
+  fi
 fi
 
 if [[ ${#migrations_to_run[@]} -gt 0 ]]; then

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -100,6 +100,24 @@ fi
 
 local_version="$(head -1 "$tv" 2>/dev/null | tr -d '[:space:]')"
 
+# Untagged-state surfaceing (2026-05-15).
+#
+# When upgrade.sh --target was given a non-tag ref (branch / SHA), the
+# TEMPLATE_VERSION first line is stamped "untagged-<short-sha>" instead
+# of a semver tag. Surface this prominently so operators know they are
+# not on a stable release cut. Skip the tag-comparison block entirely
+# afterward — semver comparison against a synthetic label is undefined.
+if [[ "$local_version" == untagged-* ]]; then
+  cat <<EOF
+====================================================================
+WARN: Meta-project is on an untagged template state ($local_version);
+      not a stable release. Re-run scripts/upgrade.sh --target <tag>
+      once a stable tag is available to return to a known release cut.
+====================================================================
+EOF
+  exit 0
+fi
+
 # Short timeout — don't stall the session on flaky network.
 all_tags="$(timeout 5 git ls-remote --tags --refs "$upstream_auth" 2>/dev/null \
              | awk '{print $2}' | sed 's|refs/tags/||' \


### PR DESCRIPTION
## Summary

Extends `scripts/upgrade.sh` to accept non-tag refs (branch, short SHA, long SHA) as `--target`, in addition to existing tag-ref behavior. `TEMPLATE_VERSION` stamps `untagged-<sha7>` for non-tag targets. `version-check.sh` emits a WARN line on untagged states. Conservative full-walk migration semantics for untagged targets. `^v[0-9]` typo guard preserves clear errors for typo'd tag names. Backward-compatible: existing tagged-target invocations unchanged.

## Test plan

- Smoke-test 174/174 PASS (11 new assertions covering branch + SHA + invalid-ref + version-check WARN)
- Existing tagged-target cases unchanged

## Why

Enables operator dogfood-iteration without cutting an rc tag each cycle. Per customer ruling 2026-05-15.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade tool now accepts branch names and commit SHAs as targets, in addition to version tags, enabling more flexible targeting during upgrades.
  * Projects on untagged template versions are now clearly marked and flagged with warnings to indicate they are not on a stable release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->