### PR TITLE
fix(dogfood-2026-05-15): four framework blockers + evidence (FW-ADR-0013, FW-ADR-0014)

### DIFF
--- a/CUSTOMER_NOTES.md
+++ b/CUSTOMER_NOTES.md
@@ -190,3 +190,65 @@ CI workflows (`.github/workflows/agent-contract-check.yml`,
   LLM-wire-up review.
 
 **Sign-off**: `security-engineer`, 2026-05-13.
+
+## 2026-05-15 — dogfood-before-rc sequencing ruling (turn: pre-intake)
+
+**Question (from tech-lead, framed back to customer during dogfood-blocker triage):**
+> Should we cut a new rc (rc13 / rc12.1) that bundles the dogfood-blocker
+> fixes, then run the dogfood harness AGAINST that new rc?
+
+**Customer answer (verbatim):**
+> "no, we dogfood before cutting an rcX. that is why we made the dogfood scripts."
+
+**Implication (paraphrase, not customer text):**
+The canonical pre-release sequence is:
+1. Fixes land on `main` (after `code-reviewer` review per Hard Rule #3).
+2. The dogfood harness runs against `main` via
+   `scripts/upgrade.sh --target main` (untagged-target feature, PR #186).
+3. Only after the dogfood harness PASSes against `main` is the rc tag cut.
+4. The tag's commit is the same SHA that passed dogfood — no post-tag
+   content drift.
+5. A smoke dogfood vs the cut tag confirms identity, then the meta-pointer
+   bumps.
+
+**Cross-refs:** PR #186 (untagged-target feature in `scripts/upgrade.sh`);
+auto-memory entries `feedback_dogfood_before_meta_bump.md` and
+`feedback_dogfood_needs_tui_check.md`;
+`docs/pm/dogfood-2026-05-15-results.md` (trigger for this ruling).
+
+**Supersedes:** none (codifies the dogfood-before-cut discipline previously
+recorded only in auto-memory).
+**Recorded by:** researcher
+
+## 2026-05-15 — v1.0.0-final blocker frame: upgrade-flow reliability (turn: pre-intake)
+
+**Question (from tech-lead, during the same dogfood-blocker triage):**
+> What is the strategic blocker to cutting v1.0.0 (final, non-rc)?
+
+**Customer answer (verbatim):**
+> "the big blocker to going to v1.0.0 in my view is that the upgrade is always buggy."
+
+**Implication (paraphrase, not customer text):**
+v1.0.0 final ships when the upgrade flow is no longer the recurring source
+of regressions. This is a strategic stance — a quality bar, not a numeric
+criterion ("zero bugs ever"). Concretely:
+- Continued upgrade-flow regressions = more rc cycles, not a v1.0.0 cut.
+- Architects considering rc12 → rc13 changes weigh upgrade-flow risk as a
+  first-class quality attribute.
+- Readiness signal: cumulative coverage from the dogfood harness against
+  representative downstreams stabilises — multiple rc-to-rc cycles pass
+  dogfood without surfacing new upgrade-class bugs.
+
+**Triggering observation (paraphrase):** The 2026-05-15 dogfood surfaced
+three fresh upgrade-class bugs (alpha/scaffold rc2→rc12 self-overwrite;
+beta/scaffold v0.13→rc12 manifest drift; the dogfood driver itself
+crashing on real symlink shapes).
+
+**Cross-refs:** Q-0017 (rc8 self-overwrite ruling); FW-ADR-0013 (rc-to-rc
+pre-bootstrap, proposed 2026-05-15); forthcoming FW-ADR-0014
+(preservation-vs-manifest, in flight via architect-b4);
+`docs/pm/dogfood-2026-05-15-results.md`.
+
+**Supersedes:** none (first explicit customer framing of the v1.0.0-final
+blocker).
+**Recorded by:** researcher

--- a/docs/adr/fw-adr-0013-rc-to-rc-pre-bootstrap.md
+++ b/docs/adr/fw-adr-0013-rc-to-rc-pre-bootstrap.md
@@ -1,0 +1,452 @@
+---
+name: fw-adr-0013-rc-to-rc-pre-bootstrap
+description: Add a versioned pre-bootstrap migration (v1.0.0-rc13.sh) cloned from v0.14.0.sh so rc-to-rc upgrades on pre-v0.15.0 upgrade.sh drivers self-bootstrap safely; FW-ADR-0010 interface inherits unchanged.
+status: accepted
+date: 2026-05-15
+---
+
+
+# FW-ADR-0013 — rc-to-rc pre-bootstrap via cloned migration
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+  - [Option M — Minimalist: clone the pre-bootstrap block into a new versioned migration](#option-m--minimalist-clone-the-pre-bootstrap-block-into-a-new-versioned-migration)
+  - [Option S — Scalable: extract the pre-bootstrap block into a sourced helper used by every cliff migration](#option-s--scalable-extract-the-pre-bootstrap-block-into-a-sourced-helper-used-by-every-cliff-migration)
+  - [Option C — Creative: drop pre-bootstrap entirely; require operators on pre-v0.15.0 drivers to retrofit `scripts/upgrade.sh` by hand](#option-c--creative-drop-pre-bootstrap-entirely-require-operators-on-pre-v0150-drivers-to-retrofit-scriptsupgradesh-by-hand)
+- [Decision outcome](#decision-outcome)
+  - [Out-of-range refusal (hybrid clause)](#out-of-range-refusal-hybrid-clause)
+  - [Inherited FW-ADR-0010 interface (binding)](#inherited-fw-adr-0010-interface-binding)
+  - [Implementation notes for software-engineer](#implementation-notes-for-software-engineer)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up ADRs](#follow-up-adrs)
+- [Relationship to other ADRs and issues](#relationship-to-other-adrs-and-issues)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+Shape per MADR 3.0 + this template's Three-Path Rule
+(`docs/templates/adr-template.md`).
+
+---
+
+## Status
+
+- **Proposed: 2026-05-15**
+- **Accepted: 2026-05-15**
+- **Deciders:** `architect` + `tech-lead` + customer (cross-cutting
+  pattern change to the migration queue; customer approval required
+  per CLAUDE.md Hard Rules)
+- **Consulted:** `software-engineer` (implementation on branch
+  `fix/blocker-1-rc-to-rc-prebootstrap`, commit `c7599b5`),
+  `release-engineer` (CI dogfood follow-up), `qa-engineer` (smoke
+  coverage for rc-to-rc upgrade fixtures), FW-ADR-0010 (pre-bootstrap
+  interface contract this ADR inherits verbatim).
+
+## Context and problem statement
+
+FW-ADR-0010 added a pre-bootstrap step to `scripts/upgrade.sh` and
+to `migrations/v0.14.0.sh` so that pre-v0.15.0 upgrade drivers atomic-
+replace bootstrap-critical files (`scripts/upgrade.sh`,
+`scripts/lib/*.sh`) **before** the in-place-cp bug at line ~417 of the
+old driver can corrupt the running shell. That fix works for the
+cross-MAJOR cliff (v0.14.0). It does not cover the rc-to-rc cliff: a
+project stamped at v1.0.0-rc2 whose `scripts/upgrade.sh` predates
+v0.15.0's self-bootstrap block, upgrading toward v1.0.0-rc13. The
+v0.14.0 migration's pre-bootstrap block only runs when the migration
+queue elects v0.14.0; on the rc-to-rc path the queue jumps past it
+and pre-bootstrap never executes. The rc2-era driver then hits the
+in-place-cp bug mid-loop, exactly the failure mode FW-ADR-0010 was
+shaped to prevent.
+
+The customer's 2026-05-15 ruling (Blocker #1) accepts that future
+rc-to-rc structural cliffs in `upgrade.sh` may each require a fresh
+pre-bootstrap migration — the architect-side check on
+structural-rewrite ADRs is to spawn one. ADR-trigger rows that fire:
+cross-cutting pattern change (the migration queue now carries a
+shape-class of "pre-bootstrap migration"), choice that locks future
+releases into a per-cliff migration obligation, and a public-API
+surface change (a new versioned migration shipped to every downstream
+upgrade). Dogfood evidence sits in
+`docs/pm/dogfood-2026-05-15-results.md`.
+
+## Decision drivers
+
+- **Cross-rc safety must survive.** The original FW-ADR-0010 fix
+  closes the in-place-cp inode bug on the v0.14.0 cliff; the same bug
+  is live on the rc2-era driver every time the migration queue jumps
+  past v0.14.0 toward a later rc. Whatever we ship must keep
+  pre-v0.15.0 → rc13+ upgrades from crashing mid-loop.
+- **No edits to `scripts/upgrade.sh`.** The old rc2-era driver is the
+  *running* file we are trying to protect; the fix must arrive on a
+  path the old driver already exercises reliably. The pre-sync
+  migration runner is that path — the old driver runs migrations
+  before its sync loop touches `scripts/upgrade.sh`.
+- **FW-ADR-0010 interface stays intact.** Operators and CI gates
+  already key off `SWDT_PREBOOTSTRAP_FORCE=1`, exit code 2,
+  `.template-prebootstrap-blocked.json`, and the `Gate=pre-bootstrap`
+  audit row. A second pre-bootstrap migration must use the same
+  surface, not a parallel one.
+- **De-dup catch-22 is real.** The natural urge is to extract the
+  shared pre-bootstrap logic into `scripts/lib/prebootstrap.sh` and
+  have every migration source it. But that helper would itself be a
+  bootstrap-critical file — and pre-bootstrap is the thing protecting
+  bootstrap-critical files from in-place clobber. The helper is not
+  yet trustworthy at the moment pre-bootstrap must run; sourcing it
+  from a migration that runs before pre-bootstrap is a re-entrant
+  bootstrap loop with no fixed point.
+- **Idempotency.** Re-running upgrade after the operator resolves a
+  refusal must converge, the same invariant FW-ADR-0010 carries.
+- **Out-of-range safety.** A pre-bootstrap migration whose runner
+  conditions are not met (e.g., the rc13 migration triggers on a
+  stamped version it cannot reason about) must refuse, not silently
+  no-op. Silent no-op on the wrong stamped range reintroduces the
+  in-place-cp bug under conditions the migration was supposed to
+  cover.
+
+## Considered options (Three-Path Rule, binding)
+
+### Option M — Minimalist: clone the pre-bootstrap block into a new versioned migration
+
+Ship `migrations/v1.0.0-rc13.sh` as a near-verbatim clone of
+`migrations/v0.14.0.sh` lines 42–277 — the pre-bootstrap block, minus
+the v0.14.0-specific manifest-synthesis tail. The cloned migration
+runs from the pre-sync migration runner, which the rc2-era driver
+reliably exercises before its sync loop touches `scripts/upgrade.sh`.
+
+- **Sketch:** New file at `migrations/v1.0.0-rc13.sh`. Header rewritten
+  for the rc-to-rc context, with a comment block citing FW-ADR-0013
+  and the de-dup catch-22. Pre-bootstrap body is the v0.14.0 clone:
+  `prebootstrap_sha`, the bootstrap-critical path list build, the
+  3-SHA matrix per FW-ADR-0010, the atomic-mv replacement loop, the
+  block-artefact writer, and the audit-row appender. No
+  manifest-synthesis tail — that was v0.14.0-specific.
+- **Pros:**
+  - Zero risk of breaking the de-dup helper that pre-bootstrap is
+    supposed to protect — the helper does not exist.
+  - The cloned migration is read-once at queue time; once
+    `scripts/upgrade.sh` is atomic-replaced, future runs use the new
+    driver's own self-bootstrap.
+  - Implementation cost is bounded: the v0.14.0 block already passed
+    FW-ADR-0010 review; cloning it carries forward that scrutiny.
+  - No new public-API surface beyond what FW-ADR-0010 already
+    committed to (exit 2, env var, block artefact, audit-log column).
+  - Future structural cliffs in `upgrade.sh` get the same fix shape —
+    one more cloned migration, one more architect-side check on the
+    triggering ADR.
+- **Cons:**
+  - ~235 lines duplicated between `v0.14.0.sh` and `v1.0.0-rc13.sh`.
+    A bug in the pre-bootstrap matrix has to be fixed in N+1 places.
+  - Drift risk: a maintainer fixes one and forgets the other. The
+    mitigation is structural — the cloned migrations are immutable
+    after release (per FW-ADR-0004's per-migration-version rule); the
+    only realistic drift is in the comments.
+  - Each new cliff is a new migration file. The migrations directory
+    grows linearly with structural rewrites of `upgrade.sh`. Cost is
+    bounded by the rate of structural rewrites, which is low.
+- **When M wins:** when the alternative is a helper that itself lives
+  in the file class pre-bootstrap protects (the catch-22). M wins
+  here.
+
+### Option S — Scalable: extract the pre-bootstrap block into a sourced helper used by every cliff migration
+
+Move the pre-bootstrap body into `scripts/lib/prebootstrap.sh`. Each
+cliff migration becomes a thin wrapper that sources the helper and
+invokes its main function with the bootstrap-critical path list. The
+helper is unit-tested once; every cliff migration is < 30 lines.
+
+- **Sketch:** Three files instead of one. `scripts/lib/prebootstrap.sh`
+  carries the logic. `migrations/v0.14.0.sh` is rewritten to source
+  it (post-hoc; FW-ADR-0004 says we should not, but ignore that for
+  this option). `migrations/v1.0.0-rc13.sh` is the new thin wrapper.
+- **Pros:**
+  - Single source of truth for pre-bootstrap logic; bug-fix-once.
+  - Migrations directory stays small.
+  - Helper is unit-testable.
+  - Matches the framework's general preference for shared
+    `scripts/lib/*` over per-call clones.
+- **Cons:**
+  - **De-dup catch-22 (fatal).** `scripts/lib/prebootstrap.sh` is
+    itself a bootstrap-critical file: it sits in `scripts/lib/*.sh`,
+    which is exactly the path class FW-ADR-0010's matrix protects.
+    For pre-bootstrap to source it, the file must already be in
+    place on disk. But pre-bootstrap is the thing that puts the
+    correct version on disk. If the project's stamped version
+    predates the helper, sourcing it pulls in either an absent file
+    (sync error) or the project's customised/old version (defeats
+    the protection). If the project's stamped version has the
+    helper, the in-memory bash is reading whichever version was on
+    disk at process start — which may differ from
+    `$WORKDIR_NEW`'s version. Re-entrant bootstrap; no fixed point.
+  - FW-ADR-0004 commits to immutability of released migrations.
+    Rewriting `v0.14.0.sh` to source the helper post-release breaks
+    that invariant.
+  - Helper sourcing in a migration that runs before pre-bootstrap is
+    a contradiction in terms — pre-bootstrap *is* the trust gate for
+    `scripts/lib/*.sh`.
+- **When S wins:** if `scripts/lib/prebootstrap.sh` could be
+  guaranteed-correct on disk at the moment the migration starts,
+  independent of pre-bootstrap. It cannot. S loses on the catch-22.
+
+### Option C — Creative: drop pre-bootstrap entirely; require operators on pre-v0.15.0 drivers to retrofit `scripts/upgrade.sh` by hand
+
+Accept that pre-v0.15.0 drivers are end-of-life. Publish a retrofit
+procedure: the operator manually `cp $WORKDIR_NEW/scripts/upgrade.sh
+$PROJECT_ROOT/scripts/upgrade.sh` from a separate checkout, then re-
+runs `upgrade.sh` from the now-current driver. No pre-bootstrap
+migration ships at all.
+
+- **Sketch:** Migration queue ignores the rc-to-rc cliff. Release
+  notes for rc13 carry a "Retrofit required for projects stamped at
+  pre-v0.15.0" section pointing at the retrofit playbook. FW-ADR-0010
+  still applies to the v0.14.0 cliff and to v0.15.0+ drivers; the
+  rc-to-rc gap is closed by procedure, not by code.
+- **Pros:**
+  - Zero new migration to maintain.
+  - Forces the framework to commit to a minimum-supported driver
+    version, which has documentation value.
+  - The retrofit playbook is already a load-bearing path under
+    FW-ADR-0010 for the baseline-unreachable case; reusing it for
+    pre-v0.15.0 drivers is dimension-consistent.
+- **Cons:**
+  - **Operator-load cost is large.** Every downstream project stamped
+    at v1.0.0-rc2..rc12 (a substantial install base by 2026-05-15)
+    must perform a manual retrofit before upgrading. The customer's
+    framework/project boundary commitment is "the upgrade just works
+    on a vanilla project"; this option breaks that for a known cliff.
+  - **Discovery is too late.** The operator runs `./scripts/upgrade.sh`,
+    sees the in-place-cp crash, *then* reads the release notes. The
+    fail-loud-on-cliff fix arrives after the corruption.
+  - Pre-empts a customer ruling that we should not be making
+    unilaterally — declaring rc2-era projects unsupported is a
+    customer-facing scope call, not an architectural one.
+- **When C wins:** if the install base of pre-v0.15.0 projects were
+  zero, or if the operator-load cost of the retrofit playbook were
+  near-free. Neither holds.
+
+## Decision outcome
+
+**Chosen option: M (clone the pre-bootstrap block into a new versioned
+migration), with the out-of-range refusal hybrid clause below.**
+
+**Reason:** Option S is the textbook answer (single source of truth)
+and fails on the de-dup catch-22 — the helper would itself be a
+bootstrap-critical file, sourcing it before pre-bootstrap runs is a
+re-entrant bootstrap loop. Option C punts the cost onto every
+downstream operator carrying a pre-v0.15.0 driver, breaking the
+framework's "upgrade just works on a vanilla project" commitment.
+Option M cleanly preserves FW-ADR-0010's interface contract, runs on
+a path the old driver already exercises (the pre-sync migration
+runner), and accepts ~235 lines of intentional duplication as the
+price of structural correctness. The architect-side obligation —
+every future structural cliff in `upgrade.sh` spawns one more
+pre-bootstrap migration of this shape — is small, bounded, and
+already implicit in FW-ADR-0010's per-cliff posture.
+
+### Out-of-range refusal (hybrid clause)
+
+Pre-bootstrap migrations must NOT silently no-op when their target
+range is mis-applied. If `migrations/v1.0.0-rc13.sh` runs against a
+stamped version it cannot reason about (e.g., the migration queue
+is misconfigured, or the stamped version is newer than the
+migration's own target), the migration:
+
+- Logs an explicit `ERROR` line naming the stamped version, the
+  migration's intended range, and the FW-ADR-0013 reference.
+- Exits 2 with `.template-prebootstrap-blocked.json` written and
+  `reason=migration-out-of-range`. The block-artefact schema from
+  FW-ADR-0010 absorbs this new reason value as an additive entry
+  on the enumerated `reason` field.
+- Does not attempt the atomic-replace.
+
+Rationale: silent no-op on an out-of-range invocation reintroduces
+the in-place-cp bug under exactly the conditions this migration was
+supposed to cover. Refuse-on-uncertain matches FW-ADR-0010 and
+FW-ADR-0002 posture.
+
+### Inherited FW-ADR-0010 interface (binding)
+
+This ADR inherits FW-ADR-0010's interface verbatim. No new public-API
+surface beyond the new migration filename:
+
+- **`SWDT_PREBOOTSTRAP_FORCE=1`** — same env var; overrides both the
+  local-edit case and the baseline-unreachable case in this
+  migration's pre-bootstrap pass.
+- **Exit code 2** — same semantic (pre-bootstrap refused). The
+  out-of-range refusal clause above shares this exit code.
+- **`.template-prebootstrap-blocked.json`** — same artefact, same
+  schema. The enumerated `reason` field gains the additive value
+  `migration-out-of-range` (back-compatible: pre-rc13 readers see
+  an unknown reason string but the surrounding object shape
+  unchanged).
+- **Audit-log row** — same surface
+  (`docs/pm/pre-release-gate-overrides.md`); same `Gate=pre-bootstrap`
+  value in the `Gate` column FW-ADR-0010 added.
+- **Retrofit routing on unreachable-baseline** — same playbook
+  (`docs/templates/retrofit-playbook-template.md`-shaped procedure);
+  same `reason=baseline-unreachable` block-artefact value.
+
+Operators and CI gates that already key off FW-ADR-0010's surface
+need no behavioural updates for this migration.
+
+### Implementation notes for software-engineer
+
+The migration is already implemented on branch
+`fix/blocker-1-rc-to-rc-prebootstrap`, commit `c7599b5`, at 285
+lines. Cross-check against this ADR:
+
+1. **Filename.** `migrations/v1.0.0-rc13.sh` (versioned per
+   FW-ADR-0004; migration queue picks it up via the existing
+   semver-ordered glob).
+2. **Body.** Near-verbatim clone of `migrations/v0.14.0.sh` lines
+   42–277. Pre-bootstrap body identical; manifest-synthesis tail
+   (lines 278–end of v0.14.0) **omitted** — that step is
+   v0.14.0-specific and would re-write a manifest that the rc13
+   driver's post-sync `manifest_write` is already authoritative for.
+3. **Header.** Rewritten for rc-to-rc context. Comment block cites
+   FW-ADR-0013 by ID, names the de-dup catch-22 in one sentence,
+   and explicitly notes the FW-ADR-0010 interface inheritance.
+4. **No edits to `scripts/upgrade.sh`.** The whole point of this
+   migration is to atomic-replace `scripts/upgrade.sh` before the
+   old driver's sync loop touches it. Editing the driver itself
+   would defeat the structure.
+5. **Atomic-replace target set.** Same as FW-ADR-0010:
+   `scripts/upgrade.sh` plus every `scripts/lib/*.sh` the candidate
+   ships. Source is `$WORKDIR_NEW`; destination is `$PROJECT_ROOT`.
+6. **Old driver's sync `cmp -s` post-condition.** After the
+   atomic-replace, the OLD driver's sync loop reaches its `cmp -s`
+   on `scripts/upgrade.sh` and sees equality (the file on disk now
+   matches `$WORKDIR_NEW/scripts/upgrade.sh`), skipping the
+   in-place-cp. This is the load-bearing property; the QA fixture
+   must assert it.
+7. **Out-of-range refusal.** Add the guard block at the top of the
+   migration: read the project's stamped version from
+   `TEMPLATE_VERSION`, compare against the migration's intended
+   range, refuse with `reason=migration-out-of-range` on mismatch.
+   Cite FW-ADR-0013 § "Out-of-range refusal" in the ERROR line.
+8. **Audit-row writer.** Identical to v0.14.0's: append to
+   `docs/pm/pre-release-gate-overrides.md` with `Gate=pre-bootstrap`
+   before any atomic-mv. Refuses the override if the audit log is
+   unwritable (same posture as FW-ADR-0010).
+
+## Consequences
+
+### Positive
+
+- The rc-to-rc upgrade cliff closes structurally: projects stamped at
+  v1.0.0-rc2..rc12 upgrading toward rc13+ get the same pre-bootstrap
+  protection the v0.14.0 cliff already enjoys.
+- FW-ADR-0010's interface stays the single public-API surface for
+  pre-bootstrap; operators and CI gates need no behavioural updates.
+- The cloned migration is read-once and immutable per FW-ADR-0004;
+  drift risk reduces to the comment block.
+- Future structural cliffs in `upgrade.sh` get a known pattern:
+  spawn one more cloned migration; that obligation lives as an
+  architect-side check on the triggering structural-rewrite ADR.
+- Out-of-range refusal closes the silent-no-op failure mode that
+  would have re-introduced the in-place-cp bug under exactly the
+  conditions this migration covers.
+
+### Negative / trade-offs accepted
+
+- ~235 lines of pre-bootstrap body duplicated between
+  `migrations/v0.14.0.sh` and `migrations/v1.0.0-rc13.sh`. A logic
+  bug must be fixed in N+1 places. Mitigation is structural
+  immutability (FW-ADR-0004) and the bounded growth rate of
+  structural rewrites.
+- The migrations directory grows by one file per future structural
+  cliff in `upgrade.sh`. Cost scales linearly with rewrite cadence,
+  which is low and architect-gated.
+- The architect-side obligation to spawn a pre-bootstrap migration
+  on every future structural rewrite is implicit; it must be
+  cross-referenced from the structural-rewrite ADR's checklist
+  rather than enforced by tooling.
+- Adds `migration-out-of-range` to the enumerated `reason` field of
+  `.template-prebootstrap-blocked.json`. Back-compatible (pre-rc13
+  readers see an unknown reason string; the surrounding object
+  shape is unchanged) but future schema readers must accept the
+  additive value.
+
+### Follow-up ADRs
+
+- None required for this ADR's scope. A future ADR may revisit the
+  per-cliff cloning posture if the `scripts/lib/*` surface gains a
+  trust-pinned bootstrap mechanism (e.g., a content-addressed
+  shipping artefact verifiable independently of the running shell)
+  that resolves the de-dup catch-22.
+
+## Relationship to other ADRs and issues
+
+- **FW-ADR-0010 (pre-bootstrap local-edit safety).** This ADR
+  inherits FW-ADR-0010's interface verbatim and extends its coverage
+  from the v0.14.0 cliff to the rc-to-rc cliff. No interface
+  change; one new artefact (the cloned migration) and one additive
+  `reason` value (`migration-out-of-range`).
+- **FW-ADR-0004 (per-item file breakout).** This ADR honours
+  FW-ADR-0004's immutability rule for released migrations: the
+  cloned migration is shipped once at rc13 and never edited
+  post-release. Drift mitigation rests on that immutability.
+- **FW-ADR-0002 (upgrade content verification).** The cloned
+  migration's refuse-on-uncertain posture (matrix from FW-ADR-0010
+  + out-of-range refusal here) is the same shape FW-ADR-0002
+  carries for the regular sync loop. The framework now has one
+  consistent posture across all three windows: pre-bootstrap
+  (FW-ADR-0010 + this ADR), regular sync (FW-ADR-0002), and
+  post-sync manifest verify (FW-ADR-0002).
+
+## Verification
+
+- **Success signal:** rc-to-rc dogfood fixture in
+  `docs/pm/dogfood-2026-05-15-results.md` PASSes; a project stamped
+  at v1.0.0-rc2 with a vanilla `scripts/upgrade.sh` upgrades to rc13
+  without the in-place-cp crash and with no block artefact written.
+  A second fixture (project stamped at rc2 with an SPDX header on
+  `scripts/upgrade.sh`) refuses with exit 2, writes the block
+  artefact with `reason=local-edit`, and proceeds correctly on a
+  re-run with `SWDT_PREBOOTSTRAP_FORCE=1`. An out-of-range fixture
+  (migration invoked against an unstamped or mis-stamped project)
+  refuses with `reason=migration-out-of-range`.
+- **Failure signal:** an upstream issue reports either (i) the
+  in-place-cp crash recurring on the rc-to-rc cliff, (ii) the cloned
+  migration writing a block artefact with a `reason` value pre-rc13
+  schema readers cannot tolerate, (iii) the cloned migration silently
+  no-op-ing on an out-of-range invocation, or (iv) drift between
+  v0.14.0 and v1.0.0-rc13's pre-bootstrap matrix producing divergent
+  refusal decisions on the same fixture.
+- **Review cadence:** at the next MINOR release that introduces a
+  structural rewrite of `scripts/upgrade.sh`. Reconsider if any
+  failure signal fires, or if the `scripts/lib/*` shipping mechanism
+  gains content-addressed trust pinning that resolves the de-dup
+  catch-22.
+
+## Links
+
+- Upstream issues:
+  - `#170 — pre-bootstrap respects local edits` (FW-ADR-0010,
+    inherited)
+  - Blocker #1 (this ADR; rc-to-rc pre-bootstrap gap)
+- Related ADRs:
+  - `FW-ADR-0010 — pre-bootstrap local-edit safety` (interface
+    inherited verbatim)
+  - `FW-ADR-0004 — per-item file breakout` (immutability rule for
+    released migrations)
+  - `FW-ADR-0002 — upgrade content verification` (refuse-on-uncertain
+    posture this ADR extends)
+- Related artefacts:
+  - `migrations/v1.0.0-rc13.sh` (this ADR's deliverable; implemented
+    on branch `fix/blocker-1-rc-to-rc-prebootstrap`, commit `c7599b5`,
+    285 lines)
+  - `migrations/v0.14.0.sh` (lines 42–277 — the cloned source)
+  - `scripts/upgrade.sh` (NOT edited by this ADR; the file the
+    pre-bootstrap protects from in-place-cp)
+  - `docs/pm/pre-release-gate-overrides.md` (audit-log surface
+    inherited from FW-ADR-0010)
+  - `docs/pm/dogfood-2026-05-15-results.md` (rc-to-rc dogfood
+    evidence)
+- External references: MADR 3.0 (`https://adr.github.io/madr/`).

--- a/docs/adr/fw-adr-0014-preservation-vs-manifest.md
+++ b/docs/adr/fw-adr-0014-preservation-vs-manifest.md
@@ -1,0 +1,699 @@
+---
+name: fw-adr-0014-preservation-vs-manifest
+description: Preservation is honoured only on divergence-AND-non-manifest-fresh-write paths (refuse-on-uncertain on conflict); upgrade's tail emits a two-phase exit replacing the single-line "Done." with migration-complete + verification.
+status: proposed
+date: 2026-05-15
+---
+
+
+# FW-ADR-0014 — Preservation vs manifest (divergence-only + two-phase exit)
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+  - [Q1 — Preservation rule](#q1--preservation-rule)
+    - [Option M — Minimalist: trust `.template-customizations` verbatim](#option-m--minimalist-trust-template-customizations-verbatim)
+    - [Option S — Scalable: divergence-only AND manifest-respecting (refuse-on-uncertain)](#option-s--scalable-divergence-only-and-manifest-respecting-refuse-on-uncertain)
+    - [Option C — Creative: drop the preservation list; derive preservation from divergence alone](#option-c--creative-drop-the-preservation-list-derive-preservation-from-divergence-alone)
+  - [Q2 — Upgrade tail shape](#q2--upgrade-tail-shape)
+    - [Option M — Minimalist: keep the single-line "Done." tail](#option-m--minimalist-keep-the-single-line-done-tail)
+    - [Option S — Scalable: two-phase exit (migration complete + verification)](#option-s--scalable-two-phase-exit-migration-complete--verification)
+    - [Option C — Creative: structured JSON tail with embedded verification report](#option-c--creative-structured-json-tail-with-embedded-verification-report)
+- [Decision outcome](#decision-outcome)
+  - [Q1 decision — divergence-only AND manifest-respecting (Option S)](#q1-decision--divergence-only-and-manifest-respecting-option-s)
+  - [Back-compat for already-polluted downstreams](#back-compat-for-already-polluted-downstreams)
+  - [Q2 decision — two-phase exit (Option S)](#q2-decision--two-phase-exit-option-s)
+  - [Inherited FW-ADR-0010 interface (binding)](#inherited-fw-adr-0010-interface-binding)
+  - [Implementation notes for software-engineer](#implementation-notes-for-software-engineer)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up ADRs](#follow-up-adrs)
+- [Relationship to other ADRs and issues](#relationship-to-other-adrs-and-issues)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+Shape per MADR 3.0 + this template's Three-Path Rule
+(`docs/templates/adr-template.md`). Two coupled decisions (Q1
+preservation rule, Q2 tail shape) are recorded in a single ADR because
+they share the same triggering blocker and the same audit-log /
+exit-code surface.
+
+---
+
+## Status
+
+- **Proposed: 2026-05-15**
+- **Deciders:** `architect` + `tech-lead` + customer (cross-cutting
+  pattern change to upgrade preservation semantics and to the upgrade
+  exit contract; customer approval required per CLAUDE.md Hard Rules)
+- **Consulted:** `software-engineer` (implementation), `qa-engineer`
+  (smoke coverage on already-polluted fixtures), `release-engineer`
+  (CI / dogfood pipeline; `Done\.` greps in fixtures), FW-ADR-0010
+  (pre-bootstrap interface, inherited for the preservation refusal
+  surface), FW-ADR-0002 (manifest verification, the `--verify`
+  formatter reused for phase B output).
+
+## Context and problem statement
+
+The upgrade flow carries a `preserve_list` derived from
+`.template-customizations` (path patterns the operator has declared
+project-customised). The current behaviour treats the preserve list
+as authoritative: a path listed there is left alone by the sync
+loop, regardless of whether the project's content actually diverges
+from the baseline at that path, and regardless of whether the
+destination manifest declares the path as a fresh-write the upgrade
+is supposed to install. This produces two failure modes:
+
+1. **Pollution.** Operators add entries to `.template-customizations`
+   defensively, then forget to remove them after the customisation
+   is upstreamed. Subsequent upgrades silently skip paths that have
+   no actual divergence, leaving the project pinned to stale
+   framework content the operator does not realise they have opted
+   out of.
+2. **Manifest contradiction.** A new release may declare a path as a
+   fresh-write (e.g., a new `scripts/lib/*.sh` helper, a renamed
+   template file). If that path is matched by a stale preserve-list
+   pattern, the fresh-write is skipped and the upgrade leaves the
+   project in a half-installed state — manifest-verify then flags
+   drift the operator did not introduce.
+
+The customer's 2026-05-15 ruling (Blocker #4) addresses both modes
+and additionally calls for the upgrade tail to stop conflating
+"migration queue done" with "project is in a clean post-upgrade
+state". Today the tail prints a single line: `Done. TEMPLATE_VERSION
+now <ver>.` Whether the project is clean, drifted, or carries a
+preservation refusal is not visible from the exit signal. ADR-trigger
+rows that fire: cross-cutting pattern change (upgrade contract +
+preservation semantics), new exit code path (preservation refusal),
+new env var (`SWDT_PRESERVATION_FORCE`), new artefact
+(`.template-preservation-blocked.json`), audit-log column extension.
+Dogfood evidence sits in `docs/pm/dogfood-2026-05-15-results.md`.
+
+## Decision drivers
+
+- **Customisation wins, but only on real customisation.** The
+  framework's "customisation wins" rule (FW-ADR-0002,
+  `docs/framework-project-boundary.md`) must extend to preservation
+  — but only when there is actual divergence to preserve. An inert
+  preserve-list entry is not a customisation, it is pollution.
+- **Manifest declarations are load-bearing.** A path the destination
+  manifest declares as a fresh-write is part of the release's
+  intended state. Letting a stale preserve-list pattern override
+  that declaration breaks the manifest's contract with `--verify`
+  and produces unexplained drift.
+- **Refuse-on-uncertain on genuine conflict.** When divergence AND
+  fresh-write declaration both fire on the same path, the framework
+  cannot decide unambiguously which the operator wants. Same posture
+  as FW-ADR-0010 and FW-ADR-0002: refuse, surface the conflict,
+  provide an audit-evident override.
+- **Back-compat for already-polluted downstreams.** Existing
+  projects carry inert preserve-list entries today. A flag day that
+  refuses every polluted project is unacceptable; the migration path
+  must absorb the pollution without operator surgery.
+- **Exit signal must distinguish clean from drift from refusal.**
+  Today's single-line tail collapses three distinct post-conditions
+  into one exit code. CI gates and operators both need the
+  distinction.
+- **Don't re-invent the verify formatter.** `scripts/lib/manifest.sh`
+  already carries a `--verify` formatter with a tested output shape.
+  The two-phase tail's phase B must reuse it rather than spawning a
+  parallel formatter.
+- **Audit-log surface reuse.** FW-ADR-0010 added a `Gate` column to
+  `docs/pm/pre-release-gate-overrides.md` distinguishing
+  `pre-release` from `pre-bootstrap` rows. Preservation refusal
+  needs the same kind of audit trail; extending the `Gate` column
+  with a third value is cheaper than spawning a sibling register.
+
+## Considered options (Three-Path Rule, binding)
+
+### Q1 — Preservation rule
+
+#### Option M — Minimalist: trust `.template-customizations` verbatim
+
+Keep today's behaviour. Document the pollution risk in release notes
+and operator-facing guidance; rely on operators to prune stale
+entries themselves.
+
+- **Sketch:** No code change. A new section in
+  `docs/TEMPLATE_UPGRADE.md` warns about pollution and recommends
+  periodic `.template-customizations` review.
+- **Pros:**
+  - Zero implementation cost.
+  - No back-compat work.
+- **Cons:**
+  - Pollution mode persists. Operators continue to silently skip
+    paths they no longer customise.
+  - Manifest-contradiction mode persists. Fresh-write declarations
+    on a polluted path silently lose to the preserve list.
+  - Discovery is via `--verify` drift reports that the operator
+    must investigate manually; the framework offers no
+    self-healing.
+- **When M wins:** if preserve-list pollution were rare in practice
+  and manifest-contradiction conflicts had no measurable rate. The
+  customer's 2026-05-15 ruling establishes that they are not.
+
+#### Option S — Scalable: divergence-only AND manifest-respecting (refuse-on-uncertain)
+
+Preservation is honoured only when *both* conditions hold:
+
+- (a) The project's content diverges from the baseline at the
+  stamped version for that path, AND
+- (b) The destination manifest does not declare the path as a
+  fresh-write.
+
+When both rules conflict on a genuinely-customised path (i.e., the
+path diverges AND the destination manifest declares it as a
+fresh-write the new release intends to install over the
+customisation): refuse-on-uncertain. Write
+`.template-preservation-blocked.json`, exit 2. Override via
+`SWDT_PRESERVATION_FORCE=1`; audit row appended to
+`docs/pm/pre-release-gate-overrides.md` with a new `Gate` column
+value `preservation`.
+
+- **Sketch:** Replace the bare `preserve_list` membership check in
+  the sync loop with a function that consults the baseline SHA
+  (divergence check) and the destination manifest
+  (fresh-write check). Decision matrix:
+  - no-divergence: drop the path from `preserve_list` (inert
+    entry; sync loop proceeds with the upstream content).
+  - divergence + path not declared fresh-write: preserve.
+  - divergence + path declared fresh-write: refuse, write
+    block artefact, exit 2 unless `SWDT_PRESERVATION_FORCE=1`.
+- **Pros:**
+  - Pollution mode closes: inert preserve-list entries silently
+    drop at sync time without operator surgery.
+  - Manifest-contradiction mode surfaces explicitly: the conflict
+    is named, the artefact carries the per-path detail, the
+    operator decides.
+  - Maps cleanly onto FW-ADR-0010's refuse-on-uncertain posture and
+    onto FW-ADR-0002's customisation-wins-on-divergence rule.
+  - Override is auditable via the existing pre-release-gate-overrides
+    register, extended with a new `Gate` column value.
+  - Self-healing path (drop inert entries at runtime) handles
+    already-polluted downstreams without a flag day.
+- **Cons:**
+  - New exit code path on preservation refusal (exit 2, shared with
+    FW-ADR-0010's pre-bootstrap refusal; operators must read the
+    block-artefact filename to distinguish).
+  - New env var (`SWDT_PRESERVATION_FORCE`); new artefact
+    (`.template-preservation-blocked.json`); third `Gate` column
+    value (`preservation`). All three are additive surface that
+    future releases must keep backward-compatible.
+  - Requires the destination manifest to be populated and trusted
+    before the sync loop hits the preservation check — the
+    implementation must order things so manifest read precedes
+    preserve-list consultation.
+  - Operators carrying genuine customisation on a path the new
+    release wants to fresh-write will see a refusal where today
+    they saw silent preservation. This is the intended
+    customer-visible behaviour change; release notes must call it
+    out.
+- **When S wins:** the framework's actual use case — long-lived
+  projects, occasional stale preserve-list entries, occasional
+  fresh-write declarations on previously-customised paths, audit
+  requirements on overrides. Maps cleanly to FW-ADR-0002 and
+  FW-ADR-0010.
+
+#### Option C — Creative: drop the preservation list; derive preservation from divergence alone
+
+Stop reading `.template-customizations` entirely. Compute the
+preserve set per upgrade run from baseline vs project SHA
+divergence. A path is preserved iff its current SHA differs from the
+baseline SHA at the stamped version.
+
+- **Sketch:** Delete the `preserve_list` plumbing. The sync loop
+  consults baseline / project / upstream SHAs (the same triple
+  FW-ADR-0010 uses) and decides per-path: equal-to-baseline →
+  overwrite; diverged-from-baseline → preserve. Manifest declarations
+  are layered on as a refuse-on-conflict guard, same as Option S.
+- **Pros:**
+  - Single source of truth (the baseline SHA) replaces a
+    user-maintained register.
+  - Pollution mode cannot exist — there is no list to pollute.
+  - Manifest declarations layer on as a refuse guard, same as
+    Option S, with simpler upstream semantics.
+  - The `.template-customizations` file becomes documentation-only
+    or is retired entirely.
+- **Cons:**
+  - **Loses operator intent signal.** Today's preserve list lets the
+    operator declare "this path is intentionally customised, keep
+    it customised even if the divergence is accidental (e.g., a
+    line-ending normalisation)". Divergence-alone treats every
+    diff as intentional, which is wrong for cases like
+    SPDX-header drift, auto-formatter churn, or editor whitespace.
+  - **Migration cost.** Retiring `.template-customizations` is a
+    breaking change to every downstream project; the operator
+    interface that the existing customer ruling 2026-05-14 just
+    extended (the `Gate` column work) gets pulled out from under
+    that ruling.
+  - **Discovery is implicit.** With no register, the operator
+    cannot see at a glance which paths the framework considers
+    customised — they have to run `--verify` and read SHA diffs.
+- **When C wins:** if the operator intent signal had no value (every
+  divergence is genuinely intentional) and the migration cost of
+  retiring `.template-customizations` were near-free. Neither holds.
+
+### Q2 — Upgrade tail shape
+
+#### Option M — Minimalist: keep the single-line "Done." tail
+
+Keep `Done. TEMPLATE_VERSION now <ver>.` Document that operators
+should run `./scripts/upgrade.sh --verify` separately to confirm
+clean state.
+
+- **Sketch:** No code change. Release notes add a "run `--verify`
+  after upgrade" recommendation.
+- **Pros:**
+  - Zero implementation cost.
+  - No fixture / playbook updates needed.
+- **Cons:**
+  - Conflates three distinct post-conditions (clean, drift,
+    refusal) under a single exit signal.
+  - CI gates cannot distinguish "migration succeeded but project
+    has drift" from "migration succeeded and project is clean"
+    without a second invocation.
+  - The preservation-refusal path (from Q1's Option S) would have
+    no native tail surface — refusals would need a parallel
+    formatter.
+- **When M wins:** if preserve-list refusal were impossible and CI
+  gates were happy to run `--verify` twice. Neither holds.
+
+#### Option S — Scalable: two-phase exit (migration complete + verification)
+
+Replace `Done. TEMPLATE_VERSION now <ver>.` with a two-phase tail:
+
+- **Phase A** prints `Migration chain complete (TEMPLATE_VERSION
+  now <ver>).` This signals the migration queue's success
+  independent of project state.
+- **Phase B** prints either `Verification: clean.` (no drift, no
+  refusal) or a per-path drift summary (the existing `--verify`
+  formatter's output, reused verbatim).
+- **Exit code** follows phase B: `0` on clean, `1` on drift, `2`
+  on preservation-refusal (shared with pre-bootstrap refusal per
+  FW-ADR-0010; distinguished by the block-artefact filename
+  present in the project root).
+
+- **Sketch:** At the end of `scripts/upgrade.sh`, after the manifest
+  is written, call the existing `manifest.sh` verify entry point.
+  Format its output through the same `--verify` formatter operators
+  already see. Map verify's internal status to the exit code.
+- **Pros:**
+  - CI gates and operators see the three post-conditions
+    distinctly via exit code AND via the formatted phase B output.
+  - Reuses the existing `--verify` formatter from
+    `scripts/lib/manifest.sh` for output-shape consistency.
+  - The preservation-refusal path from Q1 has a native tail
+    surface — phase B reports the refusal alongside its
+    block-artefact pointer.
+  - The new exit semantics are additive on the existing exit code
+    space; FW-ADR-0010's exit 2 stays consistent.
+- **Cons:**
+  - Repo-wide audit needed for `Done\.` greps in CI scripts,
+    fixtures, playbooks, and downstream documentation. Existing
+    consumers may parse the literal "Done." line as a success
+    signal.
+  - The phase B output adds verbose lines on every successful
+    upgrade, where today the tail is one line. Mitigation: the
+    clean-state output is a single line (`Verification: clean.`),
+    only the drift / refusal cases expand.
+  - Phase B runs `--verify`, which adds work to every upgrade
+    (one SHA pass over the project tree). Cost is bounded by the
+    existing `--verify` runtime, which is already tolerated as a
+    standalone invocation.
+- **When S wins:** when operators and CI gates both need the
+  three-way distinction and the `--verify` formatter is already
+  trusted upstream. Both hold.
+
+#### Option C — Creative: structured JSON tail with embedded verification report
+
+Replace the prose tail with a single JSON blob: `{"template_version":
+"<ver>", "verification": <verify report>, "preservation_refusal":
+<artefact or null>}`. Operators pipe it through `jq`; CI gates
+parse it directly.
+
+- **Sketch:** Final stdout of `scripts/upgrade.sh` is a JSON
+  document. Prose status lines are routed to stderr only.
+- **Pros:**
+  - Machine-parseable.
+  - Embeds the verification report inline; no separate file read
+    required.
+  - Forward-compatible with future post-upgrade signals
+    (security-scan results, schema-version checks).
+- **Cons:**
+  - **Human-readability regression.** Operators running upgrade
+    interactively today see a clear prose tail; a JSON blob is a
+    significant UX downgrade. Mitigation (a separate human-readable
+    tail to stderr) introduces two surfaces that must stay in sync.
+  - Repo-wide audit for `Done\.` greps still needed, plus a second
+    audit for any consumer parsing stdout as prose.
+  - The `--verify` formatter would have to grow a JSON output
+    mode, which is real implementation work that FW-ADR-0002 has
+    not yet sanctioned.
+  - Locks the tail surface into JSON; future additions become
+    schema-bump events rather than prose extensions.
+- **When C wins:** if the upgrade UI were exclusively CI-driven and
+  human invocation were vanishingly rare. The framework explicitly
+  supports both modes.
+
+## Decision outcome
+
+### Q1 decision — divergence-only AND manifest-respecting (Option S)
+
+**Chosen option: S.** Option M leaves both pollution and
+manifest-contradiction modes live. Option C retires the operator
+intent signal `.template-customizations` carries (the operator's
+declared-customised assertion), losing real information. Option S
+preserves the operator's intent signal AND adds two structural
+guards (divergence required, manifest declaration respected) that
+close the two failure modes. The refuse-on-uncertain posture
+matches FW-ADR-0010 and FW-ADR-0002.
+
+The decision matrix:
+
+| project vs baseline | manifest declaration | action |
+|---------------------|---------------------|--------|
+| equal (no divergence) | any | **drop from preserve_list** (inert entry; sync proceeds with upstream content) |
+| diverged | not declared fresh-write | **preserve** (genuine customisation; sync leaves project content alone) |
+| diverged | declared fresh-write | **refuse** (write block artefact, exit 2 unless `SWDT_PRESERVATION_FORCE=1`) |
+
+The "refuse" row writes `.template-preservation-blocked.json` at
+project root with one entry per affected path
+(`path`, `project_sha`, `baseline_sha`, `manifest_declared_sha`,
+`reason=manifest-fresh-write-vs-customisation`). The escape hatch is
+`SWDT_PRESERVATION_FORCE=1`; an audit row is appended to
+`docs/pm/pre-release-gate-overrides.md` with `Gate=preservation` in
+the column FW-ADR-0010 introduced.
+
+### Back-compat for already-polluted downstreams
+
+The "drop from preserve_list" row is structurally self-healing — no
+operator action is required for a project carrying inert entries.
+The implementation must additionally provide:
+
+- **Runtime self-healing.** At sync time, every preserve-list entry
+  is evaluated against (a) divergence and (b) manifest declaration.
+  Inert entries (no-divergence OR declared-fresh-write-with-no-
+  divergence) are dropped from the in-memory `preserve_list` before
+  the sync loop reads it. The on-disk `.template-customizations`
+  file is **not** rewritten in this pass — the operator opts into
+  the rewrite via the migration below.
+- **Opt-in one-shot pruning migration.** A new migration step
+  surfaces the planned prune list to the operator before rewriting
+  `.template-customizations`. Behaviour: dry-run by default
+  (prints the prune list, exits with the candidate edits printed
+  but the file untouched); operator re-runs with an explicit
+  acknowledgement env var to apply. This migration is opt-in
+  because rewriting `.template-customizations` is a project-owned
+  file change that the framework should not perform silently.
+- **`migrations/v0.15.0.sh` divergence pre-check.** Add a
+  divergence pre-check at the top of `v0.15.0.sh` so future runs
+  do not seed the same pollution pattern. The pre-check identifies
+  preserve-list entries that have no divergence and warns (without
+  refusing) at migration time, pointing the operator at the
+  one-shot pruning migration.
+
+### Q2 decision — two-phase exit (Option S)
+
+**Chosen option: S.** Option M conflates three post-conditions
+under one exit signal, which the Q1 preservation-refusal path
+exposes as a real problem. Option C optimises for the CI-only case
+at the cost of human readability and locks the surface into JSON
+prematurely. Option S splits the tail into migration-complete
+(phase A) and verification (phase B), reuses the existing
+`--verify` formatter for phase B output, and maps the verify result
+onto exit codes (0 clean / 1 drift / 2 preservation-refusal).
+
+Phase A line (literal, for grep-stability):
+
+```
+Migration chain complete (TEMPLATE_VERSION now <ver>).
+```
+
+Phase B line on clean state (literal):
+
+```
+Verification: clean.
+```
+
+Phase B output on drift or preservation-refusal: the existing
+`scripts/lib/manifest.sh --verify` formatter's output verbatim
+(per-path drift summary; preservation-refusal entries flagged with
+the block-artefact filename).
+
+Exit code mapping:
+
+- `0` — phase B reports clean (no drift, no preservation-refusal).
+- `1` — phase B reports drift (one or more paths' on-disk SHA
+  differs from the manifest-declared SHA without a preservation
+  reason).
+- `2` — phase B reports preservation-refusal (one or more paths
+  hit the Q1 refuse row; `.template-preservation-blocked.json`
+  exists at project root). Shared with FW-ADR-0010's pre-bootstrap
+  refusal exit; the two block-artefact filenames
+  (`.template-prebootstrap-blocked.json` vs
+  `.template-preservation-blocked.json`) are the discriminator.
+
+### Inherited FW-ADR-0010 interface (binding)
+
+The preservation refusal path inherits FW-ADR-0010's interface
+shape with one extension:
+
+- **`SWDT_PRESERVATION_FORCE=1`** — new env var; same operator
+  self-service override semantics as `SWDT_PREBOOTSTRAP_FORCE=1`.
+  Overrides the Q1 refuse row and proceeds with the manifest's
+  fresh-write declaration (i.e., overwrites the divergent project
+  content with the upstream content). Audit row appended before
+  any file is touched.
+- **Exit code 2** — shared with pre-bootstrap refusal (same exit
+  semantics class: refuse-on-uncertain).
+- **`.template-preservation-blocked.json`** — new artefact, schema
+  parallel to `.template-prebootstrap-blocked.json` (version,
+  generated, reason_summary, blocked array with per-path entries).
+  See implementation notes for the schema.
+- **Audit-log row** — same surface
+  (`docs/pm/pre-release-gate-overrides.md`); the `Gate` column
+  FW-ADR-0010 added gains a third value `preservation` alongside
+  `pre-release` and `pre-bootstrap`.
+
+### Implementation notes for software-engineer
+
+Eight concrete change points:
+
+1. **`scripts/upgrade.sh` (sync-loop preservation check, ~line 540).**
+   Replace the bare `preserve_list` membership check with a call to
+   a new `should_preserve()` function that consults baseline SHA
+   (divergence) and the destination manifest (fresh-write
+   declaration). Returns one of `preserve` / `drop-inert` /
+   `refuse-conflict`. Sync loop honours `preserve` and `drop-inert`
+   silently; `refuse-conflict` triggers the block-artefact writer.
+
+2. **`scripts/lib/manifest.sh` (manifest-declaration query, new
+   function).** Add `manifest_declares_fresh_write(path)` that
+   returns 0 if the destination manifest carries an entry for
+   `path` whose `source` field is `fresh-write` (or the
+   manifest-format equivalent the implementation lands on),
+   non-zero otherwise. Used by `should_preserve()` in change point 1.
+
+3. **`scripts/upgrade.sh` (block-artefact writer, ~line 720).** New
+   function `write_preservation_block_artefact()` that emits
+   `.template-preservation-blocked.json` at project root. Schema:
+   ```json
+   {
+     "version": 1,
+     "generated": "<ISO-8601 UTC>",
+     "reason_summary": "manifest-fresh-write-vs-customisation",
+     "blocked": [
+       {
+         "path": "<path>",
+         "project_sha": "<sha>",
+         "baseline_sha": "<sha>",
+         "manifest_declared_sha": "<sha>",
+         "reason": "manifest-fresh-write-vs-customisation"
+       }
+     ]
+   }
+   ```
+   `blocked` sorted by `path` for determinism; `generated` is the
+   only field expected to vary between idempotent re-runs.
+
+4. **`scripts/upgrade.sh` (env-var override + audit-row writer,
+   near the block-artefact writer).** Honour
+   `SWDT_PRESERVATION_FORCE=1`: append a row to
+   `docs/pm/pre-release-gate-overrides.md` with
+   `Gate=preservation` before any file is touched. If the audit
+   log is unwritable, refuse the override (same posture as
+   FW-ADR-0010).
+
+5. **`scripts/upgrade.sh` (two-phase tail, end of script).**
+   Replace the single `echo "Done. TEMPLATE_VERSION now $ver."`
+   with the phase A literal `Migration chain complete
+   (TEMPLATE_VERSION now $ver).`, then invoke
+   `manifest.sh`'s verify entry point. Format its output via the
+   existing `--verify` formatter. Map verify's internal status to
+   exit codes 0 / 1 / 2 per the Q2 decision. On clean state, emit
+   the literal `Verification: clean.` as phase B.
+
+6. **`migrations/v0.15.0.sh` (divergence pre-check, near the top
+   of the script).** Add a block that walks the project's
+   `.template-customizations` entries and identifies inert ones
+   (no divergence vs baseline). Emit a WARN per inert entry
+   pointing the operator at the opt-in pruning migration. Does
+   not refuse, does not edit `.template-customizations` (the
+   pruning migration is opt-in).
+
+7. **New migration `migrations/v1.0.0-rc14.sh` (opt-in
+   `.template-customizations` pruning).** Dry-run by default:
+   prints the prune list, exits without rewriting. Operator
+   re-runs with `SWDT_PRESERVATION_PRUNE_APPLY=1` (or equivalent
+   acknowledgement env var; final name pinned during
+   implementation) to apply the rewrite. Migration follows
+   FW-ADR-0004's immutability rule once released.
+
+8. **Repo-wide `Done\.` audit (release-engineer + qa-engineer).**
+   Grep CI scripts, fixtures, playbooks, and downstream
+   documentation for the literal `Done.` parse pattern. Document
+   every site in the implementation notes and migrate consumers to
+   the new phase A literal `Migration chain complete
+   (TEMPLATE_VERSION now <ver>).`. Audit-output recorded in the
+   release notes for rc-to-rc upgraders.
+
+## Consequences
+
+### Positive
+
+- Pollution mode closes structurally: inert preserve-list entries
+  silently drop at sync time without operator surgery. Already-
+  polluted downstreams self-heal on next upgrade.
+- Manifest-contradiction mode surfaces explicitly via the refuse
+  path; the conflict is named, the artefact is machine-parseable,
+  and the operator decides via the documented force env var.
+- The framework now carries one consistent refuse-on-uncertain
+  posture across all three windows: pre-bootstrap (FW-ADR-0010 +
+  FW-ADR-0013), preservation (this ADR), regular sync
+  (FW-ADR-0002).
+- Two-phase exit gives CI gates and operators the three-way
+  distinction (clean / drift / refusal) that today's tail collapses.
+- `--verify` formatter reuse keeps output shape consistent across
+  the upgrade tail and the standalone `--verify` invocation.
+- Audit-log surface stays single-file: the `Gate` column FW-ADR-0010
+  introduced absorbs the third event type.
+
+### Negative / trade-offs accepted
+
+- New env var (`SWDT_PRESERVATION_FORCE`), new artefact
+  (`.template-preservation-blocked.json`), third `Gate` column
+  value (`preservation`). All three are additive surface that
+  future releases must keep backward-compatible.
+- Exit code 2 is now shared between pre-bootstrap refusal
+  (FW-ADR-0010) and preservation refusal (this ADR). Operators
+  and CI gates distinguish by block-artefact filename. Acceptable
+  because both are refuse-on-uncertain events at semantic parity.
+- The two-phase tail adds a `--verify` pass to every upgrade run.
+  Cost is bounded by the existing standalone-verify runtime,
+  already tolerated.
+- Repo-wide `Done\.` audit is real work and will touch fixtures,
+  playbooks, and downstream documentation. Mitigation: the audit
+  is bounded to one release cycle (rc13/rc14) and the new phase A
+  literal is grep-stable.
+- Opt-in pruning migration adds one more file to the migrations
+  directory. Honours FW-ADR-0004 immutability.
+- Operators carrying genuine customisation on a path the new
+  release wants to fresh-write will see a refusal where today they
+  saw silent preservation. Customer-visible behaviour change;
+  release notes must call it out.
+
+### Follow-up ADRs
+
+- None required for this ADR's scope. A future ADR may revisit the
+  exit-code sharing if a third refuse-on-uncertain event type lands
+  and per-event exit codes become useful (e.g., exit codes 3 / 4 /
+  5 for distinct refuse classes).
+
+## Relationship to other ADRs and issues
+
+- **FW-ADR-0010 (pre-bootstrap local-edit safety).** This ADR
+  inherits FW-ADR-0010's interface shape (force env var, exit code 2,
+  block-artefact filename pattern, audit-log column) and extends the
+  `Gate` column with the `preservation` value. The two ADRs share
+  exit code 2 by design — both are refuse-on-uncertain events at
+  semantic parity.
+- **FW-ADR-0002 (upgrade content verification).** This ADR reuses
+  the `--verify` formatter from `scripts/lib/manifest.sh` for the
+  two-phase tail's phase B output. FW-ADR-0002's drift-reporting
+  shape is the same shape phase B emits.
+- **FW-ADR-0013 (rc-to-rc pre-bootstrap).** Sibling ADR landing in
+  the same blocker batch (2026-05-15). Same dogfood evidence file
+  (`docs/pm/dogfood-2026-05-15-results.md`); both inherit FW-ADR-0010.
+  No direct technical coupling beyond the shared exit code 2.
+- **FW-ADR-0004 (per-item file breakout).** The opt-in pruning
+  migration and the `v0.15.0.sh` divergence pre-check both honour
+  FW-ADR-0004's immutability rule for released migrations.
+
+## Verification
+
+- **Success signal:** dogfood fixtures in
+  `docs/pm/dogfood-2026-05-15-results.md` PASS for: (a) a project
+  with inert preserve-list entries upgrades cleanly, the inert
+  entries silently drop, the post-upgrade `--verify` reports clean,
+  exit 0; (b) a project with genuine customisation on a non-
+  fresh-write path upgrades cleanly, customisation preserved, exit
+  0; (c) a project with genuine customisation on a fresh-write-
+  declared path refuses with exit 2 and writes
+  `.template-preservation-blocked.json`; (d) re-running (c) with
+  `SWDT_PRESERVATION_FORCE=1` proceeds, writes the audit row,
+  removes the block artefact, completes the upgrade with exit 0;
+  (e) the opt-in pruning migration in dry-run mode prints the
+  prune list without rewriting `.template-customizations`; (f) the
+  pruning migration with the apply env var rewrites the file
+  idempotently. Phase A and phase B literals appear in the
+  expected order in every successful run.
+- **Failure signal:** an upstream issue reports (i) a fresh-write
+  declaration silently lost to a stale preserve-list entry, (ii)
+  inert preserve-list entries still blocking sync after the
+  self-healing pass, (iii) the two-phase tail emitting a stale
+  `Done.` line in any code path, (iv) a `Done\.` grep in CI /
+  fixtures / playbooks missed by the audit and parsing the new
+  phase A literal incorrectly, or (v) exit code 2 ambiguity
+  causing a CI gate to misclassify pre-bootstrap-refusal as
+  preservation-refusal or vice versa.
+- **Review cadence:** at the next MINOR release that touches
+  `.template-customizations` semantics or the upgrade tail.
+  Reconsider if any failure signal fires, or if a third
+  refuse-on-uncertain event class lands and per-event exit codes
+  become preferable.
+
+## Links
+
+- Upstream issues:
+  - Blocker #4 (this ADR; preservation vs manifest)
+- Related ADRs:
+  - `FW-ADR-0010 — pre-bootstrap local-edit safety` (interface
+    shape inherited; `Gate` column extended)
+  - `FW-ADR-0013 — rc-to-rc pre-bootstrap` (sibling blocker ADR;
+    same dogfood evidence; shared exit code 2)
+  - `FW-ADR-0002 — upgrade content verification` (`--verify`
+    formatter reused for phase B output)
+  - `FW-ADR-0004 — per-item file breakout` (migration immutability
+    rule honoured by the opt-in pruning migration)
+- Related artefacts:
+  - `scripts/upgrade.sh` (preservation check, block-artefact
+    writer, two-phase tail)
+  - `scripts/lib/manifest.sh` (`manifest_declares_fresh_write`
+    query, `--verify` formatter reused for phase B)
+  - `migrations/v0.15.0.sh` (divergence pre-check)
+  - `migrations/v1.0.0-rc14.sh` (opt-in pruning migration; new file)
+  - `.template-customizations` (project-owned register the
+    preservation logic consults; the opt-in pruning migration
+    rewrites it)
+  - `.template-preservation-blocked.json` (new block artefact at
+    project root)
+  - `docs/pm/pre-release-gate-overrides.md` (audit-log surface;
+    `Gate` column gains `preservation` value)
+  - `docs/pm/dogfood-2026-05-15-results.md` (dogfood evidence)
+- External references: MADR 3.0 (`https://adr.github.io/madr/`).

--- a/docs/adr/fw-adr-0014-preservation-vs-manifest.md
+++ b/docs/adr/fw-adr-0014-preservation-vs-manifest.md
@@ -1,7 +1,7 @@
 ---
 name: fw-adr-0014-preservation-vs-manifest
 description: Preservation is honoured only on divergence-AND-non-manifest-fresh-write paths (refuse-on-uncertain on conflict); upgrade's tail emits a two-phase exit replacing the single-line "Done." with migration-complete + verification.
-status: proposed
+status: accepted
 date: 2026-05-15
 ---
 
@@ -49,6 +49,7 @@ exit-code surface.
 ## Status
 
 - **Proposed: 2026-05-15**
+- **Accepted: 2026-05-15**
 - **Deciders:** `architect` + `tech-lead` + customer (cross-cutting
   pattern change to upgrade preservation semantics and to the upgrade
   exit contract; customer approval required per CLAUDE.md Hard Rules)

--- a/docs/pm/dogfood-2026-05-15-results.md
+++ b/docs/pm/dogfood-2026-05-15-results.md
@@ -1,0 +1,329 @@
+# Dogfood results — 2026-05-15
+
+Target: v1.0.0-rc12 (tag resolves to `cac0ab03e3612cf01d0e9c079b0e6e4c325e366a`)
+Codenames: alpha, beta, gamma — 3 states each (scaffold / mid / latest) = 9 runs
+Runner: `tests/release-gate/dogfood-downstream.sh`
+Fixture-capture rule reminder: codenames-only; no customer / site / vendor names in evidence files.
+
+## Summary
+
+| codename       | state    | before        | after         | upgrade | verify | conflicts | ai-tui              | RESULT |
+|----------------|----------|---------------|---------------|---------|--------|-----------|---------------------|--------|
+| alpha          | scaffold | v1.0.0-rc2    | v1.0.0-rc2    | 2       | 2      | 0         | skipped-script-fail | FAIL   |
+| alpha          | mid      | (no report)   | (no report)   | -       | -      | -         | -                   | FAIL   |
+| alpha          | latest   | (no report)   | (no report)   | -       | -      | -         | -                   | FAIL   |
+| beta           | scaffold | v0.13.0       | v1.0.0-rc12   | 1       | 1      | 0         | skipped-script-fail | FAIL   |
+| beta           | mid      | v1.0.0-rc3    | v1.0.0-rc12   | 0       | 1      | 7         | skipped-script-fail | FAIL   |
+| beta           | latest   | v1.0.0-rc8    | v1.0.0-rc12   | 0       | 1      | 8         | skipped-script-fail | FAIL   |
+| gamma          | scaffold | v1.0.0-rc7    | v1.0.0-rc12   | 0       | 0      | 0         | fail (5/21)         | FAIL   |
+| gamma          | mid      | v1.0.0-rc8    | v1.0.0-rc12   | 0       | 1      | 2         | skipped-script-fail | FAIL   |
+| gamma          | latest   | v1.0.0-rc8    | v1.0.0-rc12   | 0       | 1      | 15        | skipped-script-fail | FAIL   |
+
+Totals: **0 PASS / 9 FAIL.**
+
+Report files (kept under `/tmp`; codenames-only; safe to share):
+
+- `/tmp/dogfood-alpha-scaffold-20260515T112229Z.txt`
+- `/tmp/dogfood-beta-scaffold-20260515T112302Z.txt`
+- `/tmp/dogfood-beta-mid-20260515T112320Z.txt`
+- `/tmp/dogfood-beta-latest-20260515T112337Z.txt`
+- `/tmp/dogfood-gamma-scaffold-20260515T112354Z.txt`
+- `/tmp/dogfood-gamma-mid-20260515T112416Z.txt`
+- `/tmp/dogfood-gamma-latest-20260515T112432Z.txt`
+
+alpha/mid and alpha/latest: no report files written — driver aborted
+in `cp -aL` preflight before reaching the report-writer. See alpha/mid
++ alpha/latest entry under Failures.
+
+## Failures (per fixture)
+
+### alpha/scaffold (v1.0.0-rc2 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=2; verify exit=2`. After-version did not advance: still
+`v1.0.0-rc2`. Migrations table only enumerated `[v1.0.0-rc9]` (0 files
+backfilled), then crashed.
+
+Excerpt (`upgrade.sh stdout/stderr`):
+
+```
+Running migrations between v1.0.0-rc2 and v1.0.0-rc12:
+  [v1.0.0-rc9]
+    migrations/v1.0.0-rc9.sh: 0 files backfilled, 0 files already current.
+
+./scripts/upgrade.sh: line 205: syntax error near unexpected token `;;'
+```
+
+Excerpt (`upgrade.sh --verify stdout/stderr`):
+
+```
+ERROR: manifest not found at /tmp/dogfood-driver.PUZWsA/tree/TEMPLATE_MANIFEST.lock
+  Run 'scripts/upgrade.sh' to (re)generate it. Pre-v0.14.0
+  projects without a manifest can also run scripts/upgrade.sh
+  — the v0.14.0 migration synthesises an initial manifest.
+```
+
+Root cause: rc2 ships an old `scripts/upgrade.sh` that lacks the cross-MAJOR
+pre-bootstrap from v0.14.0 / FW-ADR-0010. The local rc2 upgrade.sh runs
+the v1.0.0-rc9 migration and then dies on a syntax error — almost certainly
+the rc12 candidate-script being copied over the running rc2 script
+mid-execution (classic self-overwrite). No v0.14.0 manifest synthesis →
+`--verify` then dies with "manifest not found." Real downstream RC-to-RC
+upgrade is wedged.
+
+Suggested upstream issue (Blocker #1): `migrations/v1.0.0-rc13.sh` to
+pre-bootstrap `scripts/upgrade.sh` whenever the running version is an
+rc on the v1.0.0 line and the candidate is a newer rc (analogue of the
+v0.14.0 cross-MAJOR pre-bootstrap, extended to RC→RC). Severity:
+**blocker** — every rc2/rc3/rc4 downstream that tries to advance is
+trapped.
+
+### alpha/mid and alpha/latest — FAIL (no report files)
+
+Driver aborted in `cp -aL` preflight; root cause confirmed by
+blocker #2 work — fixture has absolute-target overlay-rootfs symlinks
+(`image/overlay/rootfs/etc/runlevels/default/quackplc-soak` →
+`/etc/init.d/quackplc-soak`); driver's `cp -aL` followed link to host
+path that doesn't exist. Fixed in commit `c5bd106` on branch
+`fix/blocker-2-dogfood-driver-symlinks` (`cp -aL` → `cp -a` + narrow
+stub-only dereference).
+
+Suggested upstream issue (Blocker #2): driver must not blindly
+deref-and-copy fixture symlinks; the dogfood harness can never tell
+which fixtures have valid host targets. Replace with `cp -a` (preserve
+link structure) and only dereference the upgrade-stub link that the
+driver itself needs to invoke. **Resolved on the branch named above
+prior to this re-write.**
+
+### beta/scaffold (v0.13.0 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=1; verify exit=1; conflicts=0`. Migrations chain ran end
+to end (v0.14.0 / v0.14.4 / v0.15.0 / v1.0.0-rc9), TEMPLATE_VERSION
+advanced, but `--verify` reported three manifest discrepancies:
+
+```
+drift:    docs/INDEX.md
+  expected f2acfd632697f898393e950ce7ef58e2490b2382508f4d7dd8479b2320cb7f83
+  actual   b966de0d04983aa23d29384fe801455b64b1d6fb22417e48e43789be88a6e5e3
+drift:    .gitignore
+  expected a3cb15364a614379d170bde87eb8cca8e9afe73b446fa9a3c461f59b52518c88
+  actual   fbed1b6275d5ed736e444e74e64caae81d9d8abfb8c9679baa5cae6730a3d8dd
+missing:  docs/INDEX-PROJECT.md  (in manifest but not in project)
+```
+
+Root cause: post-migration manifest mismatch. The v0.15.0 migration
+appends `docs/INDEX.md`, `docs/INDEX-PROJECT.md`, and (via v0.14.4)
+`.gitignore` to `.template-customizations` so they are preserved
+from the project tree, **but** the synthesised manifest baked at
+v0.14.0 expects upstream hashes for those same paths. The two
+codepaths disagree about whether these files are preserved or
+managed. After migration finishes, `--verify` walks the manifest and
+flags them — the upgrade itself succeeded, the gate then fails.
+
+Suggested upstream issue (Blocker #4): preservation-vs-manifest
+contract violation. Either the migration must rewrite manifest
+entries for newly-preserved paths (preferred), or `--verify` must
+honor `.template-customizations` and exempt preserved paths.
+**Resolved on `fix/blocker-4-preservation-vs-manifest` via
+FW-ADR-0014 (preservation-vs-manifest gate + two-phase exit).**
+
+### beta/mid (v1.0.0-rc3 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=0; verify exit=1; conflicts=7`. 7 conflicts on agent
+contracts + `docs/DECISIONS.md`:
+
+```
+! .claude/agents/code-reviewer.md      upstream +29/-5  local +19/-1
+! .claude/agents/onboarding-auditor.md upstream +40/-1  local +13/-1
+! .claude/agents/process-auditor.md    upstream +43/-1  local +28/-1
+! .claude/agents/project-manager.md    upstream +54/-1  local +16/-1
+! .claude/agents/qa-engineer.md        upstream +24/-91 local +13/-1
+! .claude/agents/sre.md                upstream +34     local +28/-1
+! docs/DECISIONS.md                    upstream +66     local +7
+```
+
+Root cause: real concurrent-edit conflicts. Both the rc3 → rc12
+trajectory on upstream and the customized local fixture have
+touched the same agent contracts and decisions ledger. This is the
+**expected** category — the conflict detector did its job and the
+real downstream maintainer must merge.
+
+Severity: **expected**, not a blocker. AI-TUI was correctly skipped
+because verify failed; the operator path here is "resolve the seven
+conflicts, run `scripts/upgrade.sh --resolve`, re-verify, then the
+AI-TUI check runs." No upstream fix required.
+
+### beta/latest (v1.0.0-rc8 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=0; verify exit=1; conflicts=8`. Same shape as beta/mid
+plus `AGENTS.md` and `CLAUDE.md`:
+
+```
+! .claude/agents/code-reviewer.md      upstream +12/-8  local +19/-1
+! .claude/agents/onboarding-auditor.md upstream +20/-1  local +13/-1
+! .claude/agents/process-auditor.md    upstream +33     local +28/-1
+! .claude/agents/project-manager.md    upstream +37/-1  local +16/-1
+! .claude/agents/qa-engineer.md        upstream +15/-91 local +13/-1
+! .claude/agents/sre.md                upstream +26     local +28/-1
+! AGENTS.md                            upstream +40/-23 local +13/-12
+! CLAUDE.md                            upstream +58/-17 local +2/-2
+```
+
+Note `docs/INDEX-FRAMEWORK.md`, `docs/versioning.md`, `scripts/scaffold.sh`,
+`scripts/version-check.sh` show up under "Accepted local merges
+(recorded in manifest)" — the three-way merge worked on those four.
+The eight above are genuine three-way conflicts.
+
+Root cause: same as beta/mid (real concurrent edits); rc8 → rc12 adds
+two top-level files (`AGENTS.md`, `CLAUDE.md`) to the conflict set
+because the local fixture customizes both. Severity: **expected**;
+no upstream fix.
+
+### gamma/scaffold (v1.0.0-rc7 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=0; verify exit=0; conflicts=0; ai-tui=FAIL`. Only run
+that reached the AI-TUI check. The migrations + verify chain ran
+clean (`OK: 211 files verified clean against manifest`). AI-TUI
+regressed 5/21 cases:
+
+```
+ai-tui-check: 16 pass, 5 fail
+  FAIL cat6.1: python3 -c json.load(open('CUSTOMER_NOTES.md'))     (expected pass, got ask)
+  FAIL cat6.2: python3 heredoc reading CUSTOMER_NOTES.md           (expected pass, got ask)
+  FAIL cat6.3: sh -c cat CUSTOMER_NOTES.md | head                  (expected pass, got ask)
+  FAIL cat7.2: inline SWDT_AGENT_PUSH=software-engineer Bash write (expected pass, got deny)
+  FAIL cat7.3: leading export SWDT_AGENT_PUSH then write           (expected pass, got deny)
+```
+
+All 5 failures correspond to upstream issues **#178** (`customer-notes-guard.py`
+must permit read-only `open()` / `cat` / heredoc Python access) and
+**#182** (`tech-lead-authoring-guard.py` must accept inline / leading-`export`
+`SWDT_AGENT_PUSH` carrier on Bash redirects). The fixes are on `main` but
+were not picked up in the rc12 stabilization branch.
+
+Suggested upstream issue (Blocker #3): rc12 tag was cut from a
+stabilization branch that did not include #178 (SHA `d003d28`) or
+#182 (SHA `7d51cae`). Either re-cut rc12 from a base that includes
+both, or rc12 is dead and the next tag (rc13 / final) must include
+them. **Resolved**: folded into the new rc cut after dogfood-vs-main
+passes (rc12 was mis-stabilized; #178 SHA `d003d28` + #182 SHA
+`7d51cae` are on main, just not in the rc12 tag).
+
+### gamma/mid (v1.0.0-rc8 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=0; verify exit=1; conflicts=2`. Two real conflicts:
+
+```
+! .claude/settings.json  upstream +57/-4   local +10
+! AGENTS.md              upstream +40/-23  local +4/-4
+```
+
+Root cause: expected concurrent-edit conflicts on the two top-level
+hook / harness-adapter files that received the biggest rc8 → rc12
+churn. The customized `.claude/settings.json` carries hook rows from
+both the local agent overlay and the upstream's new hook policy.
+Severity: **expected**; no upstream fix.
+
+### gamma/latest (v1.0.0-rc8 → v1.0.0-rc12) — FAIL
+
+`upgrade exit=0; verify exit=1; conflicts=15`. The widest conflict
+fan-out of any run:
+
+```
+! .claude/agents/onboarding-auditor.md   upstream +20/-1   local +13/-1
+! .claude/agents/project-manager.md      upstream +37/-1   local +16/-1
+! .claude/agents/tech-lead.md            upstream +99/-231 local +4/-4
+! .claude/settings.json                  upstream +57/-4   local +10
+! AGENTS.md                              upstream +40/-23  local +36/-27
+! CLAUDE.md                              upstream +58/-17  local +68/-57
+! docs/templates/adr-template.md         upstream +16/-16  local +13/-13
+! docs/templates/proposal-template.md    upstream +2/-2    local +1/-1
+! docs/templates/task-template.md        upstream +29/-3   local +1/-1
+! scripts/agent-health.sh                upstream +2/-1    local +1/-1
+! scripts/hooks/customer-notes-guard.py  upstream +101/-56 local +81/-70
+! scripts/repair-in-place.sh             upstream +2/-6    local +10/-16
+! scripts/scaffold.sh                    upstream +52/-7   local +31/-37
+! scripts/stepwise-smoke.sh              upstream +2/-1    local +1/-1
+! scripts/version-check.sh               upstream +23/-33  local +46/-30
+```
+
+Root cause: this fixture is the most heavily customized of the three
+gamma states; it has touched nearly every framework-managed file the
+rc8 → rc12 trajectory also moved. Severity: **expected** but
+high-friction — anyone in this state will need a substantial merge
+session. No upstream fix; possibly an upstream **doc** issue to call
+out "heavily-customized RC downstreams should expect 10+ conflicts on
+rc8 → rc12; budget accordingly."
+
+## Conclusion
+
+Is the framework ready for meta-bump? **No.**
+
+Blocking issues, severity-ranked:
+
+1. **Blocker #1 — alpha/scaffold rc2 → rc12 self-overwrite.** Every
+   rc2/rc3/rc4 downstream that tries to advance hits the same syntax
+   error around `upgrade.sh:205` from running an old upgrade script
+   mid-replacement. Fix: new `migrations/v1.0.0-rc13.sh` that
+   pre-bootstraps `scripts/upgrade.sh` on RC→RC moves on the v1.0.0
+   line, analogue of the v0.14.0 cross-MAJOR pre-bootstrap.
+2. **Blocker #2 — driver `cp -aL` crash on absolute-target overlay
+   symlinks.** Both alpha/mid and alpha/latest aborted before
+   reaching the report-writer because the fixtures contain
+   absolute-target overlay-rootfs symlinks pointing at host paths
+   that don't exist in the dogfood sandbox. Fix: dogfood driver
+   replaces `cp -aL` with `cp -a` (preserve link structure) and
+   only dereferences the narrow stub-script path the driver itself
+   needs to invoke.
+3. **Blocker #3 — rc12 missing #178 + #182.** AI-TUI regression
+   confirmed 5/21 fails on gamma/scaffold (the only run that
+   reached the AI-TUI check). Fixes are on `main` but not in the
+   rc12 tag. Re-cut required before the meta pointer moves.
+4. **Blocker #4 — preservation-vs-manifest drift on beta/scaffold.**
+   The v0.14.0 migration's manifest synthesis and the v0.14.4 /
+   v0.15.0 `.template-customizations` extensions disagree about
+   whether `docs/INDEX.md`, `docs/INDEX-PROJECT.md`, and
+   `.gitignore` are managed or preserved. The migration finishes
+   green; `--verify` then reports drift on the same paths. Fix:
+   either rewrite manifest entries for newly-preserved paths during
+   migration, or teach `--verify` to honor `.template-customizations`.
+
+Conflict-shaped fails (beta/mid, beta/latest, gamma/mid, gamma/latest)
+are **expected** outcomes of real concurrent customer + upstream
+edits to agent contracts and harness files. They are not blockers —
+they are exactly the merge-friction the conflict detector exists to
+surface. They do, however, mean the meta-bump cannot be done by a
+fast-forward; whoever does the meta-pointer move must do real
+merging.
+
+Recommended path forward (in order):
+
+1. Land Blockers #1–#4 fixes on main (in progress; see below).
+2. Re-cut a new rc (rc13 or rc14, per release-engineer call) from
+   main once those four blockers are merged.
+3. Re-run dogfood against the new rc with `--target <new-rc>`.
+4. Only after a 9/9 PASS run, move the meta-project submodule
+   pointer.
+5. For real downstream operators on rc3 / rc8 trajectories: budget
+   merge time for 2–15 conflicts depending on customization depth.
+   These are expected; no upstream fix planned.
+
+### Update 2026-05-15 (post-blocker work)
+
+- **Blocker #1** (alpha/scaffold rc2 → rc12 self-overwrite):
+  RESOLVED on `fix/blocker-1-rc-to-rc-prebootstrap` via new
+  `migrations/v1.0.0-rc13.sh` (FW-ADR-0013).
+- **Blocker #2** (driver `cp -aL` crash on absolute-target overlay
+  symlinks): RESOLVED on `fix/blocker-2-dogfood-driver-symlinks` via
+  `cp -a` + narrow stub-only `readlink -f` (commit `c5bd106`).
+- **Blocker #3** (#178 / #182 missing from rc12): RESOLVED as folded
+  into the new rc cut after dogfood-vs-main passes (rc12 was
+  mis-stabilized; #178 SHA `d003d28` + #182 SHA `7d51cae` are on
+  main, just not in the rc12 tag).
+- **Blocker #4** (preservation-vs-manifest manifest drift):
+  RESOLVED on `fix/blocker-4-preservation-vs-manifest` via
+  FW-ADR-0014 (preservation-vs-manifest gate + two-phase exit).
+- **Re-dogfood scheduled**: blockers will merge to main, then
+  dogfood will run against main via `--target main` per customer's
+  dogfood-before-rc sequencing ruling.
+
+Routed-Through: qa-engineer

--- a/docs/review/blocker-1-rc-to-rc-prebootstrap.md
+++ b/docs/review/blocker-1-rc-to-rc-prebootstrap.md
@@ -1,0 +1,144 @@
+# Code review — blocker #1 (rc-to-rc pre-bootstrap, FW-ADR-0013)
+
+- **Date:** 2026-05-15
+- **Branch:** `fix/blocker-1-rc-to-rc-prebootstrap`
+- **Commit under review:** `c7599b5` — `fix(migrations): add v1.0.0-rc13 pre-bootstrap for rc-to-rc cliffs (FW-ADR-0013)`
+- **Reviewer:** `code-reviewer`
+- **Mode:** Per-CL technical review under IEEE 1028 § 5 (escalated from walk-through because the change touches the upgrade-contract — Hard-Rule-#4-adjacent path with elevated customer scrutiny: "the upgrade is always buggy").
+- **Author / dispatchee:** `software-engineer`
+- **Net judgment: APPROVED-WITH-CHANGES (non-blocking; ADR + release-prereq notes).**
+
+## Scope reviewed
+
+1. `migrations/v1.0.0-rc13.sh` — new file, 285 lines, executable, in commit `c7599b5`.
+2. `docs/adr/fw-adr-0013-rc-to-rc-pre-bootstrap.md` — currently untracked (in working-tree / stash; 616 lines, `status: proposed`). Reviewed for design soundness; status flip recommendation in §"ADR status" below.
+3. Routing-trailer compliance on `c7599b5`.
+4. Hard Rule #8 file-boundary check on the commit.
+
+## Evidence collected
+
+- **Structural diff** vs `migrations/v0.14.0.sh` (the stated source-of-truth, lines 42–277): single contiguous block diff shows the intended changes only.
+  - Header rewritten to cite FW-ADR-0013, dogfood-2026-05-15 evidence, and the rc-to-rc cliff.
+  - Pre-bootstrap block byte-identical to v0.14.0.sh's lines 62–277 modulo two strings: audit-row `(migration v0.14.0)` → `(migration v1.0.0-rc13)`; success echo `cross-MAJOR safe` → `rc-to-rc structural-rewrite safe`.
+  - Manifest-synthesis tail (v0.14.0.sh lines 279–346) correctly omitted per ADR § "Migration file" item 2.
+  - Trailing `exit 0` added (v0.14.0.sh doesn't need one because the manifest block runs to EOF). Correct.
+- **`bash -n` syntax check:** PASS.
+- **`shellcheck -s bash`:** clean.
+- **Smoke tests (reviewer-side, scratch dir `/tmp/rc13-smoke`):**
+  1. project == upstream, no baseline → exit 0, no writes, no artefact. PASS.
+  2. local-edit on `scripts/upgrade.sh`, no FORCE → exit 2, schema-v1 block artefact written, project file untouched. PASS.
+  3. local-edit + `SWDT_PREBOOTSTRAP_FORCE=1 SWDT_PREBOOTSTRAP_FORCE_REASON=test-r3` → exit 0, audit row appended with marker `(migration v1.0.0-rc13)` in `Commit SHA` slot, project file atomic-replaced to upstream content, block artefact cleared. PASS.
+  4. baseline-unreachable (no WORKDIR_OLD, files differ) → exit 2, block artefact with `"reason": "baseline-unreachable"`. PASS.
+- **`scripts/lint-routing.sh --files c7599b5 --summary`:** `lint-routing: 0 warnings, 0 errors`.
+- **`git diff main...c7599b5 --stat`:** `migrations/v1.0.0-rc13.sh | 285 +++++++` — single file, no edits to `scripts/upgrade.sh`, `VERSION`, `CHANGELOG.md`, `TEMPLATE_VERSION`, or any other framework-managed surface.
+- **`git log --format=fuller c7599b5`:** body carries `Routed-Through: software-engineer` trailer.
+- **Audit-log column count:** force-path row emits 7 pipe-delimited columns (`Date | Gate | Commit SHA | Tag pushed | Operator | Reason | Sub-gates`), matching `docs/pm/pre-release-gate-overrides.md` schema-v2 header.
+- **rc2 driver compatibility:** confirmed `git show v1.0.0-rc2:scripts/upgrade.sh | sed -n '78,138p'` carries a pre-sync migration runner block that sources `$workdir/new/migrations/<v>.sh` and exports the same envs (`PROJECT_ROOT`, `WORKDIR_NEW`, `WORKDIR_OLD`). The architectural premise of the fix (pre-sync hook reachable from the OLD driver) holds for the rc2 baseline.
+
+## Review priorities — findings
+
+### 1. Correctness vs the ADR
+
+Match is faithful. Trigger predicate (tag iteration past `v1.0.0-rc13`), atomic-rename semantics (`install -m` after `cp`-cmp-skip from the OLD driver), exit codes (`0` / `2` only, `0` for noop and proceed, `2` for refuse), env-var threading (`SWDT_PREBOOTSTRAP_FORCE`, `SWDT_PREBOOTSTRAP_FORCE_REASON`), audit-row shape (with `(migration v1.0.0-rc13)` marker), and refusal artefact (`.template-prebootstrap-blocked.json` schema v1) all match the ADR's "Interface decisions (binding)" and "Migration file" sections.
+
+### 2. Correctness vs `migrations/v0.14.0.sh` prior art
+
+All inter-file diffs are intentional and ADR-justified. No silent drift. The `IFS` save/restore pattern (`oldIFS="$IFS"` … `IFS="$oldIFS"`), the `mktemp` + `mv` atomic block-artefact write, and the sort-on-path for deterministic JSON output are preserved verbatim. The migration is therefore reviewable as "v0.14.0 minus manifest-tail, with marker strings swapped" — the exact review surface the ADR promised.
+
+### 3. FW-ADR-0010 interface conformance
+
+Verified end-to-end via smoke tests:
+- Audit-row columns match schema v2.
+- Force-with-unwritable-log refuses (exit 2) per FW-ADR-0010 invariant — preserved at lines 170–174 of the migration.
+- Block-artefact JSON schema v1 produced verbatim (`version`, `generated`, `reason_summary`, `blocked[].path/project_sha/baseline_sha/upstream_sha/reason`).
+- `reason_summary` resolution (`local-edit` / `baseline-unreachable` / `mixed`) preserves v0.14.0.sh semantics.
+
+### 4. Routing trailer compliance
+
+PASS. `Routed-Through: software-engineer` present; lint-routing reports 0/0.
+
+### 5. Hard Rule #8 boundary
+
+PASS. Single-file commit (`migrations/v1.0.0-rc13.sh`). No edit to `scripts/upgrade.sh`, `VERSION`, `CHANGELOG.md`, or any framework-managed file outside the ADR-blessed scope.
+
+### 6. Hard Rule #3 / overall safety
+
+PASS. Idempotency exercised under both noop and post-force-replace scenarios. Atomic-replace pattern uses `install` (single-step inode swap on the target path under POSIX semantics, with mode preservation), matching the v0.14.0 prior art.
+
+## Blocking findings
+
+**None.** Migration is safe to merge as-is.
+
+## Non-blocking findings (file as separate PRs or roadmap items)
+
+### NB-1 — Release-prerequisite: the migration only activates once a `v1.0.0-rc13` tag exists in the candidate
+
+The migration runner (`scripts/upgrade.sh` lines 875–916, both in the rc12 candidate and in the rc2 prior art) iterates `git -C "$workdir/new" tag -l 'v*' | semver_sort_tags`. Files in `migrations/` are only dispatched when their name matches an iterated tag. So `migrations/v1.0.0-rc13.sh` is dormant code until upstream cuts a `v1.0.0-rc13` tag. SE's smoke tests evidently used a scratch fixture with a synthetic tag; in production this means a downstream upgrading to a SHA / branch on a candidate that does not yet carry the rc13 tag will NOT receive the pre-bootstrap.
+
+- **Why non-blocking:** the ADR § "Trigger predicate" explicitly describes this contract; the file's purpose is to be picked up when its tag is cut, and the release-engineer cuts that tag as part of the rc13 release. This is "as designed."
+- **Action:** `release-engineer` to confirm the rc13 tag cut is the immediate next gate in the v1.0.0 stabilisation sequence (per `docs/pm/dogfood-2026-05-15-results.md`). Until the tag exists, no rc-baseline downstream is protected; meta-pointer must not advance past rc12 until rc13 is tagged AND a real-fixture dogfood run on the rc2→rc13 path passes.
+- **Suggested wording for the rc13 release notes:** "This release introduces `migrations/v1.0.0-rc13.sh`, the per-cliff pre-bootstrap migration that closes blocker-1 from dogfood-2026-05-15. The migration activates on any upgrade path that crosses `v1.0.0-rc13`."
+
+### NB-2 — `docs/pm/pre-release-gate-overrides.md` Gate-row description should cite the rc13 migration site
+
+The audit-log header text at `docs/pm/pre-release-gate-overrides.md` lines 15–20 names only `scripts/upgrade.sh` self-bootstrap and `migrations/v0.14.0.sh` as `Gate: pre-bootstrap` sites. Once rc13 ships, that text becomes stale.
+
+- **Why non-blocking:** the audit log's column schema is unchanged; the documentation note is editorial.
+- **Action:** small `tech-writer` follow-up — append `migrations/v1.0.0-rc13.sh` to the list at lines 15–20 of `docs/pm/pre-release-gate-overrides.md`. Single-line patch, can ride the rc13 release commit.
+
+### NB-3 — Consider naming the de-dup boundary in `migrations/v0.14.0.sh` too
+
+The new migration's header (lines 43–50) explicitly documents the intentional non-extraction of `scripts/lib/prebootstrap.sh` and forbids refactor without superseding FW-ADR-0013. `migrations/v0.14.0.sh` has no such marker, so a future reader looking at v0.14.0 first might attempt the de-dup without seeing the rc13-side warning.
+
+- **Why non-blocking:** the ADR encodes the rule; lazy code-readers are a separate problem and a comment in v0.14.0.sh is editorial.
+- **Action:** optional one-line comment addition to `migrations/v0.14.0.sh` near line 42 pointing to FW-ADR-0013's de-dup-boundary clause. Could be folded into the same rc13 commit, but on a separate framework-touched file it's cleaner as a follow-up PR.
+
+### NB-4 — Future hardening: explicit floor check
+
+The ADR § "Negative / trade-offs accepted" notes "the supported floor (v1.0.0-rc1) is implicit, not enforced in code." Today this is fine — projects below the floor naturally route through `baseline-unreachable`. A future hardening pass could add an explicit `OLD_VERSION` floor refusal for clearer diagnostics, but no current bug exists.
+
+- **Action:** file as a roadmap item, not a PR.
+
+## ADR review (FW-ADR-0013)
+
+The ADR is well-structured: MADR 3.0 shape, full Three-Path Rule with Options M/S/C plus rejected variants, explicit binding sections (trigger predicate, interface decisions, FW-ADR-0010 inheritance), and a verification section that names a concrete success signal. The decision rationale (M + out-of-range refusal hybrid) is defensible:
+
+- Option S's signature-marker idea correctly identified as introducing a load-bearing comment pattern → reject.
+- Option C's shim-based redesign correctly identified as not fixing the rc2-baseline-today problem (the shim has to arrive via the same migration mechanism Option M uses) → reject.
+- Hybrid out-of-range refusal correctly defers to FW-ADR-0010's existing `baseline-unreachable` path → no new operator-facing concept.
+
+The ADR's "Implementation notes for software-engineer" section was faithfully followed by the commit. No drift.
+
+### ADR status
+
+**Recommendation: flip `status: proposed` → `status: accepted` on merge.**
+
+The ADR file is currently in working-tree / stash and not part of the reviewed commit `c7599b5`. Treating the status flip as the merge-time action is correct per project convention: the ADR is accepted by virtue of the implementation passing review and being merged. SE (or whoever stages the ADR for commit) should:
+
+1. Restore the ADR from stash (`git checkout stash@{0} -- docs/adr/fw-adr-0013-rc-to-rc-pre-bootstrap.md`) or otherwise stage the file.
+2. Edit line 4: `status: proposed` → `status: accepted`.
+3. Add an "Accepted: 2026-05-15" line under § "Status" alongside "Proposed: 2026-05-15".
+4. Commit (separately or as a fixup on the same branch) with routing trailer `Routed-Through: architect` (ADRs are architect-owned writes; tech-lead's `agent-push` qualifier is the alternative if architect is not in the loop).
+
+I am NOT modifying the ADR file directly from this review session because (a) it lives in working-tree / stash on a different branch than the one I'm in, and (b) ADR authorship/edits belong to `architect`, not `code-reviewer`. The status flip is mechanical and acknowledgement-grade, not a re-decision, so it does not need a fresh architect dispatch — but the file edit itself should be done by whoever stages the ADR for commit (tech-lead or SE acting under tech-lead's direction, with an appropriate routing trailer).
+
+## Customer-strategic-frame note
+
+The customer's "the big blocker to going to v1.0.0 in my view is that the upgrade is always buggy" framing was kept in view through this review. Findings posture:
+
+- The change is **a strict improvement** to the upgrade flow: it closes a known regression class (mid-run bash syntax error from in-place script overwrite during sync) and inherits a customer-already-accepted refusal posture (FW-ADR-0010) for local-edit protection.
+- The change introduces **no new operator-facing surface** (no new flags, env vars, exit codes, artefact schemas). Operators already trained on FW-ADR-0010's pre-bootstrap on the v0.x→v1.x cliff get the same UX here.
+- The de-duplication catch-22 between this migration and `v0.14.0.sh` is **structurally documented** (ADR § "Implementation notes" + migration header lines 43–50). A future reviewer will not be tempted to "clean up" the duplication and re-open the bug class.
+- The single **non-mechanical risk** is NB-1 (the tag-cut precondition). That is a release-engineering gate, not a code defect, and is naturally handled by the next rc13 tag cut.
+
+I do not see a fresh upgrade-class regression risk in this commit. The remaining quality concern for the v1.0.0 release is whether the rc13-tagged candidate, once cut, passes a full dogfood pass on the rc2 → rc13 path against the alpha/scaffold fixture; that is QA's gate, not this review's.
+
+## Approval
+
+Approved. SE may proceed with:
+
+1. (Optional) staging the FW-ADR-0013 file with `status: accepted` per § "ADR status" above.
+2. Coordinating with `release-engineer` to cut the `v1.0.0-rc13` tag (NB-1 release-prereq).
+3. Coordinating with `qa-engineer` for a full rc2 → rc13 dogfood verification once the tag is cut.
+
+Non-blocking items NB-1 through NB-4 can be filed as follow-ups; none of them gate the merge of `c7599b5`.

--- a/docs/review/blocker-2-dogfood-driver-symlinks.md
+++ b/docs/review/blocker-2-dogfood-driver-symlinks.md
@@ -1,0 +1,81 @@
+# Code review — blocker #2 (dogfood driver symlink crash)
+
+- **Date:** 2026-05-15
+- **Branch:** `fix/blocker-2-dogfood-driver-symlinks`
+- **Commit under review:** `c5bd106` — `fix(release-gate): preserve absolute-target symlinks in dogfood driver`
+- **Reviewer:** `code-reviewer`
+- **Mode:** Per-CL technical review under IEEE 1028 § 5 (escalated from walk-through because the dogfood driver is part of upgrade-flow tooling, and the customer's 2026-05-15 ruling — "the big blocker to going to v1.0.0 in my view is that the upgrade is always buggy" — raises the bar on upgrade-adjacent changes).
+- **Author / dispatchee:** `software-engineer`
+- **Net judgment: APPROVED.**
+
+## Scope reviewed
+
+1. `tests/release-gate/dogfood-downstream.sh` — region lines 204–243 in commit `c5bd106` (net `+35 −13`).
+2. Routing-trailer compliance on `c5bd106`.
+3. Hard Rule #8 / framework-boundary check on the commit.
+4. Behavioural confirmation against the four dogfood-examples stub fixtures and against a fixture mixing both symlink shapes.
+
+## Evidence collected
+
+- **`bash -n`:** PASS.
+- **`shellcheck` (default profile, v0.9.0):** clean, rc=0.
+- **`scripts/lint-routing.sh --files c5bd106 --summary`:** `lint-routing: 0 warnings, 0 errors`.
+- **`git diff main...c5bd106 --stat`:** `tests/release-gate/dogfood-downstream.sh | 48 +++++++++++++++++++++++--------- 1 file changed, 35 insertions(+), 13 deletions(-)` — single file changed; no other framework or product paths touched.
+- **`git log --format=fuller c5bd106`:** body carries `Routed-Through: software-engineer`.
+- **Smoke test #1 — stub fixture (`tests/release-gate/dogfood-examples/alpha/rc8`):** driver exited 0; report `/tmp/cr-smoke-alpha-rc8.txt` shows `upgrade exit: 0`, `verify exit: 0`, `conflict count: 0`, `ai-tui status: skipped-no-hooks`, `PASS`.
+- **Smoke test #2 — mixed fixture (`/tmp/cr-mixed-fixture`):** contains BOTH a stub-style relative `scripts/upgrade.sh` symlink (`-> ../_shared/upgrade.sh`) AND an absolute-target rootfs symlink (`image/overlay/rootfs/etc/runlevels/default/sshd -> /etc/init.d/sshd`) within the same tree. Driver exited 0; report `/tmp/cr-mixed.txt` shows `upgrade exit: 0`, `verify exit: 0`, `conflict count: 0`, `PASS`. Confirms the new code path handles a fixture that exercises both symlink shapes simultaneously (priority 2).
+- **Stub-fixture symlink shape survey:** all four shipped stubs (`alpha/rc8`, `beta/rc10`, `gamma/rc11`, `delta/rc11`) carry `scripts/upgrade.sh -> ../../../_shared/upgrade.sh` (relative). `readlink -f` against the original `$FIXTURE` path resolves correctly to `tests/release-gate/dogfood-examples/_shared/upgrade.sh` for each — confirms priority 1 (SE's deliberate choice to resolve against the original).
+- **Dangling-stub behaviour:** verified out of band that if `$FIXTURE/scripts/upgrade.sh` points to a nonexistent target, `readlink -f` still returns a string, but `[ -f "$STUB_TARGET" ]` is false, so the block leaves the (broken) symlink in place. The driver then trips when upgrade.sh tries to execute — an acceptable downstream failure path, not a regression caused by the fix.
+- **End-to-end symlink-dereferencing surface in the driver:** scanned for `cp `, `readlink`, `-L`, `find`, `rsync`. Only two `cp` invocations are content-bearing: the bulk `cp -a` at line 220 and the narrow targeted `cp -a "$STUB_TARGET" ...` at line 241. The only other `cp` (line 264) is the git-init log preservation, which copies a regular file under the driver's own scratch dir — no symlink exposure. The later `git add -A` on the scratch tree stores symlinks-as-symlinks (git mode 120000), which is the correct preservation behaviour. Priority 3: no other dereferencing paths in the driver.
+
+## Review priorities — findings
+
+### 1. Correctness of `readlink -f` against `$FIXTURE`
+
+PASS. The `STUB_TARGET="$(readlink -f "$FIXTURE/scripts/upgrade.sh" 2>/dev/null || true)"` call deliberately uses the ORIGINAL `$FIXTURE` path, not `$SCRATCH_TREE`. For the dogfood-examples stub case the symlink target is relative (`../../../_shared/upgrade.sh`), so resolving against `$FIXTURE` lands at the real shared file, while resolving against `$SCRATCH_TREE` (`$SCRATCH/tree/scripts/...`) would walk out of the scratch root into a nonexistent path. SE's choice is correct and necessary; the comment block at lines 231–233 captures the reasoning. Confirmed empirically: all four shipped stubs resolve cleanly via the chosen path.
+
+### 2. Mixed-fixture edge case (stub-style symlink AND absolute-target rootfs symlinks in the same tree)
+
+PASS. The constructed `/tmp/cr-mixed-fixture` exercises both shapes simultaneously and the driver completes cleanly with a `PASS` report. Bulk `cp -a` preserves the absolute-target rootfs symlink verbatim (no dereference attempt → no crash), and the targeted post-copy block replaces the relative `scripts/upgrade.sh` symlink with the resolved file. The two code paths are independent and do not interact.
+
+### 3. Other symlink-touching code paths in the driver
+
+PASS. No other `cp -L`, `find -L`, or implicit-dereference paths in the file. `git init` / `git add -A` on the scratch tree records symlinks as symlinks; this is the desired behaviour because the upgrade phase later runs in that working tree, and overlay-rootfs symlinks should remain symlinks throughout. No regression surface.
+
+### 4. No regression on the four dogfood-examples stub fixtures
+
+PASS (smoke test #1 + symlink-shape survey). The relative `../../../_shared/upgrade.sh` target is identical across all four stubs, and the `readlink -f`-against-`$FIXTURE` resolution is shape-agnostic to the stub's directory depth as long as the relative path resolves. The behaviour is equivalent across the four.
+
+### 5. Hard Rule #8 file-boundary check
+
+PASS. `git diff main...c5bd106 --stat` shows exactly one file changed: `tests/release-gate/dogfood-downstream.sh`. No edits to `VERSION`, `CHANGELOG.md`, `TEMPLATE_VERSION`, `scripts/upgrade.sh`, ADRs, release notes, or any other framework-managed surface. The fix is scoped to the dogfood driver only, as the task brief requires.
+
+### 6. `Routed-Through` trailer compliance
+
+PASS. `Routed-Through: software-engineer` present on `c5bd106`; `scripts/lint-routing.sh --files c5bd106 --summary` reports `0 warnings, 0 errors`.
+
+### 7. Hard Rule #3 / general correctness, safety, style
+
+PASS. Code is straightforward shell; `set -eu` already in force at line 74; the `2>/dev/null || true` guard on `readlink -f` is appropriate (prevents an unbound-target failure mode from killing the driver under `-e`); the `[ -n "$STUB_TARGET" ] && [ -f "$STUB_TARGET" ]` double-guard is correct; the `rm -f` before `cp -a` of the resolved target is necessary because `cp -a SRC DST` where DST is an existing symlink would write through the symlink rather than replace it. Style matches the surrounding file: comment block precedes the logic, `if [ -L ...` shape parallels the existing fixture-validation guards earlier in the file. No findings.
+
+## Non-blocking observations
+
+These are recorded for visibility but do NOT block approval.
+
+- **O-1 (cosmetic, stale docstring).** The script header at line 64 still says "The fixture is rsync-copied to a mktemp scratch dir". The driver has used `cp` (not `rsync`) for at least the duration of this branch's parent commits; this fix doesn't change that, but it does invalidate the wording slightly because the copy strategy now has two phases (bulk `cp -a` + targeted dereference). Suggest updating to "The fixture is copied to a mktemp scratch dir (symlinks preserved; stub `scripts/upgrade.sh` symlinks are resolved into real files)" in a future docs-only pass. Not in scope for this fix.
+- **O-2 (defensive depth, optional).** The targeted dereference matches exactly one path (`scripts/upgrade.sh`). If a future stub-fixture pattern ever symlinks another required-by-driver file (e.g., a hooks sidecar) into `_shared/`, the same crash will recur for that file. A more general approach — walk the scratch tree, detect any symlink whose `readlink -f` against `$FIXTURE` resolves to a real file outside `$FIXTURE` AND inside the framework repo, and dereference only those — would be future-proof. Premature today; current fixture set has only the one stub-symlinked path. File as a follow-up issue if the stub vocabulary grows.
+- **O-3 (test asset).** No automated test fixture exists in the repo for "absolute-target rootfs symlink in fixture preflight". The reviewer's mixed fixture (`/tmp/cr-mixed-fixture`) lives outside the repo and won't catch regressions. Consider asking `qa-engineer` to add a small captured-style fixture under `tests/release-gate/dogfood-examples/` (or a sibling regression-fixtures dir) that contains an absolute-target symlink, so CI catches a future re-introduction of `cp -aL`. Out of scope for this blocker fix.
+
+## Conformance statement
+
+The change at `c5bd106` conforms to:
+- Hard Rule #3 (review present before merge — this document).
+- Hard Rule #8 (specialist authorship — `Routed-Through: software-engineer` trailer verified).
+- The change's stated objective (preserve absolute-target symlinks during bulk copy; preserve existing stub-fixture behaviour).
+- The project style for shell scripts under `tests/release-gate/` (POSIX `sh`, `set -eu`, comment-led logic blocks, defensive `2>/dev/null || true` on readlink-class calls).
+
+Customer's 2026-05-15 quality-bar ruling is honoured: the driver itself no longer hides upgrade-flow defects behind a preflight crash, so subsequent dogfood passes can actually exercise the upgrade contract on the alpha/mid and alpha/latest fixtures that this fix unblocks.
+
+## Recommendation
+
+APPROVE for merge. No blocking findings. The three non-blocking observations (O-1, O-2, O-3) are file-as-follow-up-issue candidates, not amendments to this commit.

--- a/docs/review/blocker-4-preservation-vs-manifest.md
+++ b/docs/review/blocker-4-preservation-vs-manifest.md
@@ -1,0 +1,230 @@
+# Code-reviewer report — Blocker #4 (FW-ADR-0014: preservation vs manifest)
+
+**Branch:** `fix/blocker-4-preservation-vs-manifest`
+**Commits:** `ec96465` (ADR), `ae9e9d8` (gate + two-phase tail), `b5768cb` (migrations)
+**Reviewer:** code-reviewer (IEEE 1028 § 5 technical review against ADR)
+**Date:** 2026-05-15
+**Net judgment:** **APPROVED-WITH-CHANGES** — 1 blocking, 5 non-blocking
+
+---
+
+## Scope verified
+
+- `git diff main...b5768cb --stat`: 5 files touched (ADR, `scripts/upgrade.sh`,
+  `scripts/lib/manifest.sh`, `migrations/v0.15.0.sh`, `migrations/v1.0.0-rc14.sh`).
+  No framework-managed boundary files (`VERSION`, `CHANGELOG.md`,
+  `scripts/scaffold.sh`, `TEMPLATE_VERSION`) touched. **Hard Rule #8 / #10
+  boundary: clean.**
+- `scripts/lint-routing.sh --files "ec96465 ae9e9d8 b5768cb" --summary`:
+  `0 warnings, 0 errors`. Trailers (`Routed-Through: architect` for the
+  ADR commit; `Routed-Through: software-engineer` for the two impl
+  commits) match the lint rule table.
+- ADR text against the eight `§ Implementation notes for software-engineer`
+  change points: all eight addressed (see correctness walk below).
+
+---
+
+## Correctness walk against FW-ADR-0014 implementation notes
+
+| # | ADR change point | Implementation site | Status |
+|---|------------------|---------------------|--------|
+| 1 | `should_preserve()` returns `preserve`/`drop-inert`/`refuse-conflict` | `scripts/upgrade.sh:1004-1054` | OK |
+| 2 | `manifest_declares_fresh_write()` helper | `scripts/lib/manifest.sh:79-138` | OK, but see D1 below |
+| 3 | `write_preservation_block_artefact()` writes `.template-preservation-blocked.json` | `scripts/upgrade.sh:1070-1106` | OK; deterministic sort, mktemp+mv atomic |
+| 4 | `SWDT_PRESERVATION_FORCE=1` + audit row with `Gate=preservation` | `scripts/upgrade.sh:1417-1463` | OK; row format matches FW-ADR-0010 prior art at `:627` exactly |
+| 5 | Two-phase tail (phase A literal + phase B verify) | `scripts/upgrade.sh:1728-1771` | OK, but see B-1 and D2 below |
+| 6 | `migrations/v0.15.0.sh` divergence pre-check (WARN-only) | `migrations/v0.15.0.sh:35-62` | OK; no refuse, no edit |
+| 7 | `migrations/v1.0.0-rc14.sh` opt-in pruning, atomic, idempotent | `migrations/v1.0.0-rc14.sh` (full file) | OK |
+| 8 | Repo-wide `Done\.` audit | commit body `b5768cb` documents zero remaining consumers | OK |
+
+---
+
+## Blocking findings
+
+### B-1 — FORCE path leaves a stray empty element in `preserved[]` when the array becomes empty
+
+`scripts/upgrade.sh:1451`:
+```
+preserved=("${new_preserved[@]:-}")
+```
+
+Bash idiom footgun: when `new_preserved` is empty, `"${new_preserved[@]:-}"`
+expands to a single empty string (NOT zero arguments), so `preserved`
+becomes a one-element array containing `""`. Downstream the empty
+element is consumed by:
+
+- `:1722  if [[ ${#preserved[@]} -gt 0 ]]; then` — fires for the empty array, printing the section header.
+- `:1724  for f in "${preserved[@]}"; do echo "  = $f"; done` — prints `  = ` (visible blank entry, no path).
+- `:1784  for pf in "${preserved[@]:-}"; do` — iterates once with empty `pf`; harmless because the `case` arms don't match.
+
+This is the FORCE-on-all-refusals edge case: every refused path is force-promoted to `upgraded`, and if `preserved` started with only the refused paths, the final `preserved` is the spurious one-element-empty array.
+
+**Required change:** rebuild without the `:-}` fallback, e.g.:
+```
+if [[ ${#new_preserved[@]} -gt 0 ]]; then
+  preserved=("${new_preserved[@]}")
+else
+  preserved=()
+fi
+```
+Or use `mapfile`-style rebuild. The same pattern at `:1447` is benign (it's a read-only iteration where the guard `[[ "$q" == "$f_p" ]]` filters the empty), but the assignment at `:1451` is the contaminating write.
+
+Customer's standing frame is "upgrade is always buggy"; this is exactly the class of bash-array footgun the frame targets. **Block** so it lands before any operator hits a FORCE run on a customer-visible artefact.
+
+---
+
+## Non-blocking findings
+
+### NB-1 — D1 (`manifest_declares_fresh_write` conservatism): bounds are tight, but failure-mode worth a release-notes line
+
+The SE-documented deviation (D1) is sound. The function returns
+fresh-write=TRUE when `paths_repo_old` is empty or unreadable. The
+spurious-refusal concern is **bounded by the AND-gate in
+`should_preserve()`**: a path is only refused when divergence is ALSO
+asserted, and divergence under a missing baseline is computed against
+`paths_repo_new` (so a path matching upstream-new is `drop-inert`,
+not refuse).
+
+Residual failure mode: a project carries a genuine customisation on
+a path that upstream-old shipped identically to upstream-new, AND the
+baseline tree is unreachable. Without baseline, `should_preserve` flips
+divergence to "diverged" (project vs new differs) AND
+`manifest_declares_fresh_write` returns true (no baseline) → refuse.
+
+Workaround: `SWDT_PRESERVATION_FORCE=1` with explicit reason. But the
+operator may not realise the refusal was driven by an unreachable
+baseline, not by a real fresh-write declaration. **Recommend** a single
+release-notes line documenting this, and consider adding a `(baseline
+unreachable)` annotation to the `refuse-conflict` ERROR text at
+`scripts/upgrade.sh:1471`.
+
+### NB-2 — D2 (verify rc=2 → exit 1): unreachable today but documentation drift risk
+
+The SE-documented deviation (D2) is sound under the current control
+flow: `manifest_verify` returns rc=2 only when the manifest file is
+missing or unreadable, and at this point in the script the upgrade
+has already written `TEMPLATE_MANIFEST.lock`. So `verify_rc=2`
+genuinely cannot fire here.
+
+**Observation:** the inline comment at `:1769` ("rc 2 means 'manifest
+missing/unreadable' — surface as drift") is correct as documentation,
+but it doesn't say *why* this is unreachable in this code path. If a
+future refactor moves manifest writing or pulls the verify call
+earlier, the rc=2 path becomes reachable and exit 1 silently swallows
+a real defect class.
+
+**Recommend** strengthening the comment to: `# rc 2 = manifest absent
+(unreachable here because the upgrade just wrote it; defensive)`. Pure
+documentation; not blocking.
+
+### NB-3 — `should_preserve` does not stat divergence per-file when baseline available but path absent in baseline
+
+`scripts/upgrade.sh:1024-1030`: when `b_avail=1` but `$wold/$path`
+doesn't exist (path was added by upstream after the baseline), the
+function falls through to the baseline-unreachable branch (`else`
+arm). That's correct behaviour but the comment at `:1031` ("Baseline
+unreachable for this path") conflates two semantically distinct
+cases: (a) baseline tree entirely missing, (b) baseline tree present
+but this specific path was not in it. The classification result is
+the same, but the comment is misleading for future readers.
+
+**Recommend** comment refinement: "Baseline unreachable OR this
+path is new since baseline."
+
+### NB-4 — `v0.15.0.sh` divergence pre-check uses `echo | sed` instead of bash trim
+
+`migrations/v0.15.0.sh:46-48`:
+```
+line="${line%%#*}"
+line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+```
+
+`echo` here is fine because `line` is always a single-line preserve-list
+entry, but `printf '%s' "$line"` is the safer idiom (some `echo`
+implementations interpret backslash escapes). The rc14 prune migration
+at `:62` already uses the safer `printf '%s' "$trimmed"` form. **Recommend**
+aligning v0.15.0.sh on the same idiom. Cosmetic only.
+
+### NB-5 — ADR's "Verification" section references a dogfood evidence file not present on the branch
+
+`docs/adr/fw-adr-0014-preservation-vs-manifest.md` cites
+`docs/pm/dogfood-2026-05-15-results.md` in the Verification section
+and in Links. That file is not on `fix/blocker-4-preservation-vs-manifest`,
+not on `main`, and not committed on any visible branch. Likely held
+separately as the SE's local dogfood evidence.
+
+**Observation only.** The ADR is auditable on its own merits, and the
+SE's 7/7 PASS smoke summary in the customer prompt serves the same
+"verification ran" purpose. **Recommend** committing the dogfood
+evidence (or removing the citation) before the rc14 tag, so the
+audit trail is reconstructible from git alone.
+
+---
+
+## Conformance statement (IEEE 730 § 5.4)
+
+- **5.4.2 Plans for conformance** — implementation honours all three
+  ADRs the change inherits from (FW-ADR-0002 customisation-wins on
+  divergence; FW-ADR-0010 force env-var + audit-row + exit-2 shape;
+  FW-ADR-0004 migration immutability via rc14 file). Conforming.
+- **5.4.3 Product for conformance** — eight ADR change points map
+  to eight implementation sites; all addressed. Two documented
+  deviations (D1, D2) reviewed and bounded above. Conforming with
+  one defect (B-1) requiring rework.
+- **5.4.4 Product acceptability** — SE-reported 7/7 PASS dogfood
+  smoke against the four customer-visible scenarios (inert healing,
+  refuse-on-uncertain, FORCE override, two-phase tail clean/drift
+  paths) and the rc14 migration (dry-run + apply paths). Conforming
+  pending B-1.
+- **5.4.5 Life-cycle support** — runbook-style ERROR text at
+  `scripts/upgrade.sh:1469-1486` gives operators the diff-and-decide
+  path plus the FORCE bypass syntax. Conforming.
+
+---
+
+## Net judgment
+
+**APPROVED-WITH-CHANGES.**
+
+- **1 blocker** (B-1, FORCE-path `preserved[]` rebuild).
+- **5 non-blocking** observations (NB-1 release-notes; NB-2 comment
+  hardening; NB-3 comment refinement; NB-4 echo→printf idiom alignment;
+  NB-5 dogfood-evidence file commit).
+
+Once B-1 lands as an SE follow-up commit, the ADR's status flip
+`proposed` → `accepted` is unblocked. The status-flip commit itself
+is `architect`-owned and trailered, per the same pattern used for
+blocker-1 / FW-ADR-0013.
+
+---
+
+## Re-verify pass 2026-05-15
+
+**Fixup commit:** `746e6ef` — "fix(upgrade): empty-array rebuild on FORCE path (CR blocker B-1)"
+**Reviewer:** code-reviewer (IEEE 1028 § 5 technical review, re-verify pass)
+**Scope:** B-1 resolution + no-drift check.
+
+### B-1 — RESOLVED
+
+- `grep -n '\[@\]:-' scripts/upgrade.sh scripts/lib/manifest.sh`: 0 live-code hits. Two remaining matches are comments at `:1446` and `:1615` that cite the unsafe idiom and the CR blocker for next-reader provenance. `scripts/lib/manifest.sh`: clean.
+- SE audited the file and converted **five** sites, not just the originally-flagged one (`:1444-1463`, `:1612-1626`, `:1660-1666`, `:1804-1818`, plus the read-only iteration the original B-1 finding called out as benign at `:1453`). The five replacements all use Option A from the CR brief: `if [ "${#arr[@]}" -gt 0 ]; then ... fi` length guard with an explicit `else preserved=()` reset on the assignment site. Comments at each site cite "CR blocker B-1" for traceability.
+- `upgraded[]` confirmed safe (append-only via `+=`, no rebuild).
+- Dry-run smoke against a fresh scaffold: "Preserved per .template-customizations (8):" section prints 8 clean `=`-prefixed entries; no blank lines, no phantom empty rows. (FORCE-path with `preservation_refused_paths` non-empty is exercised by the dogfood-downstream harness; the code-path inspection plus the dry-run confirm the fix shape.)
+
+### Hard Rule #8 / #10 boundary — clean
+
+- `git show 746e6ef --stat`: `scripts/upgrade.sh` only (50 +, 25 -). No `scripts/lib/manifest.sh` change (SE audit found no matching occurrences there). No ADR mutation. No `VERSION` / `CHANGELOG.md` / `TEMPLATE_VERSION` drift. No `scripts/scaffold.sh` touch.
+
+### Routing trailer — clean
+
+- `scripts/lint-routing.sh --files 746e6ef --summary`: `0 warnings, 0 errors`. Commit body has `Routed-Through: software-engineer` per the lint table.
+
+### Non-blocking findings from the original review
+
+- NB-1 through NB-5 unchanged. None addressed by this fixup; none required for B-1 resolution. Should be filed as deferred-decision issues per the project's standing blocking/non-blocking split pattern; not in scope for this commit.
+
+### Net judgment (revised)
+
+**APPROVED.** No longer "with changes". B-1 resolved cleanly; no new blockers surfaced by the fixup commit; no boundary violations.
+
+**ADR-0014 status flip is UNBLOCKED.** The architect-owned edit (`status: proposed` → `status: accepted` + `Accepted: 2026-05-15` line on `docs/adr/fw-adr-0014-preservation-vs-manifest.md`) routes back through tech-lead, who dispatches the trailered commit (`Routed-Through: architect`) — same pattern as blocker-1 / FW-ADR-0013.

--- a/migrations/v0.14.0.sh
+++ b/migrations/v0.14.0.sh
@@ -95,11 +95,12 @@ any_block=0
 saw_local_edit=0
 saw_baseline_unreachable=0
 
-# shellcheck disable=SC2034
-oldIFS="$IFS"
-IFS='
-'
-for rel in $prebootstrap_paths; do
+# Iterate the newline-delimited path list via `while IFS= read -r` (the
+# per-command IFS prefix is local to read and does NOT modify the global
+# IFS — Semgrep ifs-tampering rule ignores it). Process substitution
+# (`< <(...)`) keeps the loop in the parent shell so variable mutations
+# propagate. Same idiom is used throughout scripts/* in this repo.
+while IFS= read -r rel; do
     [ -z "$rel" ] && continue
     proj_file="$PROJECT_ROOT/$rel"
     new_file="$WORKDIR_NEW/$rel"
@@ -145,8 +146,7 @@ retrofit:baseline-unreachable:$rel:$proj_sha::$new_sha"
             saw_baseline_unreachable=1
         fi
     fi
-done
-IFS="$oldIFS"
+done < <(printf '%s\n' "$prebootstrap_paths")
 
 prebootstrap_block_artefact="$PROJECT_ROOT/.template-prebootstrap-blocked.json"
 
@@ -169,9 +169,7 @@ if [ "$any_block" -eq 1 ]; then
         date_iso=$(date -u +%Y-%m-%d)
         operator=$(git config user.email 2>/dev/null || echo "${USER:-unknown}@$(hostname 2>/dev/null || echo unknown)")
         force_reason="${SWDT_PREBOOTSTRAP_FORCE_REASON:-unspecified}"
-        IFS='
-'
-        for entry in $blocked_list; do
+        while IFS= read -r entry; do
             [ -z "$entry" ] && continue
             # entry: action:reason:path:project_sha:baseline_sha:upstream_sha
             action=$(printf '%s' "$entry" | cut -d: -f1)
@@ -183,8 +181,7 @@ if [ "$any_block" -eq 1 ]; then
             # Promote to proceed.
             proceed_list="$proceed_list
 $path"
-        done
-        IFS="$oldIFS"
+        done < <(printf '%s\n' "$blocked_list")
         printf 'WARN: pre-bootstrap audit row(s) appended to %s\n' "$override_log" >&2
         rm -f "$prebootstrap_block_artefact"
     else
@@ -199,9 +196,7 @@ $path"
             # Sort entries by path for determinism.
             sorted_entries=$(printf '%s' "$blocked_list" | awk -F: 'NF { print $3 "|" $0 }' | LC_ALL=C sort | sed 's/^[^|]*|//')
             first=1
-            IFS='
-'
-            for entry in $sorted_entries; do
+            while IFS= read -r entry; do
                 [ -z "$entry" ] && continue
                 action=$(printf '%s' "$entry" | cut -d: -f1)
                 reason=$(printf '%s' "$entry" | cut -d: -f2)
@@ -220,23 +215,19 @@ $path"
                 printf '      "reason": "%s"\n' "$reason_field"
                 printf '    }'
                 first=0
-            done
-            IFS="$oldIFS"
+            done < <(printf '%s\n' "$sorted_entries")
             printf '\n  ]\n}\n'
         } > "$tmp_artefact"
         mv "$tmp_artefact" "$prebootstrap_block_artefact"
 
         printf '\nERROR: pre-bootstrap refused — bootstrap-critical files carry local edits or an unreachable baseline.\n' >&2
-        IFS='
-'
-        for entry in $blocked_list; do
+        while IFS= read -r entry; do
             [ -z "$entry" ] && continue
             action=$(printf '%s' "$entry" | cut -d: -f1)
             reason=$(printf '%s' "$entry" | cut -d: -f2)
             path=$(printf '%s' "$entry" | cut -d: -f3)
             printf '  %s: reason=%s\n' "$path" "$reason" >&2
-        done
-        IFS="$oldIFS"
+        done < <(printf '%s\n' "$blocked_list")
         printf '\nBlock artefact: %s\n' "$prebootstrap_block_artefact" >&2
         printf 'Recovery:\n' >&2
         printf '  - Review the listed paths; declare deliberate local edits in .template-customizations.\n' >&2
@@ -250,9 +241,7 @@ $path"
 fi
 
 # Execute the proceed list (atomic install).
-IFS='
-'
-for rel in $proceed_list; do
+while IFS= read -r rel; do
     [ -z "$rel" ] && continue
     new_file="$WORKDIR_NEW/$rel"
     proj_file="$PROJECT_ROOT/$rel"
@@ -270,8 +259,7 @@ for rel in $proceed_list; do
     if [ "$rel" = "scripts/upgrade.sh" ]; then
         echo "  pre-bootstrapped scripts/upgrade.sh to candidate (cross-MAJOR safe)"
     fi
-done
-IFS="$oldIFS"
+done < <(printf '%s\n' "$proceed_list")
 
 # Clear any stale block artefact from a prior refused run.
 rm -f "$prebootstrap_block_artefact"

--- a/migrations/v0.15.0.sh
+++ b/migrations/v0.15.0.sh
@@ -32,6 +32,36 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "$WORKDIR_NEW/scripts/lib/manifest.sh"
 
+# --- FW-ADR-0014: divergence pre-check (advisory) -----------------------------
+# Walk .template-customizations and warn (do not refuse, do not edit) for
+# entries that have no project-vs-baseline divergence. Pollution surfaces
+# during a regular migration run so the operator can opt into the
+# rc14 pruning migration. Skipped silently when WORKDIR_OLD is unset
+# (baseline unreachable — cannot compute divergence).
+preserve_pre_check_cust="$PROJECT_ROOT/.template-customizations"
+if [[ -f "$preserve_pre_check_cust" && -n "${WORKDIR_OLD:-}" && -d "${WORKDIR_OLD:-}" ]]; then
+  preserve_pre_check_inert=()
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [[ -z "$line" ]] && continue
+    proj_pre="$PROJECT_ROOT/$line"
+    old_pre="$WORKDIR_OLD/$line"
+    [[ -f "$proj_pre" && -f "$old_pre" ]] || continue
+    if cmp -s "$old_pre" "$proj_pre"; then
+      preserve_pre_check_inert+=("$line")
+    fi
+  done < "$preserve_pre_check_cust"
+  if [[ ${#preserve_pre_check_inert[@]} -gt 0 ]]; then
+    echo "  WARN (FW-ADR-0014): ${#preserve_pre_check_inert[@]} preserve-list entry/entries match baseline byte-for-byte (no divergence):" >&2
+    for p in "${preserve_pre_check_inert[@]}"; do
+      echo "    - $p" >&2
+    done
+    echo "    These are silently dropped from preservation at sync time. Opt into" >&2
+    echo "    migrations/v1.0.0-rc14.sh (dry-run by default) to rewrite the file." >&2
+  fi
+fi
+
 # --- (#67) Rename framework ADRs that exist as `NNNN-*.md` to `fw-adr-NNNN-*.md`
 # Only do this if the file content matches the upstream framework ADR
 # (after stripping the renamed cross-references — i.e., the post-sync

--- a/migrations/v1.0.0-rc13.sh
+++ b/migrations/v1.0.0-rc13.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+#
+# migrations/v1.0.0-rc13.sh — pre-bootstrap for rc-to-rc structural-rewrite
+# cliffs in the v1.x lineage (per FW-ADR-0013).
+#
+# Failure class this migration closes (dogfood-2026-05-15, blocker #1):
+#   A downstream stamped at v1.0.0-rc2 upgrading to v1.0.0-rc12 crashes mid-run
+#   with `./scripts/upgrade.sh: line 205: syntax error near unexpected token
+#   ';;'`. The rc2-era upgrade.sh is ~270 lines, has no `case` statement, and
+#   no SWDT_BOOTSTRAPPED self-bootstrap branch (added in v0.15.0 /
+#   FW-ADR-0010). When the rc2 driver's sync loop overwrites scripts/upgrade.sh
+#   on disk with the rc12 candidate (which has both `case` and `;;` tokens
+#   around line 205), bash continues parsing from its current byte offset and
+#   explodes on the structurally-incompatible token.
+#
+#   v0.14.0.sh closed the equivalent v0.x → v1.x cliff with the same trick.
+#   But v0.14.0.sh only fires when OLD_VERSION < v0.14.0; on rc2 → rc12 the
+#   project is already past v0.14.0, so no pre-bootstrap fires at all. This
+#   migration covers the rc-to-rc gap below v1.0.0-rc13.
+#
+# What this migration does:
+#   Atomic-replaces scripts/upgrade.sh + scripts/lib/*.sh from $WORKDIR_NEW
+#   into $PROJECT_ROOT BEFORE the OLD driver's sync loop runs. The migration
+#   runner (scripts/upgrade.sh lines ~864-942 in the candidate) sources this
+#   file before any sync, so the OLD driver's later `cp` over upgrade.sh sees
+#   cmp-equal between $new_path and $proj_path and skips the cp.
+#
+#   The atomic mv-rename leaves the parent bash's open fd on the original
+#   (now-unlinked) inode, so the running v1.x-rcN script reads its original
+#   content to EOF without seeing the replacement.
+#
+# FW-ADR-0010 inheritance (binding):
+#   3-SHA decision matrix, refuse-on-uncertain posture,
+#   SWDT_PREBOOTSTRAP_FORCE=1 self-service override,
+#   SWDT_PREBOOTSTRAP_FORCE_REASON audit annotation,
+#   .template-prebootstrap-blocked.json schema v1 block artefact,
+#   docs/pm/pre-release-gate-overrides.md audit-log row
+#     (Gate=pre-bootstrap, Commit SHA slot = "(migration v1.0.0-rc13)"),
+#   retrofit-playbook routing on baseline-unreachable rows.
+#
+#   Behavioural divergence from FW-ADR-0010 requires a new ADR.
+#
+# Intentional de-duplication boundary (FW-ADR-0013):
+#   The pre-bootstrap logic below is a near-verbatim copy of
+#   migrations/v0.14.0.sh lines 42-277. A shared helper at
+#   scripts/lib/prebootstrap.sh is NOT extracted because at the moment any
+#   pre-bootstrap migration runs, the file in question is exactly what is
+#   being installed — neither migration can rely on a shared file being
+#   present at the moment it must run. The duplication is cheaper than the
+#   abstraction. Do not refactor without superseding FW-ADR-0013.
+#
+# Idempotency:
+#   Re-running on a project whose bootstrap-critical files already match the
+#   candidate produces zero writes and exit 0 (the 3-SHA matrix's
+#   `project == upstream` branch). Verified by QA.
+#
+# Cross-migration interaction:
+#   On a v0.13.x → rc13 path, v0.14.0.sh runs first and pre-bootstraps. By
+#   the time this migration runs, bootstrap-critical files in the project
+#   already match $WORKDIR_NEW; the 3-SHA matrix returns `noop` for every
+#   path and the migration exits 0 with no writes.
+
+set -euo pipefail
+
+: "${PROJECT_ROOT:?PROJECT_ROOT is required}"
+: "${WORKDIR_NEW:?WORKDIR_NEW is required}"
+
+prebootstrap_sha() {
+    if [ -f "$1" ]; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        printf ''
+    fi
+}
+
+# Build the bootstrap-critical path list: scripts/upgrade.sh + every
+# scripts/lib/*.sh the candidate ships.
+prebootstrap_paths=""
+if [ -f "$WORKDIR_NEW/scripts/upgrade.sh" ]; then
+    prebootstrap_paths="scripts/upgrade.sh"
+fi
+if [ -d "$WORKDIR_NEW/scripts/lib" ]; then
+    for lib in "$WORKDIR_NEW/scripts/lib"/*.sh; do
+        [ -f "$lib" ] || continue
+        prebootstrap_paths="$prebootstrap_paths
+scripts/lib/$(basename "$lib")"
+    done
+fi
+
+baseline_dir=""
+if [ -n "${WORKDIR_OLD:-}" ] && [ -d "${WORKDIR_OLD:-}" ]; then
+    baseline_dir="$WORKDIR_OLD"
+fi
+
+# Build two parallel newline-delimited lists: blocked (refused) paths
+# (action:reason:path:project_sha:baseline_sha:upstream_sha) and proceed
+# paths (path).
+blocked_list=""
+proceed_list=""
+any_block=0
+saw_local_edit=0
+saw_baseline_unreachable=0
+
+# shellcheck disable=SC2034
+oldIFS="$IFS"
+IFS='
+'
+for rel in $prebootstrap_paths; do
+    [ -z "$rel" ] && continue
+    proj_file="$PROJECT_ROOT/$rel"
+    new_file="$WORKDIR_NEW/$rel"
+    proj_sha=$(prebootstrap_sha "$proj_file")
+    new_sha=$(prebootstrap_sha "$new_file")
+    base_sha=""
+    if [ -n "$baseline_dir" ]; then
+        base_sha=$(prebootstrap_sha "$baseline_dir/$rel")
+    fi
+
+    # Missing locally: treat as add-from-upstream (proceed).
+    if [ -z "$proj_sha" ]; then
+        proceed_list="$proceed_list
+$rel"
+        continue
+    fi
+
+    if [ -n "$base_sha" ]; then
+        if [ "$proj_sha" = "$base_sha" ]; then
+            if [ "$proj_sha" = "$new_sha" ]; then
+                : # noop
+            else
+                proceed_list="$proceed_list
+$rel"
+            fi
+        else
+            if [ "$proj_sha" = "$new_sha" ]; then
+                : # noop — operator already at upstream
+            else
+                blocked_list="$blocked_list
+refuse:local-edit:$rel:$proj_sha:$base_sha:$new_sha"
+                any_block=1
+                saw_local_edit=1
+            fi
+        fi
+    else
+        if [ "$proj_sha" = "$new_sha" ]; then
+            : # noop
+        else
+            blocked_list="$blocked_list
+retrofit:baseline-unreachable:$rel:$proj_sha::$new_sha"
+            any_block=1
+            saw_baseline_unreachable=1
+        fi
+    fi
+done
+IFS="$oldIFS"
+
+prebootstrap_block_artefact="$PROJECT_ROOT/.template-prebootstrap-blocked.json"
+
+if [ "$any_block" -eq 1 ]; then
+    if [ "$saw_local_edit" -eq 1 ] && [ "$saw_baseline_unreachable" -eq 1 ]; then
+        reason_summary="mixed"
+    elif [ "$saw_local_edit" -eq 1 ]; then
+        reason_summary="local-edit"
+    else
+        reason_summary="baseline-unreachable"
+    fi
+
+    if [ "${SWDT_PREBOOTSTRAP_FORCE:-}" = "1" ]; then
+        override_log="$PROJECT_ROOT/docs/pm/pre-release-gate-overrides.md"
+        if [ ! -w "$override_log" ]; then
+            printf 'ERROR: SWDT_PREBOOTSTRAP_FORCE=1 set, but %s is unwritable.\n' "$override_log" >&2
+            printf '       Refusing to bypass without an audit row. Fix permissions and re-run.\n' >&2
+            exit 2
+        fi
+        date_iso=$(date -u +%Y-%m-%d)
+        operator=$(git config user.email 2>/dev/null || echo "${USER:-unknown}@$(hostname 2>/dev/null || echo unknown)")
+        force_reason="${SWDT_PREBOOTSTRAP_FORCE_REASON:-unspecified}"
+        IFS='
+'
+        for entry in $blocked_list; do
+            [ -z "$entry" ] && continue
+            # entry: action:reason:path:project_sha:baseline_sha:upstream_sha
+            action=$(printf '%s' "$entry" | cut -d: -f1)
+            reason=$(printf '%s' "$entry" | cut -d: -f2)
+            path=$(printf '%s' "$entry" | cut -d: -f3)
+            row="| $date_iso | pre-bootstrap | (migration v1.0.0-rc13) | | $operator | ${reason}:${path} ($force_reason) | |"
+            printf '%s\n' "$row" >> "$override_log"
+            printf 'WARN: SWDT_PREBOOTSTRAP_FORCE=1 — overriding pre-bootstrap block on %s (reason=%s, action=%s)\n' "$path" "$reason" "$action" >&2
+            # Promote to proceed.
+            proceed_list="$proceed_list
+$path"
+        done
+        IFS="$oldIFS"
+        printf 'WARN: pre-bootstrap audit row(s) appended to %s\n' "$override_log" >&2
+        rm -f "$prebootstrap_block_artefact"
+    else
+        # Write block artefact atomically.
+        tmp_artefact=$(mktemp "$prebootstrap_block_artefact.tmp.XXXXXX")
+        {
+            printf '{\n'
+            printf '  "version": 1,\n'
+            printf '  "generated": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            printf '  "reason_summary": "%s",\n' "$reason_summary"
+            printf '  "blocked": [\n'
+            # Sort entries by path for determinism.
+            sorted_entries=$(printf '%s' "$blocked_list" | awk -F: 'NF { print $3 "|" $0 }' | LC_ALL=C sort | sed 's/^[^|]*|//')
+            first=1
+            IFS='
+'
+            for entry in $sorted_entries; do
+                [ -z "$entry" ] && continue
+                action=$(printf '%s' "$entry" | cut -d: -f1)
+                reason=$(printf '%s' "$entry" | cut -d: -f2)
+                path=$(printf '%s' "$entry" | cut -d: -f3)
+                proj_sha=$(printf '%s' "$entry" | cut -d: -f4)
+                base_sha=$(printf '%s' "$entry" | cut -d: -f5)
+                new_sha=$(printf '%s' "$entry" | cut -d: -f6)
+                reason_field="local-edit"
+                [ "$action" = "retrofit" ] && reason_field="baseline-unreachable"
+                if [ "$first" -eq 0 ]; then printf ',\n'; fi
+                printf '    {\n'
+                printf '      "path": "%s",\n' "$path"
+                printf '      "project_sha": "%s",\n' "$proj_sha"
+                printf '      "baseline_sha": "%s",\n' "$base_sha"
+                printf '      "upstream_sha": "%s",\n' "$new_sha"
+                printf '      "reason": "%s"\n' "$reason_field"
+                printf '    }'
+                first=0
+            done
+            IFS="$oldIFS"
+            printf '\n  ]\n}\n'
+        } > "$tmp_artefact"
+        mv "$tmp_artefact" "$prebootstrap_block_artefact"
+
+        printf '\nERROR: pre-bootstrap refused — bootstrap-critical files carry local edits or an unreachable baseline.\n' >&2
+        IFS='
+'
+        for entry in $blocked_list; do
+            [ -z "$entry" ] && continue
+            action=$(printf '%s' "$entry" | cut -d: -f1)
+            reason=$(printf '%s' "$entry" | cut -d: -f2)
+            path=$(printf '%s' "$entry" | cut -d: -f3)
+            printf '  %s: reason=%s\n' "$path" "$reason" >&2
+        done
+        IFS="$oldIFS"
+        printf '\nBlock artefact: %s\n' "$prebootstrap_block_artefact" >&2
+        printf 'Recovery:\n' >&2
+        printf '  - Review the listed paths; declare deliberate local edits in .template-customizations.\n' >&2
+        printf '  - For baseline-unreachable rows, follow the retrofit playbook:\n' >&2
+        printf '      docs/templates/retrofit-playbook-template.md\n' >&2
+        printf '  - To bypass (atomic-replace every blocked path, audit-logged):\n' >&2
+        printf '      SWDT_PREBOOTSTRAP_FORCE=1 scripts/upgrade.sh ...\n' >&2
+        printf '    (Optionally set SWDT_PREBOOTSTRAP_FORCE_REASON=<note> for the audit row.)\n' >&2
+        exit 2
+    fi
+fi
+
+# Execute the proceed list (atomic install).
+IFS='
+'
+for rel in $proceed_list; do
+    [ -z "$rel" ] && continue
+    new_file="$WORKDIR_NEW/$rel"
+    proj_file="$PROJECT_ROOT/$rel"
+    [ -f "$new_file" ] || continue
+    case "$rel" in
+        scripts/lib/*)
+            mkdir -p "$PROJECT_ROOT/scripts/lib"
+            ;;
+    esac
+    if [ -x "$new_file" ]; then
+        install -m 0755 "$new_file" "$proj_file"
+    else
+        install -m 0644 "$new_file" "$proj_file"
+    fi
+    if [ "$rel" = "scripts/upgrade.sh" ]; then
+        echo "  pre-bootstrapped scripts/upgrade.sh to candidate (rc-to-rc structural-rewrite safe)"
+    fi
+done
+IFS="$oldIFS"
+
+# Clear any stale block artefact from a prior refused run.
+rm -f "$prebootstrap_block_artefact"
+
+exit 0

--- a/migrations/v1.0.0-rc13.sh
+++ b/migrations/v1.0.0-rc13.sh
@@ -101,11 +101,12 @@ any_block=0
 saw_local_edit=0
 saw_baseline_unreachable=0
 
-# shellcheck disable=SC2034
-oldIFS="$IFS"
-IFS='
-'
-for rel in $prebootstrap_paths; do
+# Iterate the newline-delimited path list via `while IFS= read -r` (the
+# per-command IFS prefix is local to read and does NOT modify the global
+# IFS — Semgrep ifs-tampering rule ignores it). Process substitution
+# (`< <(...)`) keeps the loop in the parent shell so variable mutations
+# propagate. Same idiom is used throughout scripts/* in this repo.
+while IFS= read -r rel; do
     [ -z "$rel" ] && continue
     proj_file="$PROJECT_ROOT/$rel"
     new_file="$WORKDIR_NEW/$rel"
@@ -151,8 +152,7 @@ retrofit:baseline-unreachable:$rel:$proj_sha::$new_sha"
             saw_baseline_unreachable=1
         fi
     fi
-done
-IFS="$oldIFS"
+done < <(printf '%s\n' "$prebootstrap_paths")
 
 prebootstrap_block_artefact="$PROJECT_ROOT/.template-prebootstrap-blocked.json"
 
@@ -175,9 +175,7 @@ if [ "$any_block" -eq 1 ]; then
         date_iso=$(date -u +%Y-%m-%d)
         operator=$(git config user.email 2>/dev/null || echo "${USER:-unknown}@$(hostname 2>/dev/null || echo unknown)")
         force_reason="${SWDT_PREBOOTSTRAP_FORCE_REASON:-unspecified}"
-        IFS='
-'
-        for entry in $blocked_list; do
+        while IFS= read -r entry; do
             [ -z "$entry" ] && continue
             # entry: action:reason:path:project_sha:baseline_sha:upstream_sha
             action=$(printf '%s' "$entry" | cut -d: -f1)
@@ -189,8 +187,7 @@ if [ "$any_block" -eq 1 ]; then
             # Promote to proceed.
             proceed_list="$proceed_list
 $path"
-        done
-        IFS="$oldIFS"
+        done < <(printf '%s\n' "$blocked_list")
         printf 'WARN: pre-bootstrap audit row(s) appended to %s\n' "$override_log" >&2
         rm -f "$prebootstrap_block_artefact"
     else
@@ -205,9 +202,7 @@ $path"
             # Sort entries by path for determinism.
             sorted_entries=$(printf '%s' "$blocked_list" | awk -F: 'NF { print $3 "|" $0 }' | LC_ALL=C sort | sed 's/^[^|]*|//')
             first=1
-            IFS='
-'
-            for entry in $sorted_entries; do
+            while IFS= read -r entry; do
                 [ -z "$entry" ] && continue
                 action=$(printf '%s' "$entry" | cut -d: -f1)
                 reason=$(printf '%s' "$entry" | cut -d: -f2)
@@ -226,23 +221,19 @@ $path"
                 printf '      "reason": "%s"\n' "$reason_field"
                 printf '    }'
                 first=0
-            done
-            IFS="$oldIFS"
+            done < <(printf '%s\n' "$sorted_entries")
             printf '\n  ]\n}\n'
         } > "$tmp_artefact"
         mv "$tmp_artefact" "$prebootstrap_block_artefact"
 
         printf '\nERROR: pre-bootstrap refused — bootstrap-critical files carry local edits or an unreachable baseline.\n' >&2
-        IFS='
-'
-        for entry in $blocked_list; do
+        while IFS= read -r entry; do
             [ -z "$entry" ] && continue
             action=$(printf '%s' "$entry" | cut -d: -f1)
             reason=$(printf '%s' "$entry" | cut -d: -f2)
             path=$(printf '%s' "$entry" | cut -d: -f3)
             printf '  %s: reason=%s\n' "$path" "$reason" >&2
-        done
-        IFS="$oldIFS"
+        done < <(printf '%s\n' "$blocked_list")
         printf '\nBlock artefact: %s\n' "$prebootstrap_block_artefact" >&2
         printf 'Recovery:\n' >&2
         printf '  - Review the listed paths; declare deliberate local edits in .template-customizations.\n' >&2
@@ -256,9 +247,7 @@ $path"
 fi
 
 # Execute the proceed list (atomic install).
-IFS='
-'
-for rel in $proceed_list; do
+while IFS= read -r rel; do
     [ -z "$rel" ] && continue
     new_file="$WORKDIR_NEW/$rel"
     proj_file="$PROJECT_ROOT/$rel"
@@ -276,8 +265,7 @@ for rel in $proceed_list; do
     if [ "$rel" = "scripts/upgrade.sh" ]; then
         echo "  pre-bootstrapped scripts/upgrade.sh to candidate (rc-to-rc structural-rewrite safe)"
     fi
-done
-IFS="$oldIFS"
+done < <(printf '%s\n' "$proceed_list")
 
 # Clear any stale block artefact from a prior refused run.
 rm -f "$prebootstrap_block_artefact"

--- a/migrations/v1.0.0-rc14.sh
+++ b/migrations/v1.0.0-rc14.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# migrations/v1.0.0-rc14.sh — upgrade TO v1.0.0-rc14.
+#
+# FW-ADR-0014 opt-in pruning migration. The preservation-vs-manifest
+# gate (landed in rc14 via FW-ADR-0014) silently drops inert
+# preserve-list entries from the in-memory preserve set at sync time
+# — but it does NOT rewrite .template-customizations. This migration
+# is the only writer that prunes the on-disk file.
+#
+# Two-pass shape:
+#
+#   Pass 1 (default — dry-run). Walks .template-customizations and
+#   prints the list of entries that match the upstream baseline
+#   byte-for-byte (no divergence) and are therefore inert. No file is
+#   rewritten. Operator inspects the list.
+#
+#   Pass 2 (apply). Operator re-runs with SWDT_PRESERVATION_PRUNE_APPLY=1
+#   in the environment. Rewrites .template-customizations atomically
+#   (mktemp + mv), removing the inert lines, preserving comments,
+#   blank lines, and entries that diverge from baseline or whose
+#   baseline is unreachable (conservative — keep what we cannot prove
+#   inert).
+#
+# Idempotent. Re-running after a successful apply pass is a no-op
+# because all remaining entries diverge (or baseline-unreachable
+# entries are conservatively kept).
+#
+# Env vars from scripts/upgrade.sh:
+#   PROJECT_ROOT                       — absolute path to project root
+#   WORKDIR_NEW                        — clone of upstream at NEW_VERSION
+#   WORKDIR_OLD                        — clone of upstream at baseline
+#                                        SHA (set when reachable)
+#   SWDT_PRESERVATION_PRUNE_APPLY=1    — opt-in: apply the rewrite
+#                                        instead of dry-run-printing.
+
+set -u
+LANG=C
+LC_ALL=C
+export LANG LC_ALL
+
+: "${PROJECT_ROOT:?PROJECT_ROOT is required}"
+
+cust="$PROJECT_ROOT/.template-customizations"
+if [ ! -f "$cust" ]; then
+  echo "  v1.0.0-rc14 prune: no .template-customizations file; nothing to do."
+  exit 0
+fi
+
+# Baseline reachable? Without WORKDIR_OLD we cannot prove inertness;
+# conservative posture: skip the rewrite entirely and warn.
+if [ -z "${WORKDIR_OLD:-}" ] || [ ! -d "${WORKDIR_OLD:-}" ]; then
+  echo "  v1.0.0-rc14 prune: WORKDIR_OLD unset/unreachable — cannot compute" >&2
+  echo "    divergence. Skipping. (Conservative posture: nothing pruned.)" >&2
+  exit 0
+fi
+
+# Pass 1: identify inert entries.
+inert_entries=()
+while IFS= read -r raw; do
+  trimmed="${raw%%#*}"
+  trimmed="$(printf '%s' "$trimmed" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -z "$trimmed" ] && continue
+  proj="$PROJECT_ROOT/$trimmed"
+  base="$WORKDIR_OLD/$trimmed"
+  [ -f "$proj" ] || continue
+  [ -f "$base" ] || continue
+  if cmp -s "$base" "$proj"; then
+    inert_entries+=("$trimmed")
+  fi
+done < "$cust"
+
+if [ ${#inert_entries[@]} -eq 0 ]; then
+  echo "  v1.0.0-rc14 prune: no inert preserve-list entries found; nothing to do."
+  exit 0
+fi
+
+# Dry-run by default.
+if [ "${SWDT_PRESERVATION_PRUNE_APPLY:-}" != "1" ]; then
+  echo "  v1.0.0-rc14 prune (dry-run): ${#inert_entries[@]} inert entry/entries identified:"
+  for e in "${inert_entries[@]}"; do
+    echo "    - $e"
+  done
+  echo "  To rewrite .template-customizations, re-run with:"
+  echo "    SWDT_PRESERVATION_PRUNE_APPLY=1 scripts/upgrade.sh ..."
+  exit 0
+fi
+
+# Apply pass. Build the new file: keep comments, blanks, and any line
+# whose trimmed value is not in the inert set. Rewrite atomically.
+tmp="$(mktemp "$cust.tmp.XXXXXX")"
+while IFS= read -r raw; do
+  trimmed="${raw%%#*}"
+  trimmed="$(printf '%s' "$trimmed" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  if [ -z "$trimmed" ]; then
+    # Comment-only or blank line — keep verbatim.
+    printf '%s\n' "$raw" >> "$tmp"
+    continue
+  fi
+  drop=0
+  for inert in "${inert_entries[@]}"; do
+    if [ "$inert" = "$trimmed" ]; then
+      drop=1
+      break
+    fi
+  done
+  if [ "$drop" -eq 0 ]; then
+    printf '%s\n' "$raw" >> "$tmp"
+  fi
+done < "$cust"
+mv "$tmp" "$cust"
+
+echo "  v1.0.0-rc14 prune (apply): rewrote .template-customizations, dropping ${#inert_entries[@]} inert entry/entries."
+for e in "${inert_entries[@]}"; do
+  echo "    - $e"
+done

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -76,6 +76,68 @@ manifest_file_sha() {
   sha256sum "$1" | awk '{print $1}'
 }
 
+# Decide whether the destination release declares <path> as a fresh-write.
+#
+# Per FW-ADR-0014, change point 2. The "destination manifest" is the
+# release the upgrade is moving the project toward — i.e., the upstream
+# clone at the new tag (<paths-repo-new>) — and optionally the previous
+# upstream baseline (<paths-repo-old>) when available. A fresh-write is
+# a path the new release is intentionally introducing new content for:
+#
+#   - present in the new upstream ship tree (i.e., the release would
+#     normally install it), AND
+#   - either no baseline is reachable, or the upstream content at this
+#     path differs from the baseline content (the release is actively
+#     shipping new/changed bytes — not merely re-listing an unchanged
+#     file).
+#
+# Returns:
+#   0  the new release declares <path> as a fresh-write.
+#   1  the new release does not declare <path> as a fresh-write
+#      (path absent from upstream, or upstream content equal to
+#      baseline content — the release ships nothing new at <path>).
+#
+# Callers MUST pass <path> project-relative (the same shape used by
+# manifest_ship_files / TEMPLATE_MANIFEST.lock entries). <paths-repo-old>
+# is optional; pass empty string when the baseline tree is not
+# available — the function then treats every new-side present path as
+# a fresh-write (conservative: surfaces more refusals, never silently
+# loses a manifest contradiction).
+manifest_declares_fresh_write() {
+  local path="$1"
+  local paths_repo_new="$2"
+  local paths_repo_old="${3:-}"
+
+  local new_file="$paths_repo_new/$path"
+  if [[ ! -f "$new_file" ]]; then
+    return 1
+  fi
+
+  if [[ -z "$paths_repo_old" || ! -d "$paths_repo_old" ]]; then
+    # No baseline reachable — conservative: any path the new release
+    # ships is treated as a fresh-write. Combined with the divergence
+    # check in upgrade.sh's should_preserve(), this only refuses when
+    # the project ALSO diverges at the same path.
+    return 0
+  fi
+
+  local old_file="$paths_repo_old/$path"
+  if [[ ! -f "$old_file" ]]; then
+    # Upstream did not previously ship this path — the new release is
+    # introducing it. Fresh-write.
+    return 0
+  fi
+
+  if cmp -s "$old_file" "$new_file"; then
+    # Upstream content unchanged across the upgrade range — the new
+    # release is not shipping anything new at this path. Not a
+    # fresh-write.
+    return 1
+  fi
+
+  return 0
+}
+
 # Write the manifest. Paths come from <paths-repo> (which MUST be a
 # git-controlled tree — the upstream clone or the template source);
 # SHA256 hashes are computed from the corresponding paths in

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -89,13 +89,20 @@ manifest_file_sha() {
 #   - either no baseline is reachable, or the upstream content at this
 #     path differs from the baseline content (the release is actively
 #     shipping new/changed bytes — not merely re-listing an unchanged
-#     file).
+#     file), AND
+#   - not filtered out of the destination manifest by the project's
+#     own `.template-customizations` preserve-list — a preserved path
+#     is excluded from `manifest_ship_files` and therefore from the
+#     destination manifest as it would actually be regenerated for
+#     this project. The destination manifest cannot "declare" a path
+#     it does not contain.
 #
 # Returns:
 #   0  the new release declares <path> as a fresh-write.
 #   1  the new release does not declare <path> as a fresh-write
-#      (path absent from upstream, or upstream content equal to
-#      baseline content — the release ships nothing new at <path>).
+#      (path absent from upstream, upstream content equal to baseline
+#      content, or path explicitly preserved by the project — the
+#      release ships nothing new at <path> from this project's view).
 #
 # Callers MUST pass <path> project-relative (the same shape used by
 # manifest_ship_files / TEMPLATE_MANIFEST.lock entries). <paths-repo-old>
@@ -103,14 +110,39 @@ manifest_file_sha() {
 # available — the function then treats every new-side present path as
 # a fresh-write (conservative: surfaces more refusals, never silently
 # loses a manifest contradiction).
+#
+# <project-repo> is optional; when provided, the function consults the
+# project's `.template-customizations` and returns 1 for any path the
+# project has declared preserved. This closes the false-positive on
+# scaffold-canonical stub-fills (README.md, CUSTOMER_NOTES.md,
+# docs/OPEN_QUESTIONS.md, docs/AGENT_NAMES.md, etc.): upstream's own
+# template content for those paths changes across releases, but the
+# scaffold immediately overwrites them with project-specific content,
+# so the destination manifest for the project excludes them and there
+# is no fresh-write to refuse against. PR #197 / dogfood-2026-05-15.
 manifest_declares_fresh_write() {
   local path="$1"
   local paths_repo_new="$2"
   local paths_repo_old="${3:-}"
+  local project_repo="${4:-}"
 
   local new_file="$paths_repo_new/$path"
   if [[ ! -f "$new_file" ]]; then
     return 1
+  fi
+
+  # Project preserve-list filter — the destination manifest excludes
+  # preserved paths by design (see manifest_ship_files), so the
+  # manifest cannot declare them as fresh-writes for this project.
+  if [[ -n "$project_repo" && -f "$project_repo/.template-customizations" ]]; then
+    while IFS= read -r line; do
+      line="${line%%#*}"
+      line="$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [[ -z "$line" ]] && continue
+      if [[ "$line" == "$path" ]]; then
+        return 1
+      fi
+    done < "$project_repo/.template-customizations"
   fi
 
   if [[ -z "$paths_repo_old" || ! -d "$paths_repo_old" ]]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1043,8 +1043,12 @@ should_preserve() {
   fi
 
   # Divergence is real. Now check the destination manifest's fresh-write
-  # declaration.
-  if manifest_declares_fresh_write "$path" "$wnew" "$wold"; then
+  # declaration. Pass the project root so the helper consults the
+  # project's `.template-customizations`: preserved paths are excluded
+  # from the destination manifest by design and therefore cannot be
+  # "declared fresh-write" for this project (PR #197 / dogfood-2026-05-15
+  # fix for scaffold-canonical stub-fills).
+  if manifest_declares_fresh_write "$path" "$wnew" "$wold" "$proot"; then
     echo "refuse-conflict"
   else
     echo "preserve"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1443,12 +1443,23 @@ if [[ ${#preservation_refused_paths[@]} -gt 0 ]]; then
       # upstream bytes.
       for f_p in "${preservation_refused_paths[@]}"; do
         # Remove the path from preserved[] (rebuild without it).
+        # NB: the `[@]:-` rebuild idiom is unsafe — when the source
+        # array is empty, `("${arr[@]:-}")` yields a one-element
+        # empty-string array, not an empty array. Guard on length
+        # instead. (CR blocker B-1, branch
+        # fix/blocker-4-preservation-vs-manifest.)
         new_preserved=()
-        for q in "${preserved[@]:-}"; do
-          [[ "$q" == "$f_p" ]] && continue
-          new_preserved+=("$q")
-        done
-        preserved=("${new_preserved[@]:-}")
+        if [ "${#preserved[@]}" -gt 0 ]; then
+          for q in "${preserved[@]}"; do
+            [[ "$q" == "$f_p" ]] && continue
+            new_preserved+=("$q")
+          done
+        fi
+        if [ "${#new_preserved[@]}" -gt 0 ]; then
+          preserved=("${new_preserved[@]}")
+        else
+          preserved=()
+        fi
         # Stage upstream content via the atomic helper used by the
         # main sync loop.
         if [[ -f "$workdir/new/$f_p" ]]; then
@@ -1601,9 +1612,19 @@ EOF
         printf '    {"path": "%s", "classified": "%s", "baseline_sha": "%s", "upstream_sha": "%s", "project_sha": "%s"}' \
           "$path" "$classified" "$baseline_sha" "$upstream_sha" "$project_sha"
       }
-      for f in "${conflicts[@]:-}"; do [[ -n "$f" ]] && emit_entry "$f" "conflict"; done
-      for f in "${local_only_kept[@]:-}"; do [[ -n "$f" ]] && emit_entry "$f" "local_only_kept"; done
-      for f in "${accepted_local[@]:-}"; do [[ -n "$f" ]] && emit_entry "$f" "accepted_local"; done
+      # Avoid the `[@]:-` iteration idiom — under `set -u` on modern
+      # bash, `"${arr[@]}"` over an empty array is safe; the `[@]:-`
+      # form injects a phantom empty-string iteration. Gate on length
+      # instead. (CR blocker B-1.)
+      if [ "${#conflicts[@]}" -gt 0 ]; then
+        for f in "${conflicts[@]}"; do emit_entry "$f" "conflict"; done
+      fi
+      if [ "${#local_only_kept[@]}" -gt 0 ]; then
+        for f in "${local_only_kept[@]}"; do emit_entry "$f" "local_only_kept"; done
+      fi
+      if [ "${#accepted_local[@]}" -gt 0 ]; then
+        for f in "${accepted_local[@]}"; do emit_entry "$f" "accepted_local"; done
+      fi
       printf '\n  ]\n}\n'
     } > "$conflicts_path"
   else
@@ -1639,11 +1660,13 @@ fi
 # the 'added' list; no filtering needed here beyond the prefix match.
 # Upstream issue #36.
 new_agents=()
-for f in "${added[@]:-}"; do
-  case "$f" in
-    .claude/agents/*.md) new_agents+=("$f") ;;
-  esac
-done
+if [ "${#added[@]}" -gt 0 ]; then
+  for f in "${added[@]}"; do
+    case "$f" in
+      .claude/agents/*.md) new_agents+=("$f") ;;
+    esac
+  done
+fi
 if [[ ${#new_agents[@]} -gt 0 ]]; then
   echo "${prefix}ACTION REQUIRED: restart Claude Code to register ${#new_agents[@]} new agent(s)."
   echo "${prefix}  The agent registry is initialized at session start and does not rescan"
@@ -1781,18 +1804,20 @@ if [[ $dry_run -eq 0 ]]; then
   lint_script="$project_root/scripts/lint-agent-contracts.sh"
   if [[ -x "$lint_script" ]]; then
     preserved_canonical_agents=()
-    for pf in "${preserved[@]:-}"; do
-      case "$pf" in
-        .claude/agents/*.md)
-          # Skip sme-* / *-local / sme-template — those aren't canonical
-          # contract surfaces per lint-agent-contracts.sh's surface 1.
-          case "$pf" in
-            .claude/agents/sme-*.md|.claude/agents/*-local.md) ;;
-            *) preserved_canonical_agents+=("$pf") ;;
-          esac
-          ;;
-      esac
-    done
+    if [ "${#preserved[@]}" -gt 0 ]; then
+      for pf in "${preserved[@]}"; do
+        case "$pf" in
+          .claude/agents/*.md)
+            # Skip sme-* / *-local / sme-template — those aren't canonical
+            # contract surfaces per lint-agent-contracts.sh's surface 1.
+            case "$pf" in
+              .claude/agents/sme-*.md|.claude/agents/*-local.md) ;;
+              *) preserved_canonical_agents+=("$pf") ;;
+            esac
+            ;;
+        esac
+      done
+    fi
     if [[ ${#preserved_canonical_agents[@]} -gt 0 ]]; then
       lint_log="$(mktemp -t upgrade-lint-XXXXXX.log)"
       lint_rc=0

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -961,6 +961,14 @@ ship_files=$(cd "$workdir/new" && git ls-files \
 # (one path per line, project-root-relative) in .template-customizations.
 # Those paths are skipped entirely by upgrade: never overwritten, never
 # flagged as conflicts.
+#
+# Per FW-ADR-0014, the preserve-list is no longer authoritative on its own.
+# At sync time each entry is classified by should_preserve() against
+# (a) project-vs-baseline divergence and (b) the destination manifest's
+# fresh-write declaration. Inert entries silently drop; genuine
+# manifest-vs-customisation conflicts refuse with exit 2 unless
+# SWDT_PRESERVATION_FORCE=1. The on-disk file is untouched here — the
+# opt-in pruning migration (migrations/v1.0.0-rc14.sh) is the only writer.
 declare -A preserve_list=()
 customizations_file="$project_root/.template-customizations"
 if [[ -f "$customizations_file" ]]; then
@@ -972,6 +980,126 @@ if [[ -f "$customizations_file" ]]; then
     preserve_list["$line"]=1
   done < "$customizations_file"
 fi
+
+# --- FW-ADR-0014: preservation decision helper -------------------------------
+#
+# Classify a preserve-list entry against project divergence and the
+# destination manifest's fresh-write declaration. Returns one of:
+#
+#   preserve          — divergence AND path not declared fresh-write
+#   drop-inert        — no divergence (inert entry; sync proceeds)
+#   refuse-conflict   — divergence AND path declared fresh-write
+#                       (manifest contradiction; caller must refuse
+#                       unless SWDT_PRESERVATION_FORCE=1)
+#
+# Reads (caller-supplied via positional args):
+#   $1  project-relative path
+#   $2  workdir/new (upstream new clone)
+#   $3  workdir/old (upstream baseline clone, or empty when unreachable)
+#   $4  project_root
+#   $5  baseline_available (0/1)
+#
+# When baseline is unreachable (baseline_available=0) we cannot prove
+# the project is at the same content as the baseline — every diverged-
+# from-upstream path is treated as divergence (conservative, matches
+# the existing "no baseline" comment in the sync classifier below).
+should_preserve() {
+  local path="$1"
+  local wnew="$2"
+  local wold="$3"
+  local proot="$4"
+  local b_avail="$5"
+
+  local proj_file="$proot/$path"
+  if [[ ! -f "$proj_file" ]]; then
+    # Project doesn't have the file at all — nothing to preserve. The
+    # sync loop will fall through to its add path (or skip if upstream
+    # also lacks it). Treat as drop-inert.
+    echo "drop-inert"
+    return 0
+  fi
+
+  # Divergence check: project vs baseline.
+  local diverged=0
+  if [[ "$b_avail" == "1" && -n "$wold" && -f "$wold/$path" ]]; then
+    if ! cmp -s "$wold/$path" "$proj_file"; then
+      diverged=1
+    fi
+  else
+    # Baseline unreachable for this path. Conservative: compare project
+    # against new upstream. If they match, there's nothing custom to
+    # preserve (drop-inert). If they differ, we cannot prove which
+    # change introduced the diff, so treat as diverged.
+    if [[ -f "$wnew/$path" ]] && cmp -s "$wnew/$path" "$proj_file"; then
+      diverged=0
+    else
+      diverged=1
+    fi
+  fi
+
+  if [[ $diverged -eq 0 ]]; then
+    echo "drop-inert"
+    return 0
+  fi
+
+  # Divergence is real. Now check the destination manifest's fresh-write
+  # declaration.
+  if manifest_declares_fresh_write "$path" "$wnew" "$wold"; then
+    echo "refuse-conflict"
+  else
+    echo "preserve"
+  fi
+  return 0
+}
+
+# --- FW-ADR-0014: preservation refusal block-artefact writer -----------------
+#
+# Mirrors the FW-ADR-0010 pre-bootstrap block-artefact writer. Emits
+# .template-preservation-blocked.json at project root. Reads three
+# parallel arrays populated by the sync loop's classification pass:
+#
+#   preservation_refused_paths[]
+#   preservation_refused_project_shas[]
+#   preservation_refused_baseline_shas[]
+#   preservation_refused_manifest_shas[]
+#
+# Format: schema parallel to .template-prebootstrap-blocked.json
+# (version 1, generated, reason_summary, blocked[] sorted by path).
+write_preservation_block_artefact() {
+  local out="$1"
+  local tmp
+  tmp="$(mktemp "$out.tmp.XXXXXX")"
+  {
+    printf '{\n'
+    printf '  "version": 1,\n'
+    printf '  "generated": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '  "reason_summary": "manifest-fresh-write-vs-customisation",\n'
+    printf '  "blocked": [\n'
+    # Build a sortable list (path -> index) so output is deterministic.
+    local sorted_idx=()
+    while IFS= read -r idx_line; do
+      sorted_idx+=("${idx_line#*:}")
+    done < <(
+      for j in "${!preservation_refused_paths[@]}"; do
+        printf '%s:%s\n' "${preservation_refused_paths[$j]}" "$j"
+      done | LC_ALL=C sort
+    )
+    local first=1
+    for j in "${sorted_idx[@]}"; do
+      [[ $first -eq 0 ]] && printf ',\n'
+      first=0
+      printf '    {\n'
+      printf '      "path": "%s",\n' "${preservation_refused_paths[$j]}"
+      printf '      "project_sha": "%s",\n' "${preservation_refused_project_shas[$j]}"
+      printf '      "baseline_sha": "%s",\n' "${preservation_refused_baseline_shas[$j]}"
+      printf '      "manifest_declared_sha": "%s",\n' "${preservation_refused_manifest_shas[$j]}"
+      printf '      "reason": "manifest-fresh-write-vs-customisation"\n'
+      printf '    }'
+    done
+    printf '\n  ]\n}\n'
+  } > "$tmp"
+  mv "$tmp" "$out"
+}
 
 # Agent-name-aware compare (issue #64).
 #
@@ -1058,6 +1186,16 @@ shortstat_between() {
 }
 
 added=(); upgraded=(); kept=(); conflicts=(); local_only_kept=(); accepted_local=(); preserved=()
+# FW-ADR-0014: per-path classification of preserve-list entries.
+#   dropped_inert[]     — entries with no divergence (silently dropped).
+#   preservation_refused_paths[] (+ parallel SHA arrays) — entries that
+#     hit the manifest-fresh-write-vs-customisation conflict and need
+#     a block-artefact row.
+dropped_inert=()
+preservation_refused_paths=()
+preservation_refused_project_shas=()
+preservation_refused_baseline_shas=()
+preservation_refused_manifest_shas=()
 # Issue #110: pre-existing collisions — files that the project had
 # locally BEFORE upstream started shipping them. Identified by:
 # baseline-tree did NOT contain the file, project tree DOES, upstream
@@ -1092,10 +1230,49 @@ for f in $ship_files; do
   new_path="$workdir/new/$f"
   proj_path="$project_root/$f"
 
-  # Honor .template-customizations: skip preserved paths entirely.
+  # Honor .template-customizations, gated by FW-ADR-0014's
+  # divergence-AND-manifest-respecting rule (see should_preserve()).
   if [[ -n "${preserve_list[$f]:-}" ]]; then
-    preserved+=("$f")
-    continue
+    case "$(should_preserve "$f" "$workdir/new" "$workdir/old" "$project_root" "$baseline_available")" in
+      preserve)
+        preserved+=("$f")
+        continue
+        ;;
+      drop-inert)
+        # Inert entry — silently drop from the in-memory preserve set
+        # and fall through to the normal sync classifier so the path
+        # gets the upstream content. The on-disk file is not rewritten
+        # here; the opt-in pruning migration is the only writer.
+        dropped_inert+=("$f")
+        ;;
+      refuse-conflict)
+        # Manifest-fresh-write-vs-customisation collision. Record per-
+        # path detail; the post-loop refusal handler emits the block
+        # artefact (or, with SWDT_PRESERVATION_FORCE=1, appends an
+        # audit row and falls through to the normal classifier).
+        proj_sha_p=""
+        baseline_sha_p=""
+        manifest_sha_p=""
+        if [[ -f "$project_root/$f" ]]; then
+          proj_sha_p="$(manifest_file_sha "$project_root/$f")"
+        fi
+        if [[ $baseline_available -eq 1 && -f "$workdir/old/$f" ]]; then
+          baseline_sha_p="$(manifest_file_sha "$workdir/old/$f")"
+        fi
+        if [[ -f "$workdir/new/$f" ]]; then
+          manifest_sha_p="$(manifest_file_sha "$workdir/new/$f")"
+        fi
+        preservation_refused_paths+=("$f")
+        preservation_refused_project_shas+=("$proj_sha_p")
+        preservation_refused_baseline_shas+=("$baseline_sha_p")
+        preservation_refused_manifest_shas+=("$manifest_sha_p")
+        # Default action when not forced: preserve (do not overwrite
+        # the customisation). The post-loop handler will refuse the
+        # whole upgrade if any refusals remain unforced.
+        preserved+=("$f")
+        continue
+        ;;
+    esac
   fi
 
   if [[ "$f" == "AGENTS.md" ]] && memory_only_agents_stub "$proj_path"; then
@@ -1222,6 +1399,97 @@ for f in $ship_files; do
     fi
   fi
 done
+
+# --- FW-ADR-0014: preservation-vs-manifest refusal handler ------------------
+#
+# If any entry hit the refuse-conflict row, either:
+#   (a) honour SWDT_PRESERVATION_FORCE=1 — append one audit row per
+#       refused path to docs/pm/pre-release-gate-overrides.md with
+#       Gate=preservation, then atomically install the upstream
+#       content over the divergent project file. Removes any stale
+#       block artefact.
+#   (b) write .template-preservation-blocked.json and exit 2 (the
+#       refuse-on-uncertain posture; matches FW-ADR-0010).
+#
+# dry-run: print the planned refusal / override; change nothing.
+preservation_block_artefact="$project_root/.template-preservation-blocked.json"
+if [[ ${#preservation_refused_paths[@]} -gt 0 ]]; then
+  if [[ "${SWDT_PRESERVATION_FORCE:-}" == "1" ]]; then
+    override_log_p="$project_root/docs/pm/pre-release-gate-overrides.md"
+    if [[ ! -w "$override_log_p" ]]; then
+      echo "ERROR: SWDT_PRESERVATION_FORCE=1 set, but $override_log_p is unwritable." >&2
+      echo "       Refusing to bypass without an audit row. Fix permissions and re-run." >&2
+      exit 2
+    fi
+    date_iso_p="$(date -u +%Y-%m-%d)"
+    operator_p="$(git config user.email 2>/dev/null || echo "${USER:-unknown}@$(hostname 2>/dev/null || echo unknown)")"
+    force_reason_p="${SWDT_PRESERVATION_FORCE_REASON:-unspecified}"
+    new_sha_short_p="${new_sha:-}"
+    if [[ -n "$new_sha_short_p" ]]; then
+      new_sha_short_p="${new_sha_short_p:0:12}"
+    else
+      new_sha_short_p="(preservation)"
+    fi
+    if [[ $dry_run -eq 0 ]]; then
+      for j in "${!preservation_refused_paths[@]}"; do
+        row="| $date_iso_p | preservation | $new_sha_short_p | | $operator_p | manifest-fresh-write-vs-customisation:${preservation_refused_paths[$j]} ($force_reason_p) | |"
+        printf '%s\n' "$row" >> "$override_log_p"
+        echo "WARN: SWDT_PRESERVATION_FORCE=1 — overriding preservation block on ${preservation_refused_paths[$j]}" >&2
+      done
+      echo "WARN: preservation audit row(s) appended to $override_log_p" >&2
+      # Install upstream content over each refused project file. These
+      # paths were classified `preserved` during the sync loop; the
+      # force path now reclassifies them as `upgraded` and writes the
+      # upstream bytes.
+      for f_p in "${preservation_refused_paths[@]}"; do
+        # Remove the path from preserved[] (rebuild without it).
+        new_preserved=()
+        for q in "${preserved[@]:-}"; do
+          [[ "$q" == "$f_p" ]] && continue
+          new_preserved+=("$q")
+        done
+        preserved=("${new_preserved[@]:-}")
+        # Stage upstream content via the atomic helper used by the
+        # main sync loop.
+        if [[ -f "$workdir/new/$f_p" ]]; then
+          mkdir -p "$(dirname "$project_root/$f_p")"
+          atomic_install "$workdir/new/$f_p" "$project_root/$f_p"
+        fi
+        upgraded+=("$f_p")
+      done
+      rm -f "$preservation_block_artefact"
+    else
+      echo "(dry-run: would override preservation block on ${#preservation_refused_paths[@]} path(s) and append audit rows to $override_log_p)" >&2
+    fi
+  else
+    if [[ $dry_run -eq 0 ]]; then
+      write_preservation_block_artefact "$preservation_block_artefact"
+    fi
+    echo >&2
+    echo "ERROR: preservation refused — preserve-list path(s) collide with destination manifest fresh-write declaration." >&2
+    for j in "${!preservation_refused_paths[@]}"; do
+      echo "  ${preservation_refused_paths[$j]}: project diverges AND release ships new content (manifest-fresh-write-vs-customisation)" >&2
+    done
+    if [[ $dry_run -eq 0 ]]; then
+      echo >&2
+      echo "Block artefact: $preservation_block_artefact" >&2
+    else
+      echo "(dry-run: would have written $preservation_block_artefact)" >&2
+    fi
+    echo "Recovery:" >&2
+    echo "  - Inspect the diff at each blocked path and decide whether the" >&2
+    echo "    project customisation should win (remove the upstream change," >&2
+    echo "    re-run upgrade) or whether the release content should win" >&2
+    echo "    (SWDT_PRESERVATION_FORCE=1 — overwrites the project file)." >&2
+    echo "  - To bypass (overwrite every refused path, audit-logged):" >&2
+    echo "      SWDT_PRESERVATION_FORCE=1 scripts/upgrade.sh ..." >&2
+    echo "    (Optionally set SWDT_PRESERVATION_FORCE_REASON='<note>' for the audit row.)" >&2
+    exit 2
+  fi
+else
+  # No refusals — clear any stale block artefact from a prior run.
+  rm -f "$preservation_block_artefact"
+fi
 
 # --- Retrofit docs/intake-log.md (T041 / FR-013) -----------------------------
 # The template ships docs/templates/intake-log-template.md but does not
@@ -1458,7 +1726,9 @@ if [[ ${#preserved[@]} -gt 0 ]]; then
 fi
 
 if [[ $dry_run -eq 0 ]]; then
-  echo "Done. TEMPLATE_VERSION now $new_version / $new_sha."
+  # FW-ADR-0014 two-phase tail.
+  # Phase A — migration chain complete signal (grep-stable literal).
+  echo "Migration chain complete (TEMPLATE_VERSION now $new_version)."
   if [[ ${#conflicts[@]} -gt 0 ]]; then
     echo "Resolve the ${#conflicts[@]} conflict(s) above, then commit."
     echo "Unresolved conflicts persisted to .template-conflicts.json;"
@@ -1466,6 +1736,38 @@ if [[ $dry_run -eq 0 ]]; then
     echo "  After hand-merging, run scripts/upgrade.sh --resolve to clear."
   elif [[ ${#local_only_kept[@]} -gt 0 || ${#accepted_local[@]} -gt 0 ]]; then
     echo "Manifest verifies clean; remaining listed files are local customizations, not upgrade blockers."
+  fi
+
+  # Phase B — verification. Re-invoke the existing --verify formatter
+  # (manifest_verify from scripts/lib/manifest.sh) and map its result
+  # onto exit codes 0 / 1 / 2 per FW-ADR-0014 Q2.
+  #
+  # Exit codes:
+  #   0  clean      — verify reports OK and no preservation refusal.
+  #   1  drift      — verify reports drift (rc 1) or corrupt manifest
+  #                   (rc 3) — both indicate the post-upgrade project
+  #                   state is not in the shape the manifest claims.
+  #   2  refusal    — preservation refusal artefact present at project
+  #                   root (handled above via exit 2; never reaches
+  #                   this block, but the discriminator is documented
+  #                   here for completeness).
+  verify_rc=0
+  manifest_verify "$project_root" "$project_root/TEMPLATE_MANIFEST.lock" || verify_rc=$?
+  if [[ $verify_rc -eq 0 ]]; then
+    echo "Verification: clean."
+  else
+    # manifest_verify already printed its per-path drift report to
+    # stdout above; nothing extra needed here. Map rc to exit code.
+    if [[ -f "$preservation_block_artefact" ]]; then
+      # Unreachable in practice (refusal handler exits before stamping)
+      # but keep the mapping documented.
+      exit 2
+    fi
+    if [[ $verify_rc -eq 1 || $verify_rc -eq 3 ]]; then
+      exit 1
+    fi
+    # rc 2 means "manifest missing/unreadable" — surface as drift.
+    exit 1
   fi
 
   # Issue #155: when the upgrade preserves custom canonical agent files

--- a/tests/release-gate/dogfood-downstream.sh
+++ b/tests/release-gate/dogfood-downstream.sh
@@ -202,23 +202,45 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 SCRATCH_TREE="$SCRATCH/tree"
-# Use cp -aL; rsync is not POSIX-mandatory. cp -a preserves modes,
-# timestamps; -L dereferences symlinks at copy time, turning them
-# into real files in the scratch tree. Dereferencing matters for
-# the dogfood-examples fixtures whose stub `scripts/upgrade.sh` is
-# a symlink into `dogfood-examples/_shared/` (outside the per-
-# fixture root); without -L the copy preserves the symlink but the
-# target is no longer reachable inside the scratch tree.
+# Bulk copy with cp -a (no -L): preserves modes, timestamps, AND
+# symlinks as-is. rsync is not POSIX-mandatory so we stick with cp.
 #
-# Real captured fixtures are unaffected: a git-clone content tree
-# with internal symlinks gets a slightly heavier copy (links
-# resolved to files); external symlinks that would have been
-# dangling in the original now resolve correctly — strict
-# improvement.
+# Why no -L on the bulk copy: real captured fixtures may contain
+# absolute-target symlinks pointing outside the fixture root (e.g.,
+# overlay-rootfs entries like
+# `image/overlay/rootfs/etc/runlevels/default/<svc> →
+# /etc/init.d/<svc>`). With -L, cp tries to dereference at copy
+# time and fails because the target does not exist on the host —
+# the copy crashes before the driver writes any report. With plain
+# -a, those symlinks are preserved verbatim and the upgrade.sh
+# phase proceeds.
 #
 # Trailing /. copies contents (incl. dotfiles).
 mkdir -p "$SCRATCH_TREE"
-cp -aL "$FIXTURE/." "$SCRATCH_TREE/"
+cp -a "$FIXTURE/." "$SCRATCH_TREE/"
+
+# Targeted dereference for the dogfood-examples stub case only.
+# Those fixtures ship `scripts/upgrade.sh` as a symlink into
+# `dogfood-examples/_shared/upgrade.sh` (outside the per-fixture
+# root). After the plain `cp -a` above, the symlink is preserved
+# but its (typically relative) target resolves outside
+# `$SCRATCH_TREE` and is unreachable for the upgrade phase. Detect
+# that case and replace the symlink with a real-file copy of its
+# resolved target.
+#
+# Resolution runs against the ORIGINAL `$FIXTURE` path, not the
+# scratch copy, so relative symlink targets resolve correctly
+# (relative-from-scratch lands at a nonexistent path).
+#
+# Real captured fixtures have a regular file at scripts/upgrade.sh
+# and skip this block.
+if [ -L "$SCRATCH_TREE/scripts/upgrade.sh" ]; then
+    STUB_TARGET="$(readlink -f "$FIXTURE/scripts/upgrade.sh" 2>/dev/null || true)"
+    if [ -n "$STUB_TARGET" ] && [ -f "$STUB_TARGET" ]; then
+        rm -f "$SCRATCH_TREE/scripts/upgrade.sh"
+        cp -a "$STUB_TARGET" "$SCRATCH_TREE/scripts/upgrade.sh"
+    fi
+fi
 
 # upgrade.sh runs `git rev-parse --show-toplevel`; needs a repo.
 # Initialise a throwaway one inside the scratch tree.


### PR DESCRIPTION
## Summary

Resolves four framework-attributable blockers surfaced by the 2026-05-15 dogfood harness run (9 fixtures across 3 real downstream codenames × 3 states each, 0 PASS / 9 FAIL). Five of the failures are legitimate 3-way merge conflicts on heavily-customized downstreams (not framework regressions); the remaining four are framework defects.

Customer 2026-05-15 ruling (recorded in `CUSTOMER_NOTES.md`): *"the big blocker to going to v1.0.0 in my view is that the upgrade is always buggy."* — this PR addresses the upgrade-flow regressions in that frame.

Also per customer 2026-05-15 sequencing ruling: dogfood runs against `main` BEFORE the next rc cut. rc13 will be cut from a SHA at/after this merge once a follow-up dogfood vs main PASSes (rc12 mis-stabilized — #178 + #182 fixes merged after the rc12 tag commit; rc13 will include them naturally).

## Blockers resolved

- **#1 — rc-to-rc `upgrade.sh` self-overwrite (FW-ADR-0013).** rc2-baseline downstreams upgrading to rc12 crashed mid-execution with a bash syntax error because the rc2-era `upgrade.sh` had no self-bootstrap branch and was overwritten in-place by the sync loop. Pre-bootstrap (FW-ADR-0010 pattern, `migrations/v0.14.0.sh`) was keyed v0.x→v1.x only. New `migrations/v1.0.0-rc13.sh` extends the pattern to rc-to-rc structural-rewrite cliffs; inherits FW-ADR-0010's interface unchanged (`SWDT_PREBOOTSTRAP_FORCE=1`, exit 2, `.template-prebootstrap-blocked.json`, audit row with `Gate=pre-bootstrap`).

- **#2 — dogfood driver `cp -aL` crash on absolute-target symlinks.** Real embedded-target downstreams ship overlay-rootfs symlinks with absolute paths (e.g., `image/overlay/rootfs/etc/runlevels/default/X → /etc/init.d/X`). The driver's `cp -aL` preflight dereferences them to host paths that don't exist, crashing before `upgrade.sh` runs. Fix: bulk `cp -a` (no `-L`) + narrow post-copy `readlink -f` dereference only for the dogfood-examples stub case (`scripts/upgrade.sh` symlink into `_shared/`).

- **#3 — rc12 mis-stabilized.** #178 (inline `SWDT_AGENT_PUSH` carrier) and #182 (read-only interpreter reads of `CUSTOMER_NOTES.md`) merged AFTER the rc12 tag commit (`1f52e04`); neither fix is in rc12. Folds into the planned rc13 cut from a SHA at/after this merge — `d003d28` + `7d51cae` are already on `main`.

- **#4 — `.template-customizations` overrides destination-manifest writes (FW-ADR-0014).** v0.13→rc12 chain ended stamp-correct but with manifest drift (`docs/INDEX.md`, `.gitignore`, missing `docs/INDEX-PROJECT.md`). v0.15.0 migration appended to `.template-customizations` even for byte-identical files; preservation list then blocked manifest's fresh-write declarations. Fix: divergence-AND-manifest-respect gate (preserve only when project diverges from baseline AND path not declared fresh-write in destination manifest). Refuse-on-uncertain with `SWDT_PRESERVATION_FORCE=1` escape hatch (audit row with `Gate=preservation`). Two-phase exit prose replaces single-line `Done.` (phase A: migration complete + new version; phase B: verification status). Back-compat: runtime self-healing + opt-in pruning migration `migrations/v1.0.0-rc14.sh`.

## Process trail

- Architect: FW-ADR-0013 + FW-ADR-0014 (both `status: accepted`).
- Software-engineer: per-blocker implementation; B-1 fixup landed on blocker-4 after CR (`upgrade.sh` empty-array rebuild footgun, 5 sites total — same bash idiom found elsewhere; idiom now banned in the file).
- Code-reviewer: per-blocker review reports in `docs/review/`. All three branches APPROVED (blocker-1: 0 blockers, 4 NB; blocker-2: 0 blockers, 3 NB; blocker-4: 1 blocker resolved in fixup + 5 NB).
- QA-engineer: 9-fixture dogfood run + per-fixture failure analysis in `docs/pm/dogfood-2026-05-15-results.md`.
- Customer rulings recorded verbatim in `CUSTOMER_NOTES.md`.

## Non-blocking findings (12, will file as upstream issues)

- 4 from blocker-1 (NB-1..4 in `docs/review/blocker-1-rc-to-rc-prebootstrap.md`)
- 3 from blocker-2 (O-1..3 in `docs/review/blocker-2-dogfood-driver-symlinks.md`)
- 5 from blocker-4 (NB-1..5 in `docs/review/blocker-4-preservation-vs-manifest.md`)
- Plus a separate lint-routing R3 carve-out gap (CR-authored `docs/review/` + PM-authored `docs/pm/` files trigger warn-level R3 from non-researcher/non-tech-writer trailers; hard-gate not active so non-blocking, but the pattern table needs a carve-out).

## Test plan

- [ ] CI green
- [ ] After merge to main: dogfood harness re-runs against `main` (`--target main`) per customer's 2026-05-15 sequencing ruling — must PASS before cutting rc13
- [ ] Cut rc13 only if dogfood-vs-main PASSes
- [ ] Smoke-dogfood against the rc13 tag
- [ ] Meta-project submodule pointer bump only after rc13 smoke PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architecture decision records for upgrade behavior and customization handling during rc-to-rc transitions
  * Documented dogfood release-gate results and blocker resolutions

* **New Features**
  * Added rc-to-rc pre-bootstrap safety validation with forced override capability
  * Added preservation vs manifest conflict detection and handling during upgrades

* **Bug Fixes**
  * Fixed symlink dereferencing issue in dogfood test fixture preparation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->