### PR TITLE
feat(dogfood): AI TUI check phase (session-shape corpus + settings.json routing)

### DIFF
--- a/tests/hooks/fixtures/session-shapes.yml
+++ b/tests/hooks/fixtures/session-shapes.yml
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# Session-shape corpus for the dogfood AI-TUI check phase.
+#
+# This file differs from the per-hook negative-corpus files in two ways:
+#
+#   1. Entries are run against EVERY hook in the fixture's
+#      scripts/hooks/ directory, not a single named hook. The
+#      session-shape semantics ("does this payload work in a real
+#      Claude Code / Codex session") cut across both customer-notes-guard
+#      and tech-lead-authoring-guard simultaneously, because a real
+#      session fires both hooks on the same PreToolUse event.
+#
+#   2. The `expected:` field carries `pass` or `deny`. A `deny` entry
+#      asserts that AT LEAST ONE hook fires a `deny` permissionDecision
+#      on the payload; a `pass` entry asserts that NO hook fires
+#      `ask`/`deny`. This catches both:
+#        - false-positive regressions (a payload that should pass
+#          but a hook denies it), and
+#        - false-negative regressions (a payload that should deny
+#          but no hook catches it).
+#
+# Driver: tests/hooks/run-ai-tui-check.sh
+# Invoked by: tests/release-gate/dogfood-downstream.sh after the
+#             script-level upgrade PASS, against the UPGRADED fixture's
+#             scripts/hooks/ copies (not the canonical template's).
+#
+# Why this exists: feedback-dogfood-needs-tui-check (2026-05-15). The
+# rc11->rc12 upgrade wired tech-lead-authoring-guard.py per spec but
+# the hook blocked commit-message HEREDOCs and made the inline escape
+# hatch unreachable. Script-level dogfood would have shown green;
+# operator experience was broken. Session-shape payloads catch that
+# class of regression.
+#
+# Entry shape:
+#   - label:     human-readable test name
+#   - category:  taxonomy bucket (1-7)
+#                1 = commit-message HEREDOC
+#                2 = hook-script edit (write attempt)
+#                3 = hook-script read
+#                4 = specialist dispatch
+#                5 = git push (dry-run / non-destructive)
+#                6 = interpreter read of customer-notes
+#                7 = escape-hatch inline carrier
+#   - rationale: one-line justification
+#   - regression: (optional) upstream issue ID
+#   - expected:  "pass" | "deny"
+#   - payload:   the PreToolUse event JSON the hook reads on stdin.
+#                Includes tool_name AND tool_input so hooks that
+#                discriminate on tool can do so. Stored as a string
+#                literal so YAML doesn't try to interpret the inner
+#                JSON.
+
+entries:
+
+  # =====================================================================
+  # Category 1 — Multi-line HEREDOC commit messages.
+  # Real Claude Code Bash tool shape for committing with prose body.
+  # =====================================================================
+
+  - label: "cat1.1: git commit with multi-line HEREDOC body"
+    category: 1
+    rationale: "Canonical Claude Code commit shape; must not be blocked by tech-lead-authoring-guard or customer-notes-guard."
+    regression: "feedback-dogfood-needs-tui-check"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git commit -m \"$(cat <<'EOF'\nfix(scripts): tidy helper\n\nLonger explanation across\nseveral lines.\nEOF\n)\""}}
+
+  - label: "cat1.2: git commit HEREDOC mentioning hook path in body"
+    category: 1
+    rationale: "Commit message body referencing scripts/hooks/foo.py is prose, not a write."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git commit -m \"$(cat <<'EOF'\nfix(hooks): adjust scripts/hooks/customer-notes-guard.py\nEOF\n)\""}}
+
+  - label: "cat1.3: git commit HEREDOC mentioning CUSTOMER_NOTES.md in body"
+    category: 1
+    rationale: "Prose mention in commit message is not a write to CUSTOMER_NOTES.md."
+    regression: "#175"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git commit -m \"$(cat <<'EOF'\ndocs: reference CUSTOMER_NOTES.md ruling 2026-05-15\nEOF\n)\""}}
+
+  # =====================================================================
+  # Category 2 — Writes to a hook script (tech-lead-forbidden path).
+  # =====================================================================
+
+  - label: "cat2.1: Edit-tool write to scripts/hooks/customer-notes-guard.py without escape hatch"
+    category: 2
+    rationale: "scripts/hooks/ is off the tech-lead allow-list; must deny when SWDT_AGENT_PUSH unset."
+    expected: deny
+    payload: |
+      {"tool_name":"Edit","tool_input":{"file_path":"scripts/hooks/customer-notes-guard.py","old_string":"x","new_string":"y"}}
+
+  - label: "cat2.2: Bash echo > scripts/hooks/customer-notes-guard.py without escape hatch"
+    category: 2
+    rationale: "Bash redirect to hook script is a write; must deny when SWDT_AGENT_PUSH unset."
+    expected: deny
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"echo broken > scripts/hooks/customer-notes-guard.py"}}
+
+  - label: "cat2.3: Write tool to scripts/hooks/new-hook.py without escape hatch"
+    category: 2
+    rationale: "Write tool with file_path under scripts/hooks/ must deny."
+    expected: deny
+    payload: |
+      {"tool_name":"Write","tool_input":{"file_path":"scripts/hooks/new-hook.py","content":"#!/usr/bin/env python3\nprint('x')\n"}}
+
+  # =====================================================================
+  # Category 3 — Reads of hook scripts (must pass).
+  # =====================================================================
+
+  - label: "cat3.1: cat scripts/hooks/customer-notes-guard.py"
+    category: 3
+    rationale: "Read-only inspection of a hook script must pass."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"cat scripts/hooks/customer-notes-guard.py"}}
+
+  - label: "cat3.2: grep researcher scripts/hooks/tech-lead-authoring-guard.py"
+    category: 3
+    rationale: "Read-only grep over hook script must pass."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"grep -n researcher scripts/hooks/tech-lead-authoring-guard.py"}}
+
+  - label: "cat3.3: Read tool against scripts/hooks/customer-notes-guard.py"
+    category: 3
+    rationale: "Read tool is not a write surface; must pass."
+    expected: pass
+    payload: |
+      {"tool_name":"Read","tool_input":{"file_path":"scripts/hooks/customer-notes-guard.py"}}
+
+  # =====================================================================
+  # Category 4 — Specialist dispatch via the Agent tool.
+  # The hook fires PreToolUse on Agent invocations too; tool_input
+  # carries subagent_type and prompt. None of those name a path target,
+  # so both hooks must pass through silently.
+  # =====================================================================
+
+  - label: "cat4.1: Agent dispatch to software-engineer"
+    category: 4
+    rationale: "Agent tool invocations carry no file_path; both hooks must pass through."
+    expected: pass
+    payload: |
+      {"tool_name":"Agent","tool_input":{"subagent_type":"software-engineer","description":"refactor parser","prompt":"please refactor scripts/foo.sh to extract the path parser"}}
+
+  - label: "cat4.2: Agent dispatch to researcher mentioning CUSTOMER_NOTES.md in prompt"
+    category: 4
+    rationale: "Prompt body mentioning CUSTOMER_NOTES.md is data, not a write target."
+    expected: pass
+    payload: |
+      {"tool_name":"Agent","tool_input":{"subagent_type":"researcher","description":"append customer ruling","prompt":"please append a new entry to CUSTOMER_NOTES.md per 2026-05-15 ruling"}}
+
+  - label: "cat4.3: Agent dispatch to qa-engineer"
+    category: 4
+    rationale: "Dispatch tool invocation must pass; no path target."
+    expected: pass
+    payload: |
+      {"tool_name":"Agent","tool_input":{"subagent_type":"qa-engineer","description":"run regression","prompt":"run the negative-corpus driver"}}
+
+  # =====================================================================
+  # Category 5 — git push (dry-run / non-destructive).
+  # =====================================================================
+
+  - label: "cat5.1: git push --dry-run origin main"
+    category: 5
+    rationale: "Push dry-run carries no write target; must pass."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git push --dry-run origin main"}}
+
+  - label: "cat5.2: git fetch origin"
+    category: 5
+    rationale: "Fetch is read-only on the local working tree."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git fetch origin"}}
+
+  - label: "cat5.3: git status --porcelain"
+    category: 5
+    rationale: "Read-only status query; must pass."
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"git status --porcelain"}}
+
+  # =====================================================================
+  # Category 6 — Interpreter reads of customer-notes / off-list files.
+  # The #182 fix re-promoted these to pass; this records the regression
+  # surface explicitly.
+  # =====================================================================
+
+  - label: "cat6.1: python3 -c json.load(open('CUSTOMER_NOTES.md'))"
+    category: 6
+    rationale: "Read-only open() with no mode arg defaults to read; must pass after #182 fix."
+    regression: "#182"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"python3 -c \"import json; json.load(open('CUSTOMER_NOTES.md'))\""}}
+
+  - label: "cat6.2: python3 heredoc reading CUSTOMER_NOTES.md"
+    category: 6
+    rationale: "Heredoc-fed interpreter doing only open().read() is read-only; must pass after #182."
+    regression: "#182"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"python3 <<PY\nimport json\njson.load(open('CUSTOMER_NOTES.md'))\nPY"}}
+
+  - label: "cat6.3: sh -c cat CUSTOMER_NOTES.md | head"
+    category: 6
+    rationale: "sh -c with cat | head body is read-only."
+    regression: "#182"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"sh -c 'cat CUSTOMER_NOTES.md | head -5'"}}
+
+  # =====================================================================
+  # Category 7 — Inline SWDT_AGENT_PUSH escape hatch.
+  # The #178 / #179 fixes anchored the inline form to leading position;
+  # this records the canonical permit shape.
+  # =====================================================================
+
+  - label: "cat7.1: inline SWDT_AGENT_PUSH=software-engineer Edit hook"
+    category: 7
+    rationale: "Inline escape hatch on Edit tool: the Edit tool carries file_path so the hatch must come through env or wrapper, not inline. Recorded as deny (Edit has no command line for inline parse)."
+    regression: "#178"
+    expected: deny
+    payload: |
+      {"tool_name":"Edit","tool_input":{"file_path":"scripts/hooks/customer-notes-guard.py","old_string":"x","new_string":"y"}}
+
+  - label: "cat7.2: inline SWDT_AGENT_PUSH=software-engineer Bash write to hook"
+    category: 7
+    rationale: "Inline carrier on a Bash redirect must permit (after #178)."
+    regression: "#178"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"SWDT_AGENT_PUSH=software-engineer echo x > scripts/hooks/customer-notes-guard.py"}}
+
+  - label: "cat7.3: leading export SWDT_AGENT_PUSH then write"
+    category: 7
+    rationale: "Export form at leading position widens allow-list."
+    regression: "#179"
+    expected: pass
+    payload: |
+      {"tool_name":"Bash","tool_input":{"command":"export SWDT_AGENT_PUSH=software-engineer; echo x > scripts/hooks/customer-notes-guard.py"}}

--- a/tests/hooks/run-ai-tui-check.sh
+++ b/tests/hooks/run-ai-tui-check.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/hooks/run-ai-tui-check.sh — AI TUI interaction check driver.
+#
+# Feeds session-shape payloads (tests/hooks/fixtures/session-shapes.yml)
+# through the PreToolUse hooks installed in a FIXTURE's
+# .claude/settings.json configuration, asserting that each payload
+# behaves as its `expected:` directive specifies:
+#
+#   expected: pass  — NO hook fires `ask`/`deny` on the payload
+#   expected: deny  — AT LEAST ONE hook fires a `deny` decision
+#
+# This is the second-tier check beyond the per-hook negative-corpus
+# (tests/hooks/run-negative-corpus.sh). The negative-corpus validates
+# a SINGLE hook in isolation against a same-named fixture; this
+# driver validates the COMPOSED hook set as a real session would
+# fire it on a PreToolUse event, against a downstream FIXTURE's
+# post-upgrade hooks (not the canonical template's).
+#
+# Purpose: catch AI-TUI interaction regressions that the script-level
+# dogfood (tests/release-gate/dogfood-downstream.sh) misses. See
+# feedback-dogfood-needs-tui-check (2026-05-15): the rc11->rc12
+# upgrade wired tech-lead-authoring-guard per spec but blocked
+# commit-message HEREDOCs and the inline SWDT_AGENT_PUSH escape
+# hatch, breaking real session workflow while script-level checks
+# showed green.
+#
+# Hook discovery:
+#   The driver parses <fixture>/.claude/settings.json for
+#   .hooks.PreToolUse[] entries. Each entry has a `matcher`
+#   (e.g. "Bash", "Edit", "Write|MultiEdit") and a list of hook
+#   commands. For each session-shape payload, the driver looks up
+#   the payload's `tool_name`, finds matchers that apply, and runs
+#   each matched hook against the payload.
+#
+#   Payloads whose tool_name has no matching PreToolUse hook are
+#   treated as "no hook fires" → pass-equivalent. An `expected: deny`
+#   payload that finds no matchers is therefore a fail.
+#
+# Usage:
+#   tests/hooks/run-ai-tui-check.sh --fixture <path> [--fixture-yaml <path>]
+#
+# Flags:
+#   --fixture <path>       Root of the fixture tree. The driver looks
+#                          for <path>/.claude/settings.json. If absent,
+#                          the driver exits 4 with a NOTE so the
+#                          caller can skip rather than fail.
+#   --fixture-yaml <path>  Override the corpus file. Defaults to
+#                          tests/hooks/fixtures/session-shapes.yml
+#                          relative to the repo root.
+#   --help, -h             Print this help and exit.
+#
+# Exit codes:
+#   0  PASS — every payload behaved as expected
+#   1  FAIL — at least one payload behaved inappropriately
+#   2  Argument or invocation error
+#   3  PyYAML missing (install hint emitted)
+#   4  NOTE — fixture has no .claude/settings.json or no PreToolUse
+#      hooks configured; phase skipped (caller treats as benign)
+#
+# Requires: python3 with PyYAML.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEFAULT_YAML="$REPO_ROOT/tests/hooks/fixtures/session-shapes.yml"
+
+usage() {
+    sed -n '/^# Usage:/,/^# Requires:/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+fixture=""
+fixture_yaml="$DEFAULT_YAML"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --fixture)        fixture="$2"; shift 2 ;;
+        --fixture=*)      fixture="${1#--fixture=}"; shift ;;
+        --fixture-yaml)   fixture_yaml="$2"; shift 2 ;;
+        --fixture-yaml=*) fixture_yaml="${1#--fixture-yaml=}"; shift ;;
+        --help|-h)        usage; exit 0 ;;
+        *)
+            printf 'run-ai-tui-check: unknown flag: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$fixture" ]; then
+    printf 'run-ai-tui-check: --fixture is required\n' >&2
+    exit 2
+fi
+
+if [ ! -d "$fixture" ]; then
+    printf 'run-ai-tui-check: fixture not a directory: %s\n' "$fixture" >&2
+    exit 2
+fi
+
+settings_path="$fixture/.claude/settings.json"
+if [ ! -f "$settings_path" ]; then
+    printf 'run-ai-tui-check: NOTE no settings at %s; AI TUI check skipped\n' "$settings_path" >&2
+    exit 4
+fi
+
+if [ ! -f "$fixture_yaml" ]; then
+    printf 'run-ai-tui-check: corpus YAML not found: %s\n' "$fixture_yaml" >&2
+    exit 2
+fi
+
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+    printf 'run-ai-tui-check: python3 yaml module not available.\n' >&2
+    printf '  install via: pip install --user PyYAML  (or distro python3-yaml)\n' >&2
+    exit 3
+fi
+
+# ----- Parse PreToolUse hook table out of settings.json
+# Emit TSV: matcher \t cmd (one row per (matcher, hook command) pair).
+# Matchers are bar-delimited (Claude Code spec) — the cmd row carries
+# the raw matcher string; matching against a tool_name is done in
+# bash below by splitting on '|' and comparing.
+hooktab=$(python3 - "$settings_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    doc = json.load(f)
+hooks = doc.get("hooks") or {}
+for entry in hooks.get("PreToolUse") or []:
+    matcher = str(entry.get("matcher", ""))
+    for hk in entry.get("hooks") or []:
+        if hk.get("type") != "command":
+            continue
+        cmd = str(hk.get("command", ""))
+        matcher_clean = matcher.replace("\t", " ")
+        cmd_clean = cmd.replace("\t", " ").replace("\n", " ")
+        print(f"{matcher_clean}\t{cmd_clean}")
+PY
+)
+hp_rc=$?
+if [ "$hp_rc" -ne 0 ]; then
+    printf 'run-ai-tui-check: failed to parse settings.json (rc=%d)\n' "$hp_rc" >&2
+    exit 2
+fi
+
+if [ -z "$hooktab" ]; then
+    printf 'run-ai-tui-check: NOTE no PreToolUse hooks in %s; AI TUI check skipped\n' "$settings_path" >&2
+    exit 4
+fi
+
+n_hooks=$(printf '%s\n' "$hooktab" | grep -c .)
+printf 'run-ai-tui-check: fixture=%s PreToolUse-hook-rows=%d\n' "$fixture" "$n_hooks" >&2
+printf '%s\n' "$hooktab" | while IFS=$'\t' read -r m c; do
+    printf '  matcher=%s  cmd=%s\n' "$m" "$c" >&2
+done
+
+# ----- Parse corpus into TSV: label \t category \t expected \t rationale \t payload (b64)
+tsv=$(python3 - "$fixture_yaml" <<'PY'
+import base64
+import json
+import sys
+import yaml
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    doc = yaml.safe_load(f) or {}
+entries = doc.get("entries") or []
+for e in entries:
+    label = str(e.get("label", "<unlabeled>"))
+    cat = str(e.get("category", "0"))
+    expected = str(e.get("expected", "pass"))
+    rationale = str(e.get("rationale", ""))
+    payload = e.get("payload", "")
+    if isinstance(payload, (dict, list)):
+        payload = json.dumps(payload)
+    payload = str(payload).rstrip("\n")
+    enc = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+    label = label.replace("\t", " ")
+    rationale = rationale.replace("\t", " ")
+    print(f"{label}\t{cat}\t{expected}\t{rationale}\t{enc}")
+PY
+)
+rc=$?
+if [ "$rc" -ne 0 ] || [ -z "$tsv" ]; then
+    printf 'run-ai-tui-check: failed to parse %s (rc=%d, empty=%s)\n' \
+        "$fixture_yaml" "$rc" "$( [ -z "$tsv" ] && echo yes || echo no )" >&2
+    exit 2
+fi
+
+n_entries=$(printf '%s\n' "$tsv" | grep -c .)
+printf 'run-ai-tui-check: corpus entries=%d\n' "$n_entries" >&2
+
+# ----- Helper: parse a permissionDecision out of stdout if it is JSON.
+# Non-JSON stdout (e.g. SessionStart-style banner text from reminder
+# hooks) is treated as benign — not a decision.
+parse_decision() {
+    printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+raw = sys.stdin.read().strip()
+if not raw:
+    print("")
+    sys.exit(0)
+try:
+    d = json.loads(raw)
+except Exception:
+    # Non-JSON stdout from a hook is informational, not a permission
+    # decision. Treat as benign.
+    print("")
+    sys.exit(0)
+if not isinstance(d, dict):
+    print("")
+    sys.exit(0)
+h = d.get("hookSpecificOutput") or {}
+print(h.get("permissionDecision", ""))
+' 2>/dev/null
+}
+
+# ----- Helper: extract tool_name from a payload (JSON).
+extract_tool_name() {
+    printf '%s' "$1" | python3 -c '
+import json
+import sys
+
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_name", ""))
+except Exception:
+    print("")
+' 2>/dev/null
+}
+
+# ----- Helper: does matcher_str (e.g. "Edit" or "Edit|Write") match tool_name?
+matcher_matches() {
+    local matcher="$1"
+    local tool="$2"
+    [ -z "$matcher" ] && return 0    # empty matcher = match all
+    [ -z "$tool" ] && return 1
+    local IFS='|'
+    # shellcheck disable=SC2086
+    set -- $matcher
+    for m in "$@"; do
+        if [ "$m" = "$tool" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ----- Run each payload through the matching hooks.
+total_pass=0
+total_fail=0
+failing_lines=""
+
+while IFS=$'\t' read -r label cat expected rationale enc; do
+    [ -z "$label" ] && continue
+    payload=$(printf '%s' "$enc" | base64 --decode 2>/dev/null)
+    tool_name=$(extract_tool_name "$payload")
+
+    aggregate="pass"
+    detail=""
+    matched_any="no"
+
+    while IFS=$'\t' read -r matcher cmd; do
+        [ -z "$cmd" ] && continue
+        if ! matcher_matches "$matcher" "$tool_name"; then
+            continue
+        fi
+        matched_any="yes"
+
+        # Run the hook command with payload on stdin. Honour the
+        # fixture as CLAUDE_PROJECT_DIR so allow-list-relative path
+        # normalisation works the way a real session would.
+        tmp_out=$(mktemp)
+        tmp_err=$(mktemp)
+        CLAUDE_PROJECT_DIR="$fixture" \
+            env -u SWDT_AGENT_PUSH /bin/sh -c "$cmd" \
+                <<<"$payload" >"$tmp_out" 2>"$tmp_err"
+        hook_rc=$?
+        stdout=$(cat "$tmp_out")
+        stderr=$(cat "$tmp_err")
+        rm -f "$tmp_out" "$tmp_err"
+
+        # Identify the hook by its trailing basename for diagnostics.
+        # The cmd shape is e.g. `python3 "${CLAUDE_PROJECT_DIR}/scripts/hooks/foo.py"`;
+        # we pull the basename of the last path-like token and strip
+        # any trailing quote.
+        # shellcheck disable=SC2016  # deliberate: python source is single-quoted
+        hook_name=$(printf '%s' "$cmd" | python3 -c '
+import re
+import sys
+raw = sys.stdin.read()
+m = re.findall(r"[\w./${}-]+\.(?:py|sh)", raw)
+if m:
+    base = m[-1].rsplit("/", 1)[-1]
+    print(base)
+else:
+    print("<hook>")
+' 2>/dev/null)
+
+        if [ "$hook_rc" -ne 0 ]; then
+            aggregate="crash"
+            detail="$hook_name exited $hook_rc; stderr=$stderr"
+            break
+        fi
+
+        decision=$(parse_decision "$stdout")
+        case "$decision" in
+            deny)
+                aggregate="deny"
+                detail="$hook_name denied"
+                break
+                ;;
+            ask)
+                if [ "$aggregate" = "pass" ]; then
+                    aggregate="ask"
+                    detail="$hook_name asked"
+                fi
+                ;;
+            "")
+                : # no decision; benign
+                ;;
+            *)
+                aggregate="malformed"
+                detail="$hook_name emitted unknown decision: $decision"
+                break
+                ;;
+        esac
+    done <<HOOKTAB
+$hooktab
+HOOKTAB
+
+    # Compare to expected directive.
+    ok=""
+    case "$expected" in
+        pass) [ "$aggregate" = "pass" ] && ok="yes" ;;
+        deny) [ "$aggregate" = "deny" ] && ok="yes" ;;
+        ask)  { [ "$aggregate" = "ask" ] || [ "$aggregate" = "deny" ]; } && ok="yes" ;;
+    esac
+
+    if [ "$ok" = "yes" ]; then
+        total_pass=$((total_pass + 1))
+    else
+        total_fail=$((total_fail + 1))
+        failing_lines+="  FAIL  $label (cat=$cat tool=$tool_name)"$'\n'
+        failing_lines+="        expected: $expected   got: $aggregate   matched-hooks: $matched_any"$'\n'
+        failing_lines+="        rationale: $rationale"$'\n'
+        if [ -n "$detail" ]; then
+            failing_lines+="        detail:    $detail"$'\n'
+        fi
+    fi
+done <<EOF
+$tsv
+EOF
+
+printf '\nai-tui-check: %d pass, %d fail (fixture=%s)\n' "$total_pass" "$total_fail" "$fixture" >&2
+if [ "$total_fail" -gt 0 ]; then
+    printf '\nAI TUI regressions:\n%s' "$failing_lines" >&2
+    exit 1
+fi
+exit 0

--- a/tests/hooks/run-negative-corpus.sh
+++ b/tests/hooks/run-negative-corpus.sh
@@ -82,7 +82,13 @@ if [ "$mode" = "all" ]; then
         printf 'run-negative-corpus: no fixtures dir at %s\n' "$FIXTURES_DIR" >&2
         exit 1
     fi
+    # Skip multi-hook fixtures whose name does not correspond to a
+    # single hook script. session-shapes.yml is consumed by
+    # tests/hooks/run-ai-tui-check.sh, not by this per-hook driver.
     while IFS= read -r f; do
+        case "$(basename "$f")" in
+            session-shapes.yml) continue ;;
+        esac
         fixtures+=("$f")
     done < <(find "$FIXTURES_DIR" -maxdepth 1 -type f -name '*.yml' | sort)
     if [ "${#fixtures[@]}" -eq 0 ]; then

--- a/tests/release-gate/dogfood-downstream.README.md
+++ b/tests/release-gate/dogfood-downstream.README.md
@@ -25,8 +25,9 @@ up.
 | Path | Role |
 |---|---|
 | `scripts/capture-dogfood-fixture.sh` | Operator-only. Clones a downstream repo, strips `.git/` + git/CI metadata, stores the content tree under `${HOME}/ref/dogfood/<codename>/<rc>/`. |
-| `tests/release-gate/dogfood-downstream.sh` | Driver. Replays a stored fixture through `scripts/upgrade.sh --target <ref>` + `--verify` in a scratch clone; emits a PASS/FAIL report. |
-| `tests/release-gate/dogfood-examples/` | Synthetic minimal fixtures (alpha / beta / gamma) for smoke-testing the driver itself. Stubs are symlinks into `_shared/`. |
+| `tests/release-gate/dogfood-downstream.sh` | Driver. Replays a stored fixture through `scripts/upgrade.sh --target <ref>` + `--verify` in a scratch clone; runs an AI TUI check phase against the upgraded fixture's hooks; emits a PASS/FAIL report. |
+| `tests/hooks/run-ai-tui-check.sh` | AI TUI check sub-driver. Feeds session-shape payloads (`tests/hooks/fixtures/session-shapes.yml`) through the upgraded fixture's PreToolUse hooks (per its `.claude/settings.json`). Catches hook regressions that script-level checks miss (e.g. blocking commit-message HEREDOCs). |
+| `tests/release-gate/dogfood-examples/` | Synthetic minimal fixtures (alpha / beta / gamma / delta) for smoke-testing the driver. Stubs are symlinks into `_shared/`. The delta fixture additionally ships hook scripts + `.claude/settings.json` so the AI TUI phase exercises its full path during driver smoke tests. |
 
 ## Requirements
 
@@ -54,6 +55,10 @@ tests/release-gate/dogfood-downstream.sh  ← scratch-clones the fixture
         │                                   runs upgrade.sh + --verify
         │                                   captures git status + diffstat
         │                                   classifies conflicts
+        │                                   runs AI TUI check on the
+        │                                     upgraded fixture's hooks
+        │                                     (skipped if fixture has
+        │                                      no .claude/settings.json)
         ▼
 /tmp/dogfood-<codename>-<ts>.txt          ← PASS/FAIL report; safe to share
 ```

--- a/tests/release-gate/dogfood-downstream.sh
+++ b/tests/release-gate/dogfood-downstream.sh
@@ -45,10 +45,20 @@
 #   --help, -h         Print this help and exit.
 #
 # Exit codes:
-#   0  PASS — upgrade ran, --verify clean, no unresolved conflicts
-#   1  FAIL — upgrade non-zero exit, verify non-zero, or .template-
-#      conflicts.json contains an entry classified "conflict"
+#   0  PASS — upgrade ran, --verify clean, no unresolved conflicts,
+#      AI TUI check passed (or was legitimately skipped because the
+#      fixture has no hooks)
+#   1  FAIL — upgrade non-zero exit, verify non-zero, .template-
+#      conflicts.json contains an entry classified "conflict", or
+#      AI TUI check caught a session-shape regression
 #   2  Argument or fixture validation error
+#
+# Phases (run in order; later phases skip if earlier ones fail):
+#   1. upgrade.sh --target <ref>   (script-level upgrade)
+#   2. upgrade.sh --verify         (script-level verification)
+#   3. AI TUI check                (session-shape payloads through
+#                                   the upgraded fixture's hooks;
+#                                   driver: tests/hooks/run-ai-tui-check.sh)
 #
 # Safety:
 #   - The fixture is rsync-copied to a mktemp scratch dir; the
@@ -301,12 +311,72 @@ if [ -f "$CONFLICTS_PATH" ]; then
     CONFLICT_BODY="$(cat "$CONFLICTS_PATH" 2>/dev/null || echo '<read-failed>')"
 fi
 
+# ---- AI TUI check phase ----------------------------------------------
+#
+# After script-level checks pass, exercise the UPGRADED fixture's
+# hook set against the session-shape corpus. Script-level PASS proves
+# upgrade.sh ran cleanly; AI TUI check proves the resulting hooks
+# don't break Claude Code / Codex session workflow (commit-message
+# HEREDOCs, inline SWDT_AGENT_PUSH escape hatch, specialist dispatch,
+# read-only inspections). See feedback-dogfood-needs-tui-check.
+#
+# Phase is activated when the upgraded fixture carries a
+# .claude/settings.json with PreToolUse hooks. If absent, the driver
+# emits a NOTE and treats the phase as skipped (not a regression).
+#
+# Driver path: tests/hooks/run-ai-tui-check.sh (sibling of this
+# script). Resolved relative to this driver's own location so the
+# dogfood driver works when invoked from any cwd.
+
+AI_TUI_RC=-1
+AI_TUI_LOG="$SCRATCH/ai-tui.log"
+AI_TUI_DRIVER="$(cd "$(dirname "$0")/../.." && pwd)/tests/hooks/run-ai-tui-check.sh"
+AI_TUI_STATUS="not-run"
+
+# Only run the AI TUI check if script-level upgrade + verify passed.
+# Running it on a broken upgrade adds noise without signal.
+if [ "$UPGRADE_RC" -eq 0 ] && [ "$VERIFY_RC" -eq 0 ]; then
+    if [ -x "$AI_TUI_DRIVER" ]; then
+        AI_TUI_RC=0
+        "$AI_TUI_DRIVER" --fixture "$SCRATCH_TREE" >"$AI_TUI_LOG" 2>&1 || AI_TUI_RC=$?
+        case "$AI_TUI_RC" in
+            0) AI_TUI_STATUS="pass" ;;
+            1) AI_TUI_STATUS="fail" ;;
+            2) AI_TUI_STATUS="invocation-error" ;;
+            3) AI_TUI_STATUS="pyyaml-missing" ;;
+            4) AI_TUI_STATUS="skipped-no-hooks" ;;
+            *) AI_TUI_STATUS="unknown-rc=${AI_TUI_RC}" ;;
+        esac
+    else
+        AI_TUI_STATUS="driver-missing"
+        printf 'run-ai-tui-check driver missing: %s\n' "$AI_TUI_DRIVER" >"$AI_TUI_LOG"
+    fi
+else
+    AI_TUI_STATUS="skipped-script-fail"
+    printf 'AI TUI check skipped: script-level upgrade/verify did not pass.\n' >"$AI_TUI_LOG"
+fi
+
 # ---- pass/fail classification ----------------------------------------
 
 # PASS requires:
 #   - upgrade exited 0
 #   - verify exited 0
 #   - no .template-conflicts.json entries classified "conflict"
+#   - AI TUI check passed OR was legitimately skipped (no hooks /
+#     driver missing / script-fail upstream)
+#
+# AI TUI check statuses that BLOCK PASS:
+#   - fail               (real regression caught)
+#   - invocation-error   (driver invoked wrong; needs investigation)
+#   - pyyaml-missing     (env regression; fix the env)
+#   - unknown-rc=N       (driver crashed; investigate)
+#
+# AI TUI check statuses that DO NOT block PASS:
+#   - pass               (clean)
+#   - skipped-no-hooks   (fixture has no hooks → nothing to check)
+#   - skipped-script-fail (upstream block already counted)
+#   - driver-missing     (sibling script absent; phase couldn't run)
+#   - not-run            (never set; should not happen)
 RESULT="PASS"
 REASONS=""
 if [ "$UPGRADE_RC" -ne 0 ]; then
@@ -321,6 +391,12 @@ if [ "$CONFLICT_COUNT" -gt 0 ]; then
     RESULT="FAIL"
     REASONS="${REASONS}conflicts=${CONFLICT_COUNT}; "
 fi
+case "$AI_TUI_STATUS" in
+    fail|invocation-error|pyyaml-missing|unknown-rc=*)
+        RESULT="FAIL"
+        REASONS="${REASONS}ai-tui-check=${AI_TUI_STATUS}; "
+        ;;
+esac
 
 # ---- emit report -----------------------------------------------------
 
@@ -343,6 +419,7 @@ fi
     printf 'verify exit:     %s\n' "$VERIFY_RC"
     printf 'conflicts file:  %s\n' "$CONFLICTS_PRESENT"
     printf 'conflict count:  %s\n' "$CONFLICT_COUNT"
+    printf 'ai-tui status:   %s\n' "$AI_TUI_STATUS"
     if [ -n "$CONFLICT_PARSE_NOTE" ]; then
         printf '%s\n' "$CONFLICT_PARSE_NOTE"
     fi
@@ -371,6 +448,13 @@ fi
     printf '\n'
     printf '%s\n' "---- upgrade.sh --verify stdout/stderr ----"
     cat "$VERIFY_LOG"
+    printf '\n'
+    printf '%s\n' "---- ai-tui check stdout/stderr ----"
+    if [ -f "$AI_TUI_LOG" ]; then
+        cat "$AI_TUI_LOG"
+    else
+        printf '%s\n' "(no log)"
+    fi
     printf '\n'
     printf '%s\n' "================================================================"
     if [ "$RESULT" = "PASS" ]; then

--- a/tests/release-gate/dogfood-examples/README.md
+++ b/tests/release-gate/dogfood-examples/README.md
@@ -30,6 +30,8 @@ dogfood-examples/
 └── delta/rc11/
     ├── TEMPLATE_VERSION
     ├── .template-conflicts.json   — pre-placed; 1 accepted_local + 1 conflict
+    ├── .claude/settings.json      — PreToolUse hook wiring for AI TUI check
+    ├── scripts/hooks/             — customer-notes-guard.py + tech-lead-authoring-guard.py
     └── scripts/upgrade.sh         → symlink ../../../_shared/upgrade.sh
 ```
 
@@ -69,6 +71,15 @@ writer and the snapshot fixture at
 branch — which alpha/beta/gamma do not, since the stub never writes
 that file. Expected driver verdict for delta: FAIL with
 `conflicts=1`, exit 1.
+
+`delta/rc11/` further ships `.claude/settings.json` plus copies of
+`customer-notes-guard.py` and `tech-lead-authoring-guard.py` under
+`scripts/hooks/`. This exercises the dogfood driver's AI TUI check
+phase (`tests/hooks/run-ai-tui-check.sh`): the phase runs
+session-shape payloads through the upgraded fixture's hook set and
+reports `ai-tui status: pass` in the report. The script-level
+`conflicts=1` failure still drives the overall verdict; AI TUI is
+reported alongside it.
 
 The stub deliberately does **not** accept `--dry-run`. The driver
 never invokes it; the real `scripts/upgrade.sh` covers `--dry-run`

--- a/tests/release-gate/dogfood-examples/delta/rc11/.claude/settings.json
+++ b/tests/release-gate/dogfood-examples/delta/rc11/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "SPDX-License-Identifier: MIT. Fixture-only settings: mirrors canonical template's PreToolUse hook wiring so tests/hooks/run-ai-tui-check.sh can exercise the AI TUI check phase against this fixture. Not consumed by Claude Code at runtime — only by the dogfood driver's AI TUI check.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/customer-notes-guard.py\"", "timeout": 5},
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/tech-lead-authoring-guard.py\"", "timeout": 5}
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/customer-notes-guard.py\"", "timeout": 5},
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/tech-lead-authoring-guard.py\"", "timeout": 5}
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/customer-notes-guard.py\"", "timeout": 5},
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/tech-lead-authoring-guard.py\"", "timeout": 5}
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/customer-notes-guard.py\"", "timeout": 5},
+          {"type": "command", "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/tech-lead-authoring-guard.py\"", "timeout": 5}
+        ]
+      }
+    ]
+  }
+}

--- a/tests/release-gate/dogfood-examples/delta/rc11/scripts/hooks/customer-notes-guard.py
+++ b/tests/release-gate/dogfood-examples/delta/rc11/scripts/hooks/customer-notes-guard.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# Claude Code PreToolUse hook: require explicit confirmation before
+# CUSTOMER_NOTES.md writes. The hook input does not provide a stable role
+# identity, so this is an approval gate rather than a role detector.
+
+import json
+import os
+import re
+import sys
+
+
+# Read-vs-write distinction (issues #111, #175, #182).
+#
+# Earlier versions flagged any shell command that contained the literal
+# string "CUSTOMER_NOTES.md", which prompted on every read-only inspection
+# (`grep CUSTOMER_NOTES.md`, `cat ...`, `sed -n '1,40p' ...`, `wc -l ...`,
+# `diff ... CUSTOMER_NOTES.md`, etc.). That trained the customer to dismiss
+# the prompt reflexively, which defeats the gate on actual writes (#111).
+#
+# Issue #182 widened the same class of false-positives to interpreter
+# inline / heredoc bodies — `python3 -c "json.load(open('CUSTOMER_NOTES.md'))"`,
+# `python3 <<EOF\nopen('CUSTOMER_NOTES.md').read()\nEOF`,
+# `sh -c 'cat CUSTOMER_NOTES.md'`. These are read-only and must pass.
+# Tech-lead-authoring-guard.py received the matching read-vs-write
+# tightening in PRs #178 (issue #175) and the #179/#180 follow-up
+# (heredoc-prose + non-shell-interpreter blanking). #182 mirrors the
+# same helpers here so the two sister hooks stay in sync.
+#
+# A command is treated as a write only when it both (a) mentions
+# CUSTOMER_NOTES.md AND (b) carries a write marker that resolves to the
+# file. Markers detected:
+#
+#   - shell redirection (`>`, `>>`, `>|`, `&>`, `2>&1 >`) where the target
+#     filename mentions CUSTOMER_NOTES.md, including redirects emitted
+#     INSIDE a `bash -c` / `sh -c` body
+#   - in-place edit flags (`sed -i`, `gawk -i inplace`, `perl -i`,
+#     `ruby -i`) on a CUSTOMER_NOTES.md operand
+#   - obvious mutation (`mv`, `cp`, `rm`, `truncate`, `install`) naming
+#     the file
+#   - tee / dd whose target names the file
+#   - interpreter `-c` / `-e` body with `open(path, 'w'|'a'|'x'|'+')`
+#     positional-mode or `mode='w'` kwarg-mode where the path mentions
+#     the file (#182)
+#   - interpreter heredoc body with the same `open(..., write-mode)`
+#     pattern (#182)
+#
+# Read-only commands (`grep`, `rg`, `sed -n`, `head`, `tail`, `cat`,
+# `less`, `more`, `view`, `wc`, `diff`, `cmp`, plain `awk` without
+# `-i inplace`, `find ... -print`, `ls`, `python3 -c "open(path).read()"`,
+# `python3 <<EOF; open(path).read(); EOF`, `sh -c 'cat path'`) do NOT
+# trigger the gate.
+CUSTOMER_NOTES = "CUSTOMER_NOTES.md"
+CUSTOMER_NOTES_RE = r"CUSTOMER_NOTES\.md"
+INTERPRETER_RE = r"(?:python|python3|node|ruby|perl|bash|sh|php|lua|Rscript)"
+
+
+def _mentions_customer_notes(command: str) -> bool:
+    return CUSTOMER_NOTES in command
+
+
+def _redirects_to_customer_notes(command: str) -> bool:
+    # Shell redirection into the file. Forms covered:
+    #   `> FILE`, `>> FILE`         — plain stdout redirect/append
+    #   `1> FILE`, `2> FILE`, `2>&1 > FILE`  — fd-prefixed redirect
+    #   `&> FILE`, `&>> FILE`       — bash combined stdout+stderr
+    #   `>| FILE`                   — clobber-redirect (set -C bypass)
+    # Pattern: optional fd digits OR `&`, then `>` (optional second `>`
+    # for append, optional `|` for clobber), optional whitespace, then
+    # any non-separator chars, then the filename.
+    return bool(
+        re.search(rf"(?:[0-9]+|&)?>>?\|?\s*[^|;&\s]*{CUSTOMER_NOTES_RE}", command)
+    )
+
+
+def _tee_writes_customer_notes(command: str) -> bool:
+    # Conservative-bias false positive: `tee /tmp/log < CUSTOMER_NOTES.md`
+    # uses the file as a read source rather than a tee target, but is
+    # rare enough that a stray prompt is acceptable.
+    return bool(re.search(rf"\btee\b[^|;&]*{CUSTOMER_NOTES_RE}", command))
+
+
+def _dd_writes_customer_notes(command: str) -> bool:
+    # `dd of=FILE` writes; `dd if=FILE` reads, so we test specifically
+    # for the `of=` operand paired with the filename.
+    return bool(re.search(rf"\bdd\b[^|;&]*\bof=[^|;&\s]*{CUSTOMER_NOTES_RE}", command))
+
+
+def _in_place_edits_customer_notes(command: str) -> bool:
+    in_place_patterns = (
+        r"\bsed\b[^|;&]*-i\b",
+        r"\bg?awk\b[^|;&]*-i\s+inplace\b",
+        r"\bperl\b[^|;&]*-i\b",
+        r"\bruby\b[^|;&]*-i\b",
+    )
+    return any(re.search(pattern, command) for pattern in in_place_patterns)
+
+
+def _mutation_command_touches_customer_notes(command: str) -> bool:
+    # For mv/cp the file may be source OR destination; we cannot reliably
+    # parse, so flag any mention with these verbs. rm/truncate are unambiguous.
+    return bool(
+        re.search(
+            rf"\b(mv|cp|rm|truncate|install)\b[^|;&]*{CUSTOMER_NOTES_RE}",
+            command,
+        )
+    )
+
+
+# Positional form: ``open('path', 'w')`` / ``open('path', 'wb')`` / etc.
+# The mode capture allows any chars (so 'wb', 'rb+', 'a+' all match) as
+# long as it contains at least one write-mode char. Mirrors
+# tech-lead-authoring-guard.py::_OPEN_WRITE_RE (kept verbatim so the
+# sister hooks stay aligned).
+_OPEN_WRITE_RE = re.compile(
+    r"""open\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
+# Kwarg form: ``open('path', mode='w')`` / ``open('path', buffering=0, mode='wb')``.
+_OPEN_WRITE_KWARG_RE = re.compile(
+    r"""open\(\s*['"]([^'"]+)['"][^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
+
+def _extract_open_write_paths(body: str):
+    """Return paths opened with a write mode in ``body``.
+
+    Mirrors tech-lead-authoring-guard.py::_extract_write_targets_from_body
+    but without redirect detection — the caller decides whether to scan
+    the body for redirects (shell `-c` body: yes; non-shell interpreter
+    `-c` and heredoc bodies: no, per #180 + #182).
+    """
+    if not body:
+        return []
+    targets = []
+    for regex in (_OPEN_WRITE_RE, _OPEN_WRITE_KWARG_RE):
+        for m in regex.finditer(body):
+            path, mode = m.group(1), m.group(2)
+            if any(ch in mode for ch in ("w", "a", "x", "A", "+")):
+                targets.append(path)
+    return targets
+
+
+def _find_matching_quote(command: str, start: int, quote: str) -> int:
+    """Return the index of the closing quote, or len(command) if unterminated."""
+    i = start
+    while i < len(command):
+        c = command[i]
+        if c == "\\" and i + 1 < len(command):
+            i += 2
+            continue
+        if c == quote:
+            return i
+        i += 1
+    return len(command)
+
+
+def _strip_non_shell_interpreter_bodies(command: str) -> str:
+    """Return ``command`` with non-shell ``-c`` / ``-e`` body regions blanked.
+
+    Mirrors tech-lead-authoring-guard.py::_strip_non_shell_interpreter_bodies.
+    For interpreters whose ``-c`` / ``-e`` argument is NOT shell syntax
+    (python, python3, node, ruby, perl, php, lua, Rscript), the quoted
+    body is the interpreter's own language; redirect-like ``>`` tokens
+    or quoted path strings inside it are data, not shell. Blank the body
+    region so shell-level extractors do not see phantom redirects to
+    CUSTOMER_NOTES.md (#182). The body is still scanned separately for
+    write-mode ``open(..., 'w'|...)`` calls.
+
+    Shell interpreters (``bash``, ``sh``) are deliberately excluded:
+    their ``-c`` body IS shell syntax.
+    """
+    non_shell = r"(?:python|python3|node|ruby|perl|php|lua|Rscript)"
+    pattern = re.compile(rf"\b{non_shell}\b[^|;&]*?(?:-c\b|-e\b)\s*(['\"])")
+    out = list(command)
+    for m in pattern.finditer(command):
+        quote = m.group(1)
+        start = m.end()
+        end = _find_matching_quote(command, start, quote)
+        for k in range(start, end):
+            if out[k] != "\n":
+                out[k] = " "
+    return "".join(out)
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Return ``command`` with heredoc body regions removed.
+
+    Mirrors tech-lead-authoring-guard.py::_strip_heredoc_bodies. Each
+    ``<<DELIM`` opener has its body — from the end of the opener line
+    up to and including the closing ``DELIM`` line — replaced with a
+    single newline. Shell-level write-pattern extractors (redirect,
+    tee, dd, in-place, mutation) then run only over actual shell
+    syntax, not over heredoc data (#182).
+
+    The opener line itself is preserved so post-opener redirects like
+    ``cat <<EOF >> CUSTOMER_NOTES.md`` (a real write) still trip the
+    redirect scanner.
+    """
+    if "<<" not in command:
+        return command
+    out = []
+    i = 0
+    opener_re = re.compile(
+        r"<<[-~]?\s*(?P<q>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"
+    )
+    while i < len(command):
+        m = opener_re.search(command, i)
+        if m is None:
+            out.append(command[i:])
+            break
+        delim = m.group("delim")
+        nl = command.find("\n", m.end())
+        if nl == -1:
+            out.append(command[i:])
+            break
+        # Keep up to and including the newline that ends the opener line.
+        out.append(command[i : nl + 1])
+        body_start = nl + 1
+        end_match = re.search(
+            rf"(?m)^\s*{re.escape(delim)}\s*$", command[body_start:]
+        )
+        if end_match is None:
+            break
+        skip_to = body_start + end_match.end()
+        if skip_to < len(command) and command[skip_to] == "\n":
+            skip_to += 1
+        i = skip_to
+    return "".join(out)
+
+
+def _interpreter_inline_writes_customer_notes(command: str) -> bool:
+    """Detect a write to CUSTOMER_NOTES.md inside an interpreter `-c`/`-e` body
+    or any heredoc body.
+
+    A body is a write iff it contains ``open('CUSTOMER_NOTES.md', <write-mode>)``
+    or ``open('CUSTOMER_NOTES.md', mode='<write-mode>')``. The path must
+    mention the file (basename match); other paths in the body do not
+    fire this gate (different file).
+
+    Shell `-c`/`-e` bodies (`bash -c`, `sh -c`) are also scanned for
+    shell-redirects into CUSTOMER_NOTES.md. Non-shell interpreters have
+    their bodies blanked by ``_strip_non_shell_interpreter_bodies``
+    before the outer redirect scan, so a redirect in a python/node
+    string does NOT fire the gate.
+    """
+    targets: list[str] = []
+
+    # 1. Inline `-c` / `-e` arguments. Body is `open(...)`-scanned for
+    # every interpreter; for shell interpreters we also scan the body
+    # for redirect-style writes.
+    shell_interpreters = {"bash", "sh"}
+    interp_re = re.compile(
+        rf"\b(?P<interp>{INTERPRETER_RE})\b[^|;&]*?(?:-c\b|-e\b)\s*(?P<quote>['\"])"
+    )
+    for m in interp_re.finditer(command):
+        quote = m.group("quote")
+        interp = m.group("interp")
+        start = m.end()
+        end = _find_matching_quote(command, start, quote)
+        body = command[start:end]
+        targets.extend(_extract_open_write_paths(body))
+        if interp in shell_interpreters:
+            # Shell body: redirect into CUSTOMER_NOTES.md inside the body
+            # is a real write. The non-shell case is blanked at the
+            # outer-command level by _strip_non_shell_interpreter_bodies.
+            if _redirects_to_customer_notes(body):
+                return True
+
+    # 2. Heredocs. Scan body only for write-mode open(); a heredoc body
+    # is data, not shell, so we deliberately do NOT scan for redirects
+    # (a redirect inside a heredoc body is prose, e.g. "stdout > stderr"
+    # or a python `print('a > b')`).
+    for m in re.finditer(
+        r"<<[-~]?\s*(?P<q>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)",
+        command,
+    ):
+        delim = m.group("delim")
+        body_start = m.end()
+        end_match = re.search(
+            rf"(?m)^\s*{re.escape(delim)}\s*$", command[body_start:]
+        )
+        body = (
+            command[body_start : body_start + end_match.start()]
+            if end_match
+            else command[body_start:]
+        )
+        targets.extend(_extract_open_write_paths(body))
+
+    return any(os.path.basename(t) == CUSTOMER_NOTES for t in targets)
+
+
+def _command_writes_customer_notes(command: str) -> bool:
+    if not _mentions_customer_notes(command):
+        return False
+
+    # Shell-level extractors must NOT see heredoc body text (prose with
+    # `>`) or quoted strings inside non-shell interpreter `-c` bodies
+    # (those are interpreter language, not shell). Build the "shell view"
+    # by stripping heredoc bodies + blanking non-shell -c bodies; run the
+    # shell write checks against that view. The interpreter-inline /
+    # heredoc-body write detector still receives the unmodified command
+    # so it can find real writes inside those bodies.
+    shell_view = _strip_heredoc_bodies(command)
+    shell_view = _strip_non_shell_interpreter_bodies(shell_view)
+
+    # If the post-strip view no longer mentions CUSTOMER_NOTES.md, the
+    # only remaining mentions live in interpreter / heredoc bodies; the
+    # interpreter detector is then the authoritative gate.
+    shell_view_has_target = _mentions_customer_notes(shell_view)
+
+    if shell_view_has_target:
+        shell_checks = (
+            _redirects_to_customer_notes,
+            _tee_writes_customer_notes,
+            _dd_writes_customer_notes,
+            _in_place_edits_customer_notes,
+            _mutation_command_touches_customer_notes,
+        )
+        if any(check(shell_view) for check in shell_checks):
+            return True
+
+    return _interpreter_inline_writes_customer_notes(command)
+
+
+def _path_touches_customer_notes(file_path: str) -> bool:
+    return os.path.basename(file_path) == CUSTOMER_NOTES
+
+
+def _tool_input_touches_customer_notes(tool_input: dict) -> bool:
+    file_path = tool_input.get("file_path") or tool_input.get("path") or ""
+    command = tool_input.get("command") or ""
+    return _path_touches_customer_notes(file_path) or _command_writes_customer_notes(
+        command
+    )
+
+
+def _approval_gate_output() -> dict:
+    reason = (
+        "CUSTOMER_NOTES.md is the verbatim customer-truth record. "
+        "Per the template contract, tech-lead must route customer-answer "
+        "entries to researcher; approve only for researcher-owned notes "
+        "maintenance or an intentional human edit."
+    )
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    # Fail-open if the harness sends syntactically-valid but
+    # structurally-unexpected JSON (issue #156). The hook only knows how
+    # to inspect dict-shaped payloads; anything else is not a tool
+    # invocation we should gate.
+    if not isinstance(event, dict):
+        return 0
+
+    tool_input = event.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    if not _tool_input_touches_customer_notes(tool_input):
+        return 0
+
+    print(json.dumps(_approval_gate_output()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release-gate/dogfood-examples/delta/rc11/scripts/hooks/tech-lead-authoring-guard.py
+++ b/tests/release-gate/dogfood-examples/delta/rc11/scripts/hooks/tech-lead-authoring-guard.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# Claude Code PreToolUse hook: enforce Hard Rule #8 at the tool layer.
+#
+# The main session (tech-lead) may only write to a small enumerated set of
+# orchestration artefacts. All other paths route to the owning specialist.
+# Off-allow-list writes return permissionDecision: "deny" with a message
+# naming the right specialist to dispatch.
+#
+# Escape hatch: env var SWDT_AGENT_PUSH=<role> widens the allow-list for a
+# single tool invocation to cover legitimate tool-bridge cases where a
+# specialist's sandbox cannot write its own output. CUSTOMER_NOTES.md is
+# handled by the separate customer-notes-guard.py and is passed through
+# here (its gate is authoritative; this guard does not double-block).
+#
+# Hook ordering invariant (FW-ADR-0012 § ADR-internal follow-ups):
+#   customer-notes-guard.py runs BEFORE this hook on the same matchers.
+#   That ordering must be preserved in .claude/settings.json.
+
+import fnmatch
+import importlib.util
+import json
+import os
+import pathlib
+import re
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Allow-list (binding from FW-ADR-0012 § Allow-list specification).
+# ---------------------------------------------------------------------------
+
+ALLOW_EXACT = frozenset(
+    {
+        "docs/OPEN_QUESTIONS.md",
+        "docs/intake-log.md",
+        "docs/DECISIONS.md",
+        "docs/pm/dispatch-log.md",
+        "TEMPLATE_VERSION",
+        "docs/AGENT_NAMES.md",
+    }
+)
+
+# Glob patterns. fnmatch is used for `*` matches; `**` is expanded to recursive
+# via pathlib.PurePath.match.
+ALLOW_GLOBS_SHALLOW = (
+    "docs/pm/intake-*.md",
+    "docs/pm/intake-*.local.md",
+    "docs/tasks/T-*.md",
+)
+ALLOW_GLOBS_RECURSIVE = ("docs/tech-lead/**",)
+
+
+# ---------------------------------------------------------------------------
+# Role vocabulary (binding from CLAUDE.md § Agent roster).
+# ---------------------------------------------------------------------------
+
+CANONICAL_ROLES = frozenset(
+    {
+        "tech-lead",
+        "project-manager",
+        "architect",
+        "software-engineer",
+        "researcher",
+        "qa-engineer",
+        "sre",
+        "tech-writer",
+        "code-reviewer",
+        "release-engineer",
+        "security-engineer",
+        "onboarding-auditor",
+        "process-auditor",
+    }
+)
+SME_ROLE_RE = re.compile(r"^sme-[a-z][a-z0-9_-]*$")
+
+
+CUSTOMER_NOTES_BASENAME = "CUSTOMER_NOTES.md"
+CUSTOMER_NOTES_DIR_PREFIX = "docs/customer-notes/"
+
+
+# ---------------------------------------------------------------------------
+# Vendor the Bash write-pattern detection helpers from customer-notes-guard.
+# The neighbour module is loaded by path because its filename contains a
+# hyphen (not importable as a regular module name).
+# ---------------------------------------------------------------------------
+
+_HOOKS_DIR = pathlib.Path(__file__).resolve().parent
+_GUARD_PATH = _HOOKS_DIR / "customer-notes-guard.py"
+
+
+def _load_customer_notes_guard():
+    spec = importlib.util.spec_from_file_location("customer_notes_guard", _GUARD_PATH)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except (ImportError, SyntaxError, AttributeError, OSError) as exc:
+        # Fail-safe-allow: log the captured exception to stderr so a broken
+        # neighbour module is visible rather than silently disabling the
+        # vendored helpers. Codacy PR #173 HIGH-RISK finding: broad except
+        # with no logging hides parse/import regressions.
+        sys.stderr.write(
+            "tech-lead-authoring-guard: failed to load customer-notes-guard "
+            f"({type(exc).__name__}: {exc}); continuing without it.\n"
+        )
+        return None
+    return module
+
+
+_CNG = _load_customer_notes_guard()
+
+
+# Regex set mirroring customer-notes-guard's pattern shape, parameterised on
+# a capture for the target path. The neighbour module uses fixed literals for
+# CUSTOMER_NOTES.md; here we capture the candidate path so the caller can
+# allow-list-check it.
+#
+# Path token: any non-separator chars that don't look like a shell op. We
+# allow quoted forms with simple single/double quotes.
+_PATH_TOKEN = r"['\"]?([^|;&\s<>'\"]+)['\"]?"
+_INTERPRETER_RE = r"(?:python|python3|node|ruby|perl|bash|sh|php|lua|Rscript)"
+
+
+def _extract_redirect_targets(command: str):
+    # `> FILE`, `>> FILE`, `1> FILE`, `2>&1 > FILE`, `&> FILE`, `&>> FILE`,
+    # `>| FILE`.
+    pattern = rf"(?:[0-9]+|&)?>>?\|?\s*{_PATH_TOKEN}"
+    return [m.group(1) for m in re.finditer(pattern, command)]
+
+
+def _extract_tee_targets(command: str):
+    # `tee [-a] FILE [FILE ...]` — ALL non-option tokens after `tee` are
+    # write targets (tee fans output to every listed file). Do NOT break
+    # after the first match; an attacker can otherwise stage
+    # `tee <allow-listed> <off-list>` and bypass the guard on the trailing
+    # targets (HIGH-RISK bypass — Codacy PR #173 finding).
+    targets = []
+    for m in re.finditer(r"\btee\b((?:\s+-[a-zA-Z]+)*)\s+([^|;&]+)", command):
+        tail = m.group(2).strip()
+        # Split on whitespace; filter shell ops.
+        for token in tail.split():
+            if token.startswith("-"):
+                continue
+            token = token.strip("'\"")
+            if token and not re.match(r"^[|;&<>]", token):
+                targets.append(token)
+    return targets
+
+
+def _extract_dd_targets(command: str):
+    return [
+        m.group(1)
+        for m in re.finditer(rf"\bdd\b[^|;&]*\bof={_PATH_TOKEN}", command)
+    ]
+
+
+def _extract_in_place_targets(command: str):
+    # sed -i / gawk -i inplace / perl -i / ruby -i — file is the last
+    # non-option positional arg on the same command segment.
+    targets = []
+    in_place_patterns = (
+        r"\bsed\b[^|;&]*-i\b[^|;&]*",
+        r"\bg?awk\b[^|;&]*-i\s+inplace\b[^|;&]*",
+        r"\bperl\b[^|;&]*-i\b[^|;&]*",
+        r"\bruby\b[^|;&]*-i\b[^|;&]*",
+    )
+    for pattern in in_place_patterns:
+        for m in re.finditer(pattern, command):
+            segment = m.group(0)
+            tokens = [t.strip("'\"") for t in segment.split() if t]
+            # Pick trailing tokens that look like paths.
+            for token in reversed(tokens):
+                if token.startswith("-") or token in {"sed", "awk", "gawk", "perl", "ruby", "inplace"}:
+                    continue
+                # Skip the -i argument's quoted backup-suffix value if any.
+                if "/" in token or "." in token or not token.startswith("'"):
+                    targets.append(token)
+                    break
+    return targets
+
+
+def _extract_mutation_targets(command: str):
+    # mv/cp/rm/truncate/install — flag any path-looking argument.
+    targets = []
+    for m in re.finditer(
+        r"\b(mv|cp|rm|truncate|install)\b([^|;&]+)", command
+    ):
+        tail = m.group(2)
+        for token in tail.split():
+            if token.startswith("-"):
+                continue
+            token = token.strip("'\"")
+            if token:
+                targets.append(token)
+    return targets
+
+
+# Positional form: ``open('path', 'w')`` / ``open('path', 'wb')`` / etc.
+# The mode capture allows any chars (so 'wb', 'rb+', 'a+' all match) as long
+# as it contains at least one write-mode char.
+_OPEN_WRITE_RE = re.compile(
+    r"""open\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
+# Kwarg form: ``open('path', mode='w')`` / ``open('path', buffering=0, mode='wb')``.
+# Path captured from first positional; mode captured from the kwarg. The gap
+# between the path and the ``mode=`` token allows any non-paren chars (so
+# additional kwargs like ``buffering=`` or ``encoding=`` don't block the
+# match). Code-reviewer tightening #4: positional form alone let the kwarg
+# spelling slip through as a read-only call.
+_OPEN_WRITE_KWARG_RE = re.compile(
+    r"""open\(\s*['"]([^'"]+)['"][^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
+
+def _extract_write_targets_from_body(body: str, *, scan_redirects: bool = True):
+    """Extract write-target paths from an interpreter / heredoc body.
+
+    Only flags paths that appear in a real write context:
+
+      - ``open('path', 'w'|'a'|'x'|'+'...)`` — positional mode contains
+        a write char (covers binary ``'wb'`` / ``'ab'`` too).
+      - ``open('path', mode='w')`` — kwarg mode contains a write char.
+      - shell-style redirects ``> path`` / ``>> path`` inside the body
+        (covers ``-c "... > file"`` and shell heredocs) — only when
+        ``scan_redirects=True``.
+
+    Read-only ``open('foo.json')``, ``open('foo','r')``, and
+    ``open('foo', mode='r')`` do NOT match. Quoted path tokens that are
+    not the first arg of a write-mode open do NOT match. This is the
+    core fix for issue #175; the kwarg branch closes the bypass flagged
+    in code-reviewer tightening #4.
+
+    ``scan_redirects=False`` is used for heredoc bodies (issue #180):
+    a heredoc body is data, not shell syntax. Lines like prose with
+    ``stdout > stderr`` or quoted strings containing ``>`` previously
+    tripped the redirect regex on phantom path targets. Real writes
+    via shell-redirect inside a heredoc body would require the body
+    to be re-executed as a subshell command, which is unusual; the
+    ``open(..., mode)`` detector still catches the common case of an
+    interpreter-fed heredoc that opens a file for write. The top-level
+    ``cat > FILE <<EOF`` redirect is caught by the command-level
+    extractor independently of the heredoc-body scan.
+    """
+    if not body:
+        return []
+    targets = []
+    for regex in (_OPEN_WRITE_RE, _OPEN_WRITE_KWARG_RE):
+        for m in regex.finditer(body):
+            path, mode = m.group(1), m.group(2)
+            # Require an actual write-mode char (not just '+' which could
+            # theoretically appear in a weird mode; but 'r+' is a write so
+            # '+' alone is a write signal too).
+            if any(ch in mode for ch in ("w", "a", "x", "A", "+")):
+                targets.append(path)
+    # Shell redirects inside the body. Skipped for heredoc bodies — see
+    # docstring (issue #180 false-positive on prose containing ``>``).
+    if scan_redirects:
+        targets.extend(_extract_redirect_targets(body))
+    return targets
+
+
+def _find_matching_quote(command: str, start: int, quote: str) -> int:
+    """Return the index of the closing quote, or len(command) if unterminated."""
+    i = start
+    while i < len(command):
+        c = command[i]
+        if c == "\\" and i + 1 < len(command):
+            i += 2
+            continue
+        if c == quote:
+            return i
+        i += 1
+    return len(command)
+
+
+def _extract_interpreter_inline_targets(command: str):
+    """Extract write targets from `-c` / `-e` inline arguments and heredocs.
+
+    Issue #175 fix shape:
+
+      - For ``-c`` / ``-e`` inline strings: parse the quoted body and only
+        flag paths in write-context (``open(..., 'w')`` or shell redirect).
+        Read-only ``open('foo.json')`` no longer trips.
+      - For heredoc forms (``<<EOF ... EOF``): the heredoc DELIMITER token
+        (``EOF`` etc.) is never a path. Apply the same write-context
+        detector to the heredoc body. A ``cat <<EOF`` body containing a
+        quoted path token is data, not a write — the redirect / open
+        detector finds no match and proceeds. A ``python <<EOF`` body that
+        actually opens a file for write is still caught.
+
+    Heredoc form is intentionally permissive: only the body is scanned,
+    never the trigger line itself or the rest of the command. The real
+    ``cat > FILE <<EOF`` write case is caught by the top-level redirect
+    extractor independently of this function.
+    """
+    targets = []
+
+    # 1. Inline `-c` / `-e` arguments. For shell interpreters (bash, sh),
+    # the body IS shell syntax — keep redirect detection. For other
+    # interpreters (python, node, ruby, perl, php, lua, Rscript), the body
+    # is the interpreter's own language, not shell; quoted strings or
+    # comments containing ``>`` are data, not redirects (issue #180).
+    # Rely on ``open(..., 'w'|'a'|...)`` patterns there instead.
+    shell_interpreters = {"bash", "sh"}
+    interp_re = re.compile(
+        rf"\b(?P<interp>{_INTERPRETER_RE})\b[^|;&]*?(?:-c\b|-e\b)\s*(?P<quote>['\"])"
+    )
+    for m in interp_re.finditer(command):
+        quote = m.group("quote")
+        interp = m.group("interp")
+        start = m.end()
+        end = _find_matching_quote(command, start, quote)
+        body = command[start:end]
+        scan = interp in shell_interpreters
+        targets.extend(
+            _extract_write_targets_from_body(body, scan_redirects=scan)
+        )
+
+    # 2. Heredocs (any command, not just `_INTERPRETER_RE`). Capture the
+    # delimiter, then scan the body up to the matching delimiter line.
+    # Delimiter quoting and the `-`/`~` prefix affect how the shell
+    # processes the body but not where it ends.
+    #
+    # Issue #180: heredoc bodies are DATA, not shell syntax. Prose lines
+    # containing `>` (e.g. "If x > y then we win", "stdout > stderr.log",
+    # a python `print('a > b')`) previously tripped the shell-redirect
+    # regex on phantom path targets. Skip redirect detection for heredoc
+    # bodies; rely on the `open(..., mode)` detector for real writes.
+    for m in re.finditer(
+        r"<<[-~]?\s*(?P<q>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)",
+        command,
+    ):
+        delim = m.group("delim")
+        body_start = m.end()
+        # End is the delimiter on its own line (or at end-of-string).
+        end_match = re.search(
+            rf"(?m)^\s*{re.escape(delim)}\s*$", command[body_start:]
+        )
+        if end_match:
+            body = command[body_start : body_start + end_match.start()]
+        else:
+            body = command[body_start:]
+        targets.extend(_extract_write_targets_from_body(body, scan_redirects=False))
+
+    return targets
+
+
+def _strip_non_shell_interpreter_bodies(command: str) -> str:
+    """Return ``command`` with non-shell ``-c`` / ``-e`` body regions blanked.
+
+    For interpreters whose ``-c`` / ``-e`` argument is NOT shell syntax
+    (python, python3, node, ruby, perl, php, lua, Rscript), the quoted
+    body is the interpreter's own language. Quoted strings or prose
+    inside that body containing ``>`` would otherwise trip the top-level
+    shell-redirect scanner (issue #180: ``python3 -c "print('a > b')"``
+    flagged ``b`` as a redirect target).
+
+    The body region between the opening quote and its matching close
+    is replaced with same-length space padding so byte offsets are
+    preserved (in case any caller relies on them) and so the surrounding
+    shell syntax remains scannable. The body itself is still scanned
+    for write-mode ``open()`` calls by
+    ``_extract_interpreter_inline_targets`` which sees the unmodified
+    command.
+
+    Shell interpreters (``bash``, ``sh``) are deliberately excluded:
+    their ``-c`` body IS shell syntax, so e.g.
+    ``bash -c "echo x > scripts/foo.sh"`` must still trip the redirect
+    scanner.
+    """
+    non_shell = r"(?:python|python3|node|ruby|perl|php|lua|Rscript)"
+    pattern = re.compile(rf"\b{non_shell}\b[^|;&]*?(?:-c\b|-e\b)\s*(['\"])")
+    out = list(command)
+    for m in pattern.finditer(command):
+        quote = m.group(1)
+        start = m.end()
+        end = _find_matching_quote(command, start, quote)
+        # Blank the body chars (preserve any newlines so line-anchored
+        # regex elsewhere don't get confused).
+        for k in range(start, end):
+            if out[k] != "\n":
+                out[k] = " "
+    return "".join(out)
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Return ``command`` with heredoc body regions removed.
+
+    Each ``<<DELIM`` (or ``<<-DELIM`` / ``<<~DELIM`` / ``<<"DELIM"``)
+    opener has its body — from the end of the opener line up to and
+    including the closing ``DELIM`` line — replaced with a single
+    newline. Shell-level write-pattern extractors (redirect, tee, dd,
+    in-place, mutation) then run only over actual shell syntax, not
+    over heredoc data.
+
+    Issue #180: prose inside a heredoc body containing ``>`` previously
+    tripped the top-level ``_extract_redirect_targets`` on phantom
+    targets (``> y``, ``> stderr.log``, ``> stderr``). Stripping the
+    body region before shell-level scans removes the false positive
+    while leaving real writes intact: the ``cat > FILE <<EOF`` form
+    still has its ``> FILE`` before the stripped body, and any
+    interpreter-fed heredoc that performs real I/O via ``open(..., 'w')``
+    is still caught by ``_extract_interpreter_inline_targets`` which
+    scans the body separately for write-mode open() calls.
+    """
+    if "<<" not in command:
+        return command
+    out = []
+    i = 0
+    opener_re = re.compile(
+        r"<<[-~]?\s*(?P<q>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"
+    )
+    while i < len(command):
+        m = opener_re.search(command, i)
+        if m is None:
+            out.append(command[i:])
+            break
+        delim = m.group("delim")
+        # The body starts at the next newline after the opener (the rest
+        # of the opener line — including any post-opener redirect like
+        # `<<EOF >> path` — is still real shell and must be preserved
+        # for the redirect scanner). If there is no newline, the heredoc
+        # is malformed / single-line; preserve everything up to and
+        # including the opener match and stop.
+        nl = command.find("\n", m.end())
+        if nl == -1:
+            out.append(command[i:])
+            break
+        # Keep up to and including the newline that ends the opener line
+        # (so `cat <<EOF >> scripts/foo.sh\n...` still has `>> scripts/foo.sh`
+        # visible, and `cat > FILE <<EOF\n...` still has `> FILE` visible).
+        out.append(command[i : nl + 1])
+        body_start = nl + 1
+        end_match = re.search(
+            rf"(?m)^\s*{re.escape(delim)}\s*$", command[body_start:]
+        )
+        if end_match is None:
+            # Unterminated heredoc — drop the rest.
+            break
+        # Skip past the closing-delimiter line.
+        # `end_match.end()` is the offset just after the delimiter token
+        # within the body slice; advance one more to consume the newline
+        # if present, so subsequent shell text (e.g. `)`) is preserved.
+        skip_to = body_start + end_match.end()
+        if skip_to < len(command) and command[skip_to] == "\n":
+            skip_to += 1
+        i = skip_to
+    return "".join(out)
+
+
+def _extract_write_targets_from_command(command: str):
+    """Return all candidate write-target paths found in a shell command.
+
+    The list may include duplicates and unrelated tokens; the caller filters
+    against the allow-list. Empty list means "no detectable writes".
+
+    Shell-level extractors run over a heredoc-body-stripped AND
+    non-shell-interpreter-body-blanked copy of the command (issue #180:
+    prose inside a heredoc body or quoted python/node/ruby/perl/lua/Rscript
+    string containing ``>`` previously tripped phantom redirect targets).
+    The interpreter-inline-targets extractor still sees the full command
+    so it can scan heredoc bodies and ``-c`` / ``-e`` bodies for
+    write-mode ``open()`` calls.
+    """
+    targets = []
+    shell_view = _strip_heredoc_bodies(command)
+    shell_view = _strip_non_shell_interpreter_bodies(shell_view)
+    targets.extend(_extract_redirect_targets(shell_view))
+    targets.extend(_extract_tee_targets(shell_view))
+    targets.extend(_extract_dd_targets(shell_view))
+    targets.extend(_extract_in_place_targets(shell_view))
+    targets.extend(_extract_mutation_targets(shell_view))
+    targets.extend(_extract_interpreter_inline_targets(command))
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Path handling.
+# ---------------------------------------------------------------------------
+
+
+def _normalise(path: str) -> str:
+    """Normalise to a repo-root-relative POSIX-style path.
+
+    - Strips leading `./`.
+    - Resolves `..` segments lexically.
+    - If absolute and inside CLAUDE_PROJECT_DIR, makes it relative.
+    - Otherwise returns the cleaned absolute path (which will not match the
+      allow-list and will be denied).
+    """
+    if not path:
+        return ""
+    p = path.strip()
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    project_dir = os.path.abspath(project_dir)
+
+    if os.path.isabs(p):
+        try:
+            rel = os.path.relpath(p, project_dir)
+        except ValueError:
+            rel = p
+        if rel.startswith(".."):
+            # Outside the project tree; preserve absolute form.
+            return os.path.normpath(p)
+        return rel.replace(os.sep, "/")
+
+    # Relative: lexically normalise.
+    cleaned = os.path.normpath(p).replace(os.sep, "/")
+    if cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    return cleaned
+
+
+def _matches_recursive_glob(path: str, glob: str) -> bool:
+    # glob like "docs/tech-lead/**". A path matches if it's exactly the
+    # prefix directory or strictly under it.
+    if not glob.endswith("/**"):
+        return False
+    prefix = glob[:-3]  # strip "/**"
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def is_on_allow_list(path: str) -> bool:
+    norm = _normalise(path)
+    if not norm:
+        return False
+    if norm in ALLOW_EXACT:
+        return True
+    for glob in ALLOW_GLOBS_SHALLOW:
+        if fnmatch.fnmatchcase(norm, glob):
+            return True
+    for glob in ALLOW_GLOBS_RECURSIVE:
+        if _matches_recursive_glob(norm, glob):
+            return True
+    return False
+
+
+def _is_customer_notes_path(path: str) -> bool:
+    norm = _normalise(path)
+    if not norm:
+        return False
+    if os.path.basename(norm) == CUSTOMER_NOTES_BASENAME:
+        return True
+    if norm.startswith(CUSTOMER_NOTES_DIR_PREFIX):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Specialist routing for diagnostic message.
+# ---------------------------------------------------------------------------
+
+
+# Table-driven path-to-role mapping. Order is significant: the first
+# matching rule wins, so more-specific prefixes (e.g. `docs/adr/`,
+# `docs/security/`) MUST precede the broader `docs/` fallback. Each
+# entry is (predicate, role); the predicate is a callable taking the
+# normalised path. Refactored from a long if/elif chain (Codacy
+# cyclomatic-complexity finding on PR #173); behaviour and role mapping
+# are unchanged.
+_OWNERSHIP_RULES = (
+    (lambda p: p.startswith("docs/adr/"), "architect"),
+    (lambda p: p.startswith("tests/"), "qa-engineer"),
+    (lambda p: p.startswith(".github/workflows/"), "release-engineer"),
+    (lambda p: p.startswith("docs/security/"), "security-engineer"),
+    (lambda p: p.startswith("scripts/") or p.startswith("src/"), "software-engineer"),
+    (lambda p: p == "CHANGELOG.md" or p.startswith("docs/"), "tech-writer"),
+)
+
+
+def _owning_specialist(path: str) -> str:
+    norm = _normalise(path)
+    for predicate, role in _OWNERSHIP_RULES:
+        if predicate(norm):
+            return role
+    return "the appropriate specialist"
+
+
+# ---------------------------------------------------------------------------
+# Escape-hatch parsing.
+# ---------------------------------------------------------------------------
+
+
+def _validate_role(value: str):
+    """Return value if it is a canonical role or matches sme-*, else None.
+
+    Semantic note: the escape hatch is tool-bridge work *on behalf of a
+    different specialist*. A ``tech-lead`` self-push defeats the entire
+    guard (the guard exists to keep tech-lead from authoring production
+    artifacts), so it is rejected explicitly before the canonical-roles
+    check — even though ``tech-lead`` is itself in CANONICAL_ROLES for
+    other vocabulary purposes. Code-reviewer tightening #2.
+    """
+    if not value:
+        return None
+    if value == "tech-lead":
+        # Self-push is never legitimate: the role this guard exists to
+        # restrain cannot widen its own allow-list.
+        return None
+    if value in CANONICAL_ROLES:
+        return value
+    if SME_ROLE_RE.match(value):
+        return value
+    return None
+
+
+def _agent_push_role():
+    """Return the SWDT_AGENT_PUSH role if valid, else None.
+
+    None means "no escape hatch in effect" (either unset, empty, or
+    unrecognised). Unrecognised values are treated as absent rather than
+    raising — the hook fails closed by applying the allow-list.
+    """
+    value = os.environ.get("SWDT_AGENT_PUSH", "").strip()
+    return _validate_role(value)
+
+
+# Inline form of the escape hatch: a user (or wrapper) may prefix a Bash
+# command with `SWDT_AGENT_PUSH=<role>` or `export SWDT_AGENT_PUSH=<role>;`.
+# Upstream issue #176: the natural reading of the deny message is that
+# setting the env var inline should work, but Claude Code's Bash tool
+# spawns a fresh shell so HARNESS env is required. Behavioural fix:
+# detect the inline assignment and honour it as an escape hatch for that
+# invocation. We accept the role only if it validates; unrecognised
+# values fall through to the harness-env check (and ultimately deny).
+#
+# Issue #179: the inline form MUST be the leading command. A pattern
+# like ``cd foo && SWDT_AGENT_PUSH=architect echo y > docs/adr/foo.md``
+# previously matched (env-var-prefix after `&&`) and silently widened
+# the allow-list, which is not the natural reading of the deny
+# diagnostic. Strict anchor: the assignment is the first non-whitespace
+# token of the command, OR it is preceded only by ``export\s+``. Forms
+# after ``&&``, ``||``, ``;``, ``|`` no longer match.
+_INLINE_AGENT_PUSH_RE = re.compile(
+    r"\A\s*(?:export\s+)?SWDT_AGENT_PUSH=(['\"]?)([a-zA-Z][a-zA-Z0-9_-]*)\1"
+)
+
+
+def _inline_agent_push_role(command: str):
+    """Return the inline SWDT_AGENT_PUSH role from a Bash command, else None.
+
+    Only honours the assignment when it is the leading command (issue
+    #179). The regex is anchored to the start of the string with
+    optional leading whitespace and an optional ``export`` prefix.
+    Assignments after ``&&``/``||``/``;``/``|`` do not widen the
+    allow-list — they would only take effect for the subshell the
+    operator chains them into, and naming a post-chain assignment as
+    an escape hatch for the whole command is misleading.
+    """
+    if not command:
+        return None
+    m = _INLINE_AGENT_PUSH_RE.match(command)
+    if m is None:
+        return None
+    return _validate_role(m.group(2).strip())
+
+
+# ---------------------------------------------------------------------------
+# Decision construction.
+# ---------------------------------------------------------------------------
+
+
+def _deny_output(path: str, kind: str) -> dict:
+    specialist = _owning_specialist(path)
+    reason = (
+        f"FW-ADR-0012: tech-lead may not write {kind} '{path}' directly. "
+        f"Dispatch '{specialist}' to author this file, or set "
+        "SWDT_AGENT_PUSH=<role> if this is tool-bridge work on behalf of a "
+        "specialist whose sandbox cannot write. Allow-list lives in "
+        "docs/adr/fw-adr-0012-tech-lead-authoring-guard.md."
+    )
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+def _audit_override(path: str, role: str, kind: str) -> None:
+    sys.stderr.write(
+        f"tech-lead-authoring-guard: SWDT_AGENT_PUSH={role} override permitted "
+        f"write to {kind} '{path}'.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main decision logic.
+# ---------------------------------------------------------------------------
+
+
+def _decide_for_path(path: str):
+    """Return (decision, audit_callable) for a single target path.
+
+    decision is one of:
+      - None: proceed silently (path on allow-list or deferred to
+        customer-notes-guard).
+      - dict: a hookSpecificOutput payload (deny).
+
+    audit_callable, when not None, is invoked after the decision is
+    finalised to emit the override audit-log line on stderr.
+    """
+    if not path:
+        return None, None
+
+    # Customer-notes paths defer to customer-notes-guard. We do not
+    # double-block here regardless of the escape-hatch role.
+    if _is_customer_notes_path(path):
+        return None, None
+
+    if is_on_allow_list(path):
+        return None, None
+
+    role = _agent_push_role()
+    if role is not None:
+        return None, lambda: _audit_override(_normalise(path), role, "path")
+
+    return _deny_output(_normalise(path), "path"), None
+
+
+def _decide_for_command(command: str):
+    if not command:
+        return None, None
+
+    targets = _extract_write_targets_from_command(command)
+    if not targets:
+        return None, None
+
+    off_list = []
+    for t in targets:
+        norm = _normalise(t)
+        if not norm:
+            continue
+        if _is_customer_notes_path(norm):
+            # Defer to customer-notes-guard.
+            continue
+        if is_on_allow_list(norm):
+            continue
+        off_list.append(norm)
+
+    if not off_list:
+        return None, None
+
+    first = off_list[0]
+    role = _agent_push_role() or _inline_agent_push_role(command)
+    if role is not None:
+        return None, lambda: _audit_override(first, role, "Bash target")
+
+    return _deny_output(first, "Bash target"), None
+
+
+def _collect_target_paths(tool_input: dict):
+    """Collect every file-target path the tool invocation may write to.
+
+    Per the Claude Code tool spec, ``MultiEdit`` carries a single
+    top-level ``file_path`` plus an ``edits`` array applying multiple
+    edits to that one file — so a strict reading says only ``file_path``
+    matters. Codacy PR #173 nonetheless flagged a HIGH-RISK bypass on
+    the assumption that ``edits`` (or a ``files``/``changes`` array)
+    might carry per-entry ``file_path`` fields on some tools or future
+    revisions. We close the door defensively: collect the top-level
+    ``file_path``/``path`` AND walk any list value under ``tool_input``
+    for per-entry ``file_path``/``path`` strings. If ANY collected path
+    is off the allow-list, the call is denied.
+    """
+    paths = []
+    top = tool_input.get("file_path") or tool_input.get("path") or ""
+    if isinstance(top, str) and top:
+        paths.append(top)
+
+    # Iterate every list value under tool_input and pull file_path/path
+    # entries. Arrays we have seen named: edits, changes, files.
+    for value in tool_input.values():
+        if not isinstance(value, list):
+            continue
+        for entry in value:
+            if not isinstance(entry, dict):
+                continue
+            candidate = entry.get("file_path") or entry.get("path") or ""
+            if isinstance(candidate, str) and candidate:
+                paths.append(candidate)
+    return paths
+
+
+def main() -> int:
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if not isinstance(event, dict):
+        return 0
+
+    tool_input = event.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    target_paths = _collect_target_paths(tool_input)
+    command = tool_input.get("command") or ""
+
+    decision = None
+    audit = None
+
+    # Check EVERY collected target path. If any one denies, deny the call.
+    # The first matching decision (deny or audited-override) wins so the
+    # surfaced diagnostic names a concrete path; the loop short-circuits on
+    # deny but continues past silent proceeds to find any off-list entry.
+    for path in target_paths:
+        path_decision, path_audit = _decide_for_path(path)
+        if path_decision is not None:
+            decision, audit = path_decision, path_audit
+            break
+        if path_audit is not None and audit is None:
+            # Remember the first override-audit so we still log it even if
+            # later paths are silently allowed.
+            audit = path_audit
+
+    if decision is None and isinstance(command, str) and command:
+        cmd_decision, cmd_audit = _decide_for_command(command)
+        if cmd_decision is not None:
+            decision = cmd_decision
+            audit = cmd_audit
+        elif cmd_audit is not None and audit is None:
+            audit = cmd_audit
+
+    if audit is not None:
+        audit()
+
+    if decision is not None:
+        print(json.dumps(decision))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `tests/hooks/run-ai-tui-check.sh` — multi-hook driver; parses `.claude/settings.json`'s PreToolUse table, routes payloads to the right hook by tool_name → matcher. Tests against the UPGRADED FIXTURE's hooks (not the canonical template's), catching AI-TUI-interaction regressions that script-level dogfood PASS misses.
- `tests/hooks/fixtures/session-shapes.yml` — 21 payloads across 7 categories: multi-line HEREDOC commit messages (the rc11→rc12 catch-22), writes to hook scripts (forbidden path), reads of hook scripts, specialist dispatch via Agent, `git push --dry-run` / fetch / status, interpreter reads of `CUSTOMER_NOTES.md` (post-#182 fix surface), inline `SWDT_AGENT_PUSH=` escape-hatch carriers (post-#179 fix surface).
- Delta fixture (rc11) gets `.claude/settings.json` + canonical hook copies — exercises the new phase in tests.
- Dogfood driver gets a new AI-TUI-check phase between `--verify` and pass/fail classification; report carries both phases' findings.
- `run-negative-corpus.sh` enumeration filter added to skip multi-hook fixtures (small fix surfaced during integration).

## Test plan

- [x] 21/21 session-shape payloads PASS against canonical template hooks
- [x] 21/21 PASS against delta fixture hooks (consistent across copies)
- [x] 40/40 negative-corpus PASS unchanged
- [x] Regression-detection verified: simulated deny-everything hook correctly flagged 13 of 21 mismatches (settings.json matchers only wire Write|Edit|MultiEdit|Bash; cat4 Agent + cat3.3 Read have no matcher and stay aggregate=pass; cat2.1/2.2/2.3/7.1 correctly stay deny-expected)
- [x] Skip semantics: 3 fixtures without `.claude/settings.json` (alpha/beta/gamma) correctly mark `ai-tui status: skipped-no-hooks`
- [x] Shellcheck clean

## Why

Customer rule (saved as memory `feedback-dogfood-needs-tui-check`): script-level PASS is necessary but not sufficient. The rc11→rc12 meta upgrade wired `tech-lead-authoring-guard` correctly per spec but broke commit-message HEREDOCs in Claude Code's `Bash` tool — catch-22 the script-level gate would have called green. This phase closes that gap.

## Non-blocking follow-ups (from reviewer)

- Soft-skip false-PASS risk: fixtures that SHOULD ship hooks but don't quietly pass. Mitigation idea (deferred): `dogfood-meta.yml` with `expect_hooks: true`.
- `run-negative-corpus.sh` hardcoded skip is slightly brittle for future multi-hook fixtures; sentinel comment / naming convention would be cleaner.
- cat7.1 label slightly misleading; rename suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added AI TUI hook validation test suite with session-shape fixture corpus and test driver.
  * Added hook guard scripts for testing write-protection and role-based access policies.
  * Integrated AI TUI checks into dogfood release-gate testing pipeline.

* **Documentation**
  * Updated dogfood testing documentation to describe expanded test harness with AI TUI validation phase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/196)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->