### PR TITLE
fix(upgrade): refuse to run on non-default branch by default (#203)

### DIFF
--- a/docs/TEMPLATE_UPGRADE.md
+++ b/docs/TEMPLATE_UPGRADE.md
@@ -70,6 +70,35 @@ migrations, stamps `TEMPLATE_VERSION`, and rewrites
 `TEMPLATE_MANIFEST.lock` and fails if `.template-conflicts.json` still
 contains unresolved `conflict` entries.
 
+**Default-branch guard (issue #203).** Mutating runs (no flag and
+`--resolve`) refuse to run on any branch other than the repository's
+default branch and exit `2` with a documented `ERROR` message. The
+default branch is resolved in priority order from
+`refs/remotes/origin/HEAD`, then `init.defaultBranch`, then hard-coded
+`main` as a last resort (with a stderr `NOTE`). This is an early
+guard against a previously-observed divergence trap: an upgrade that
+lands on a feature branch never reaches `main`, child branches cut
+from it inherit a `TEMPLATE_VERSION` / `TEMPLATE_MANIFEST.lock` that
+trunk does not carry, and the divergence is only detected sessions
+later when `--verify` on `main` surfaces a manifest mismatch.
+
+Run upgrades on the default branch (typically `main`). Cut feature
+branches from the post-upgrade default and let `merge` propagate the
+new stamp. If you must test the upgrade on a side branch (rare, e.g.
+verifying an upstream pre-release before merging it into trunk),
+pass `--allow-non-default-branch` — the upgrade proceeds and prints
+a one-line stderr `WARNING` naming the current branch and the
+resolved default branch.
+
+`--dry-run` and `--verify` are non-mutating and remain branch-
+agnostic; `--dry-run` is the cleanest way to preview an upgrade plan
+from a side branch without overriding the guard.
+
+On the default branch the upgrade also prints a non-fatal `WARNING`
+if the working tree is dirty, because the upgrade rewrites tracked
+files and a dirty tree muddies the rollback story. Commit or stash
+first when possible.
+
 **If the upgrade adds new agents under `.claude/agents/`, restart
 Claude Code before dispatching them.** The agent registry is
 initialized at session start and does not rescan the agents

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage: scripts/upgrade.sh [--dry-run | --verify | --resolve | --target <ref> |
+                          --allow-non-default-branch |
                           --self-test-semver | --help]
 
   --dry-run         Print the upgrade plan; change nothing.
@@ -64,6 +65,14 @@ Usage: scripts/upgrade.sh [--dry-run | --verify | --resolve | --target <ref> |
                     tag for stable projects, or the latest upstream tag
                     for projects already on a pre-release track.
                     (Issues #60/#68; untagged refs added 2026-05-15.)
+  --allow-non-default-branch
+                    Skip the default-branch guard that normally refuses to
+                    run on a non-default branch. Mutating runs (no flag /
+                    --resolve) refuse by default so the upgrade lands on
+                    trunk; pass this flag to override and accept the risk
+                    of TEMPLATE_VERSION divergence across child branches.
+                    A one-line warning naming both branches is printed.
+                    (Issue #203.)
   --help, -h        Print this help and exit.
 
 With no flag, run the full upgrade. The script:
@@ -154,6 +163,7 @@ dry_run=0
 verify_mode=0
 resolve_mode=0
 target_version=""
+allow_non_default_branch=0
 original_args=("$@")
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -173,10 +183,66 @@ while [[ $# -gt 0 ]]; do
       semver_sort_tags_self_test
       exit $? ;;
     "--resolve")     resolve_mode=1; shift ;;
+    "--allow-non-default-branch")
+                     allow_non_default_branch=1; shift ;;
     "--help"|"-h")   usage; exit 0 ;;
     *)               echo "ERROR: unknown flag: $1" >&2; echo >&2; usage >&2; exit 2 ;;
   esac
 done
+
+# Default-branch guard (issue #203). Mutating runs (no flag / --resolve)
+# must land on the default branch so that TEMPLATE_VERSION /
+# TEMPLATE_MANIFEST.lock are inherited by child feature branches via
+# merge, rather than being stamped on a side branch the trunk never
+# sees. --dry-run and --verify are non-mutating and stay
+# branch-agnostic. --allow-non-default-branch overrides with a warning.
+if [[ $dry_run -eq 0 && $verify_mode -eq 0 ]]; then
+  # Prefer symbolic-ref (works on freshly-initialised repos with an
+  # unborn branch — `git init -b main` before the first commit).
+  # Fall back to rev-parse for older edge cases. Detached HEAD returns
+  # empty from symbolic-ref and "HEAD" from rev-parse; we normalise
+  # the literal "HEAD" to empty so the guard does not refuse an
+  # ambiguous state with a misleading message.
+  current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || true)"
+  if [[ -z "$current_branch" ]]; then
+    current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+    [[ "$current_branch" == "HEAD" ]] && current_branch=""
+  fi
+  default_branch=""
+  # Priority chain — first hit wins.
+  if origin_head="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+    default_branch="${origin_head#origin/}"
+  fi
+  if [[ -z "$default_branch" ]]; then
+    default_branch="$(git config --get init.defaultBranch 2>/dev/null || true)"
+  fi
+  if [[ -z "$default_branch" ]]; then
+    default_branch="main"
+    echo "NOTE: upgrade.sh could not resolve the repository default branch from origin/HEAD or init.defaultBranch; falling back to 'main'." >&2
+  fi
+
+  if [[ -n "$current_branch" && "$current_branch" != "$default_branch" ]]; then
+    if [[ $allow_non_default_branch -eq 1 ]]; then
+      echo "WARNING: upgrade.sh running on branch '$current_branch' (default branch is '$default_branch') — --allow-non-default-branch override in effect." >&2
+    else
+      echo "ERROR: upgrade.sh refuses to run on branch '$current_branch' — default" >&2
+      echo "branch is '$default_branch'. Template upgrades must land on the default" >&2
+      echo "branch so child feature branches inherit the new stamp via merge," >&2
+      echo "not by being cut from a side branch. Pass" >&2
+      echo "--allow-non-default-branch to override (you will see a warning)." >&2
+      exit 2
+    fi
+  elif [[ -n "$current_branch" && "$current_branch" == "$default_branch" ]]; then
+    # Optional recommended check from issue #203: warn on dirty tree on
+    # the default branch. The upgrade rewrites tracked files; a dirty
+    # tree muddies the rollback story. Non-fatal.
+    if [[ -d .git ]] || git rev-parse --git-dir >/dev/null 2>&1; then
+      if ! git diff --quiet --ignore-submodules HEAD 2>/dev/null; then
+        echo "WARNING: working tree on '$default_branch' has uncommitted changes — upgrade rewrites tracked files; consider committing or stashing first." >&2
+      fi
+    fi
+  fi
+fi
 
 if [[ ! -f "$tv" ]]; then
   echo "ERROR: no TEMPLATE_VERSION at project root. Not a scaffolded project?" >&2

--- a/tests/upgrade/test-branch-guard.sh
+++ b/tests/upgrade/test-branch-guard.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/upgrade/test-branch-guard.sh — cover the issue #203 default-
+# branch guard in scripts/upgrade.sh.
+#
+# Cases:
+#   1. Default branch (main)              → guard does not fire; upgrade
+#                                           proceeds past the guard (we
+#                                           short-circuit before the
+#                                           network clone with a tweak
+#                                           that triggers the
+#                                           TEMPLATE_VERSION ERROR path,
+#                                           which is downstream of the
+#                                           guard).
+#   2. Non-default branch, no flag         → guard refuses with exit 2
+#                                           and the documented message.
+#   3. Non-default branch, override flag   → upgrade proceeds past the
+#                                           guard with a stderr WARNING.
+#   4. --dry-run on non-default branch     → guard does not fire.
+#   5. --verify on non-default branch      → guard does not fire.
+#
+# The guard runs after argument parsing and before the TEMPLATE_VERSION
+# existence check. To isolate the guard we delete TEMPLATE_VERSION in
+# the fixture; the guard runs first and either lets us reach the
+# "no TEMPLATE_VERSION" ERROR (exit 1) or refuses with the branch
+# message (exit 2). Distinguishing exit 1 vs exit 2 is sufficient
+# without standing up a full upstream fixture.
+#
+# For --dry-run and --verify, the guard is intentionally skipped per
+# the issue; we assert those paths reach the TEMPLATE_VERSION check
+# (exit 1) even on a non-default branch.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+upgrade="$repo_root/scripts/upgrade.sh"
+
+tmp="$(mktemp -d -t upgrade-branch-guard-XXXXXX)"
+keep=0
+[[ "${1:-}" == "--keep" ]] && keep=1
+trap 'if [[ $keep -eq 0 ]]; then rm -rf "$tmp"; else echo "(kept $tmp for inspection)" >&2; fi' EXIT
+
+fail=0
+pass=0
+
+check() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Build a minimal fixture project: a git repo on `main`, no
+# TEMPLATE_VERSION (so the post-guard path is the missing-stamp ERROR
+# at exit 1). We intentionally do NOT add an origin remote — that
+# exercises the priority-chain fallback path the issue specifies.
+make_fixture() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -b main -q
+    git config user.email branch-guard-test@example.invalid
+    git config user.name "Branch Guard Test"
+    : > .gitkeep
+    git add .gitkeep
+    git commit -q -m "fixture init"
+  )
+}
+
+run_upgrade() {
+  # Args: <fixture_dir> <log_file> [upgrade.sh args...]
+  local dir="$1"; shift
+  local log="$1"; shift
+  local rc=0
+  ( cd "$dir" && bash "$upgrade" "$@" ) > "$log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+echo "-- issue #203 default-branch guard --"
+
+# Case 1: default branch (main) → guard does not fire; we reach the
+# missing-TEMPLATE_VERSION error (exit 1).
+fix_main="$tmp/on-main"
+make_fixture "$fix_main"
+rc_main=$(run_upgrade "$fix_main" "$tmp/on-main.log")
+check "default branch reaches TEMPLATE_VERSION check (exit 1)" \
+  bash -c "[ '$rc_main' = '1' ]"
+check "default branch does not print branch-guard ERROR" \
+  bash -c "! grep -q 'refuses to run on branch' '$tmp/on-main.log'"
+
+# Case 2: non-default branch → guard refuses (exit 2).
+fix_feat="$tmp/on-feat"
+make_fixture "$fix_feat"
+( cd "$fix_feat" && git switch -q -c feat/x )
+rc_feat=$(run_upgrade "$fix_feat" "$tmp/on-feat.log")
+check "non-default branch refuses with exit 2" \
+  bash -c "[ '$rc_feat' = '2' ]"
+check "non-default branch prints documented refuse message" \
+  bash -c "grep -q \"refuses to run on branch 'feat/x'\" '$tmp/on-feat.log' && grep -q \"branch is 'main'\" '$tmp/on-feat.log'"
+check "non-default branch hints --allow-non-default-branch override" \
+  bash -c "grep -q -- '--allow-non-default-branch' '$tmp/on-feat.log'"
+
+# Case 3: non-default branch + --allow-non-default-branch → proceed
+# with WARNING. We expect to land on the TEMPLATE_VERSION ERROR (exit
+# 1) downstream of the guard, with the WARNING also present.
+fix_override="$tmp/on-feat-override"
+make_fixture "$fix_override"
+( cd "$fix_override" && git switch -q -c feat/y )
+rc_override=$(run_upgrade "$fix_override" "$tmp/on-feat-override.log" \
+              --allow-non-default-branch)
+check "override flag bypasses guard (reaches TEMPLATE_VERSION check, exit 1)" \
+  bash -c "[ '$rc_override' = '1' ]"
+check "override flag emits a WARNING naming both branches" \
+  bash -c "grep -q \"WARNING:.*'feat/y'.*'main'\" '$tmp/on-feat-override.log'"
+check "override flag does not print refuse ERROR" \
+  bash -c "! grep -q 'refuses to run on branch' '$tmp/on-feat-override.log'"
+
+# Case 4: --dry-run on non-default branch → guard does not fire.
+fix_dryrun="$tmp/on-feat-dryrun"
+make_fixture "$fix_dryrun"
+( cd "$fix_dryrun" && git switch -q -c feat/z )
+rc_dryrun=$(run_upgrade "$fix_dryrun" "$tmp/on-feat-dryrun.log" --dry-run)
+check "--dry-run on non-default branch skips guard" \
+  bash -c "! grep -q 'refuses to run on branch' '$tmp/on-feat-dryrun.log'"
+# Exit code should be the TEMPLATE_VERSION missing ERROR (1), not the
+# guard refuse (2).
+check "--dry-run on non-default branch returns exit != 2" \
+  bash -c "[ '$rc_dryrun' != '2' ]"
+
+# Case 5: --verify on non-default branch → guard does not fire.
+fix_verify="$tmp/on-feat-verify"
+make_fixture "$fix_verify"
+( cd "$fix_verify" && git switch -q -c feat/w )
+rc_verify=$(run_upgrade "$fix_verify" "$tmp/on-feat-verify.log" --verify)
+check "--verify on non-default branch skips guard" \
+  bash -c "! grep -q 'refuses to run on branch' '$tmp/on-feat-verify.log'"
+check "--verify on non-default branch returns exit != 2 (no branch refuse)" \
+  bash -c "[ '$rc_verify' != '2' ]"
+
+echo
+echo "PASS: $pass"
+echo "FAIL: $fail"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds an early branch-guard to `scripts/upgrade.sh` that refuses to run on a non-default branch unless `--allow-non-default-branch` is passed. Closes the divergence trap documented in #203 — the failure mode that left a downstream project (QuackDCS, rc8→rc13) with a multi-branch `TEMPLATE_VERSION` / manifest split and required a multi-hour cleanup session.

## Closes

- Closes #203

## Implementation

- Default-branch resolution priority chain: `origin/HEAD` → `init.defaultBranch` → hard-coded `main` (with stderr NOTE on the last arm).
- Guard gated to mutating paths only (`dry_run == 0 && verify_mode == 0`); `--dry-run`, `--verify`, `--help`, `--self-test-semver` are unaffected.
- New `--allow-non-default-branch` flag with a stderr warning naming both branches.
- Exit code `2` on guard refusal (matches existing unknown-flag exit code).
- Optional dirty-tree warning on the default branch (non-fatal; satisfies issue ask #6).
- Edge cases handled: detached HEAD, unborn branch (`git init -b main` pre-commit), missing origin remote.
- `usage()` heredoc + `docs/TEMPLATE_UPGRADE.md` updated.

## Test plan

- [x] `tests/upgrade/test-branch-guard.sh` (new, 154 lines, 12 cases): default-branch happy path, non-default refuse-and-exit-2, non-default + override, dry-run exempt, verify exempt, fallback path (no origin remote). 12 PASS / 0 FAIL.
- [x] `scripts/smoke-test.sh`: 174 PASS / 0 FAIL — no regressions.
- [x] Code-review: APPROVED with no blocking findings (acceptance criteria verified line-by-line; 3 non-blocking observations marked "leave it").

## Files changed

- `scripts/upgrade.sh` (+66 lines)
- `docs/TEMPLATE_UPGRADE.md` (+29 lines)
- `tests/upgrade/test-branch-guard.sh` (+154 lines, new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added default-branch guard that prevents mutating upgrade runs on non-default branches (can be overridden with `--allow-non-default-branch` flag)
  * Non-mutating operations (`--dry-run`, `--verify`) remain branch-agnostic
  * Added warnings for uncommitted changes when upgrading on default branch

* **Documentation**
  * Updated upgrade guide with default-branch guard behavior and CLI flag usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->