### PR TITLE
fix(hooks): cluster-A burndown — settings.json additive merge, pathlib coverage, project-scoped HR-8 (#201 #184 #205 #206)

### DIFF
--- a/docs/adr/fw-adr-0012-tech-lead-authoring-guard.md
+++ b/docs/adr/fw-adr-0012-tech-lead-authoring-guard.md
@@ -1120,9 +1120,8 @@ discipline; none block acceptance.
   2026-05-16, upstream issues #205 + #206).** The
   binding allow-list above enumerates project artefacts
   relative to `CLAUDE_PROJECT_DIR`. The hook short-circuits
-  to *proceed* on any write whose normalised target is
-  absolute and falls outside the resolved project
-  directory — auto-memory under
+  to *proceed* on any write whose target, before or after
+  normalisation, is absolute and outside CLAUDE_PROJECT_DIR — auto-memory under
   `~/.claude/projects/**/memory/**`, skill installation
   under `~/.claude/skills/**`, transient scratch under
   `/tmp/**`, and kernel device redirects under `/dev/**`

--- a/docs/adr/fw-adr-0012-tech-lead-authoring-guard.md
+++ b/docs/adr/fw-adr-0012-tech-lead-authoring-guard.md
@@ -1116,6 +1116,25 @@ discipline; none block acceptance.
   them despite the semantics-muddling cost.
   `software-engineer` records baseline timing in the
   self-test fixture at implementation time.
+- **Allow-list scope is project-only (addendum,
+  2026-05-16, upstream issues #205 + #206).** The
+  binding allow-list above enumerates project artefacts
+  relative to `CLAUDE_PROJECT_DIR`. The hook short-circuits
+  to *proceed* on any write whose normalised target is
+  absolute and falls outside the resolved project
+  directory — auto-memory under
+  `~/.claude/projects/**/memory/**`, skill installation
+  under `~/.claude/skills/**`, transient scratch under
+  `/tmp/**`, and kernel device redirects under `/dev/**`
+  (`/dev/null`, `/dev/stdout`, `/dev/stderr`,
+  `/dev/fd/N`). These are harness-internal write surfaces;
+  Hard Rule #8 governs project authoring discipline, not
+  byte-discard or harness state. The hook still denies
+  in-project writes off the allow-list and still requires
+  `SWDT_AGENT_PUSH=<role>` for tool-bridge work the
+  specialist's sandbox cannot perform. Implementation:
+  `_is_outside_project()` + `_is_harness_path()` in
+  `scripts/hooks/tech-lead-authoring-guard.py`.
 
 ## Links
 

--- a/scripts/hooks/customer-notes-guard.py
+++ b/scripts/hooks/customer-notes-guard.py
@@ -123,6 +123,21 @@ _OPEN_WRITE_KWARG_RE = re.compile(
     r"""open\(\s*['"]([^'"]+)['"][^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
 )
 
+# pathlib write-method coverage (issue #184). Mirrors
+# tech-lead-authoring-guard.py::_PATHLIB_* --- kept verbatim so the
+# sister hooks stay aligned. write_text / write_bytes are unconditional
+# writes; Path(...).open(...) uses the same mode-char set as open().
+_PATHLIB_CTOR = r"(?:pathlib\.)?(?:Path|PurePath|PosixPath|WindowsPath)"
+_PATHLIB_WRITE_TEXT_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.write_(?:text|bytes)\("""
+)
+_PATHLIB_OPEN_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.open\(\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+_PATHLIB_OPEN_KWARG_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.open\([^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
 
 def _extract_open_write_paths(body: str):
     """Return paths opened with a write mode in ``body``.
@@ -130,7 +145,10 @@ def _extract_open_write_paths(body: str):
     Mirrors tech-lead-authoring-guard.py::_extract_write_targets_from_body
     but without redirect detection — the caller decides whether to scan
     the body for redirects (shell `-c` body: yes; non-shell interpreter
-    `-c` and heredoc bodies: no, per #180 + #182).
+    `-c` and heredoc bodies: no, per #180 + #182). Also covers pathlib
+    write methods per issue #184: ``Path("x").write_text(...)``,
+    ``Path("x").write_bytes(...)``, ``Path("x").open("w")`` and the
+    kwarg form ``Path("x").open(mode="w")``.
     """
     if not body:
         return []
@@ -140,6 +158,14 @@ def _extract_open_write_paths(body: str):
             path, mode = m.group(1), m.group(2)
             if any(ch in mode for ch in ("w", "a", "x", "A", "+")):
                 targets.append(path)
+    # pathlib write-method detection (issue #184).
+    for m in _PATHLIB_WRITE_TEXT_RE.finditer(body):
+        targets.append(m.group(1))
+    for regex in (_PATHLIB_OPEN_RE, _PATHLIB_OPEN_KWARG_RE):
+        for m in regex.finditer(body):
+            p_path, p_mode = m.group(1), m.group(2)
+            if any(ch in p_mode for ch in ("w", "a", "x", "A", "+")):
+                targets.append(p_path)
     return targets
 
 

--- a/scripts/hooks/tech-lead-authoring-guard.py
+++ b/scripts/hooks/tech-lead-authoring-guard.py
@@ -865,11 +865,11 @@ def _decide_for_command(command: str):
     for t in targets:
         # Pre-normalisation filter for harness device paths (issue #206):
         # ``/dev/(null|stdout|stderr|fd/N|zero|random|urandom)`` and the
-        # broader ``/dev/**`` surface are not authoring targets. The
-        # _is_harness_path check below catches these via the ``/dev/``
-        # prefix, but doing the check on the raw token avoids any
-        # mis-normalisation surprises when the redirect target is bare
-        # like ``/dev/null`` (already absolute).
+        # broader ``/dev/**`` surface are not authoring targets. Checking
+        # on the raw token is sufficient — ``_is_harness_path`` early-
+        # returns False for any relative path, so absolute harness paths
+        # (e.g. ``/dev/null``) are caught here before normalisation.  No
+        # second ``_is_harness_path`` call is needed after normalisation.
         if _is_harness_path(t):
             continue
         norm = _normalise(t)
@@ -879,8 +879,6 @@ def _decide_for_command(command: str):
         # scope. ``_normalise`` returns the absolute form for these;
         # ``_is_outside_project`` recognises them.
         if _is_outside_project(t):
-            continue
-        if _is_harness_path(norm):
             continue
         if _is_customer_notes_path(norm):
             # Defer to customer-notes-guard.

--- a/scripts/hooks/tech-lead-authoring-guard.py
+++ b/scripts/hooks/tech-lead-authoring-guard.py
@@ -216,6 +216,34 @@ _OPEN_WRITE_KWARG_RE = re.compile(
     r"""open\(\s*['"]([^'"]+)['"][^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
 )
 
+# pathlib.Path write-method coverage (issue #184). The earlier regex set
+# only caught ``open(...)``-style writes; ``Path("x").write_text(...)``
+# and ``Path("x").open("w")`` slipped through as untracked writes.
+#
+# Path token: single- or double-quoted literal inside ``Path(...)`` /
+# ``pathlib.Path(...)`` / ``PurePath(...)``. Tracks both the bare class
+# and the qualified-module form.
+_PATHLIB_CTOR = r"(?:pathlib\.)?(?:Path|PurePath|PosixPath|WindowsPath)"
+
+# ``Path("foo").write_text(...)`` and ``Path("foo").write_bytes(...)``.
+# Both are write operations regardless of mode (they are the pathlib
+# equivalents of ``open(..., 'w').write(...)`` /
+# ``open(..., 'wb').write(...)``).
+_PATHLIB_WRITE_TEXT_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.write_(?:text|bytes)\("""
+)
+
+# ``Path("foo").open("w")`` (positional mode). Same mode-char set as
+# ``_OPEN_WRITE_RE``; non-write modes (``"r"``, ``"rb"``) do not match.
+_PATHLIB_OPEN_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.open\(\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
+# ``Path("foo").open(mode="w")`` (kwarg mode).
+_PATHLIB_OPEN_KWARG_RE = re.compile(
+    rf"""{_PATHLIB_CTOR}\(\s*['"]([^'"]+)['"]\s*\)\.open\([^)]*\bmode\s*=\s*['"]([^'"]*[waxA+][^'"]*)['"]"""
+)
+
 
 def _extract_write_targets_from_body(body: str, *, scan_redirects: bool = True):
     """Extract write-target paths from an interpreter / heredoc body.
@@ -225,15 +253,21 @@ def _extract_write_targets_from_body(body: str, *, scan_redirects: bool = True):
       - ``open('path', 'w'|'a'|'x'|'+'...)`` — positional mode contains
         a write char (covers binary ``'wb'`` / ``'ab'`` too).
       - ``open('path', mode='w')`` — kwarg mode contains a write char.
+      - ``Path('path').write_text(...)`` / ``write_bytes(...)`` —
+        unconditional pathlib writes (issue #184).
+      - ``Path('path').open('w')`` / ``Path('path').open(mode='w')`` —
+        pathlib open with a write mode (issue #184).
       - shell-style redirects ``> path`` / ``>> path`` inside the body
         (covers ``-c "... > file"`` and shell heredocs) — only when
         ``scan_redirects=True``.
 
-    Read-only ``open('foo.json')``, ``open('foo','r')``, and
-    ``open('foo', mode='r')`` do NOT match. Quoted path tokens that are
-    not the first arg of a write-mode open do NOT match. This is the
-    core fix for issue #175; the kwarg branch closes the bypass flagged
-    in code-reviewer tightening #4.
+    Read-only ``open('foo.json')``, ``open('foo','r')``,
+    ``open('foo', mode='r')``, ``Path('foo').read_text()``, and
+    ``Path('foo').open('r')`` do NOT match. Quoted path tokens that
+    are not the first arg of a write-mode open do NOT match. This is
+    the core fix for issues #175 (read-vs-write) and #184 (pathlib
+    coverage); the kwarg branch closes the bypass flagged in
+    code-reviewer tightening #4.
 
     ``scan_redirects=False`` is used for heredoc bodies (issue #180):
     a heredoc body is data, not shell syntax. Lines like prose with
@@ -257,6 +291,16 @@ def _extract_write_targets_from_body(body: str, *, scan_redirects: bool = True):
             # '+' alone is a write signal too).
             if any(ch in mode for ch in ("w", "a", "x", "A", "+")):
                 targets.append(path)
+    # pathlib write-method detection (issue #184). write_text/write_bytes
+    # are unconditional writes (no mode argument); Path(...).open(...)
+    # mirrors the open() mode-char check.
+    for m in _PATHLIB_WRITE_TEXT_RE.finditer(body):
+        targets.append(m.group(1))
+    for regex in (_PATHLIB_OPEN_RE, _PATHLIB_OPEN_KWARG_RE):
+        for m in regex.finditer(body):
+            p_path, p_mode = m.group(1), m.group(2)
+            if any(ch in p_mode for ch in ("w", "a", "x", "A", "+")):
+                targets.append(p_path)
     # Shell redirects inside the body. Skipped for heredoc bodies — see
     # docstring (issue #180 false-positive on prose containing ``>``).
     if scan_redirects:
@@ -490,8 +534,11 @@ def _normalise(path: str) -> str:
     - Strips leading `./`.
     - Resolves `..` segments lexically.
     - If absolute and inside CLAUDE_PROJECT_DIR, makes it relative.
-    - Otherwise returns the cleaned absolute path (which will not match the
-      allow-list and will be denied).
+    - Otherwise returns the cleaned absolute path. Issue #205: an
+      out-of-project absolute path is recognised by ``_is_outside_project``
+      and the decision layer short-circuits to proceed — HR-8 protects
+      project artefacts, not harness-internal writes (auto-memory,
+      ``/tmp``, ``/dev``, skill installation).
     """
     if not path:
         return ""
@@ -505,7 +552,9 @@ def _normalise(path: str) -> str:
         except ValueError:
             rel = p
         if rel.startswith(".."):
-            # Outside the project tree; preserve absolute form.
+            # Outside the project tree; preserve absolute form. The
+            # decision layer treats outside-project paths as out of HR-8
+            # scope and proceeds (issue #205).
             return os.path.normpath(p)
         return rel.replace(os.sep, "/")
 
@@ -514,6 +563,69 @@ def _normalise(path: str) -> str:
     if cleaned.startswith("./"):
         cleaned = cleaned[2:]
     return cleaned
+
+
+# Harness-internal write surfaces. Writes targeting these paths are not
+# project artefacts and lie outside FW-ADR-0012's scope (issues #205 +
+# #206). Patterns are evaluated against absolute paths (after _normalise
+# returns the absolute form for out-of-project inputs); ``~`` is
+# expanded once at import time so the comparison is a pure prefix check.
+_HARNESS_ALLOW_PREFIXES = (
+    os.path.expanduser("~/.claude/projects/"),  # auto-memory
+    os.path.expanduser("~/.claude/skills/"),    # skill installation
+    "/tmp/",
+    "/dev/",
+)
+# Exact-match harness paths (no trailing slash). ``/dev/null`` itself is
+# a device, not a directory; the prefix-match against ``/dev/`` catches
+# both ``/dev/null`` and ``/dev/fd/2``.
+_HARNESS_ALLOW_EXACT = frozenset({"/dev", "/tmp"})
+
+
+def _is_outside_project(path: str) -> bool:
+    """Return True if ``path`` resolves to an absolute location outside
+    the resolved CLAUDE_PROJECT_DIR.
+
+    Issue #205: HR-8 is project-scoped. Writes to harness-internal
+    surfaces (auto-memory under ``~/.claude/projects/**/memory/``, skill
+    installation under ``~/.claude/skills/``, ``/tmp``, ``/dev``) are
+    not the guard's jurisdiction. The decision layer uses this helper
+    to short-circuit before the allow-list lookup.
+
+    Returns False for relative paths (those remain project-scoped) and
+    for absolute paths inside the project tree.
+    """
+    if not path:
+        return False
+    p = path.strip()
+    if not os.path.isabs(p):
+        return False
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    project_dir = os.path.abspath(project_dir)
+    try:
+        rel = os.path.relpath(p, project_dir)
+    except ValueError:
+        # Different drive on Windows; treat as outside.
+        return True
+    return rel.startswith("..")
+
+
+def _is_harness_path(path: str) -> bool:
+    """Return True if ``path`` is a known harness write surface.
+
+    Pattern set covers auto-memory, skills, ``/tmp``, and ``/dev``
+    (issues #205 + #206). Matched purely by absolute-path prefix; the
+    caller is responsible for passing an already-normalised path
+    (``_normalise`` returns absolute form for outside-project inputs).
+    """
+    if not path:
+        return False
+    p = path.strip()
+    if p in _HARNESS_ALLOW_EXACT:
+        return True
+    if not os.path.isabs(p):
+        return False
+    return any(p.startswith(pref) for pref in _HARNESS_ALLOW_PREFIXES)
 
 
 def _matches_recursive_glob(path: str, glob: str) -> bool:
@@ -699,7 +811,8 @@ def _decide_for_path(path: str):
     """Return (decision, audit_callable) for a single target path.
 
     decision is one of:
-      - None: proceed silently (path on allow-list or deferred to
+      - None: proceed silently (path on allow-list, outside the project
+        tree, on the harness allow-list, or deferred to
         customer-notes-guard).
       - dict: a hookSpecificOutput payload (deny).
 
@@ -707,6 +820,22 @@ def _decide_for_path(path: str):
     finalised to emit the override audit-log line on stderr.
     """
     if not path:
+        return None, None
+
+    # Issue #205: HR-8 is project-scoped. Absolute paths outside
+    # CLAUDE_PROJECT_DIR are not the guard's jurisdiction (auto-memory,
+    # ``/tmp``, ``/dev``, skill installs). Short-circuit before the
+    # customer-notes / allow-list checks.
+    if _is_outside_project(path):
+        return None, None
+
+    # Issue #205 + #206: known harness write surfaces always proceed,
+    # even when expressed as a relative path that happens to begin with
+    # ``/tmp`` or ``/dev`` (defence-in-depth — _normalise turns absolute
+    # outside-project paths into absolute form, but a caller passing
+    # ``/dev/null`` literally would already have hit the
+    # _is_outside_project branch).
+    if _is_harness_path(path):
         return None, None
 
     # Customer-notes paths defer to customer-notes-guard. We do not
@@ -734,8 +863,24 @@ def _decide_for_command(command: str):
 
     off_list = []
     for t in targets:
+        # Pre-normalisation filter for harness device paths (issue #206):
+        # ``/dev/(null|stdout|stderr|fd/N|zero|random|urandom)`` and the
+        # broader ``/dev/**`` surface are not authoring targets. The
+        # _is_harness_path check below catches these via the ``/dev/``
+        # prefix, but doing the check on the raw token avoids any
+        # mis-normalisation surprises when the redirect target is bare
+        # like ``/dev/null`` (already absolute).
+        if _is_harness_path(t):
+            continue
         norm = _normalise(t)
         if not norm:
+            continue
+        # Issue #205: outside-project absolute targets are out of HR-8
+        # scope. ``_normalise`` returns the absolute form for these;
+        # ``_is_outside_project`` recognises them.
+        if _is_outside_project(t):
+            continue
+        if _is_harness_path(norm):
             continue
         if _is_customer_notes_path(norm):
             # Defer to customer-notes-guard.

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1637,6 +1637,177 @@ if [[ $dry_run -eq 0 && -f "$customizations_file" ]]; then
   fi
 fi
 
+# --- Additive merge for .claude/settings.json hook wiring (issue #201) --------
+# The framework ships PreToolUse hooks (tech-lead-authoring-guard.py,
+# customer-notes-guard.py) and SessionStart reminder hooks via
+# scripts/hooks/, but `.claude/settings.json` is customarily customised
+# by downstream projects (env, permissions, allow / deny lists). It
+# therefore lands in the `preserved` / `conflicts` bucket above and the
+# upstream hook wiring never reaches the file. Result: shipped-but-dead
+# hooks; Hard Rule #8 unenforced at the tool layer.
+#
+# Fix: after the main sync, parse the project's existing settings.json
+# and additively merge any missing framework hook entries (de-duped by
+# `command`). Existing customer entries — env, permissions, custom
+# hooks — are preserved verbatim; only missing framework hooks are added.
+# Idempotent: re-running the upgrade with all framework hooks already
+# present is a no-op.
+#
+# The merge runs in-process via a small Python helper (json module
+# only, no extra deps). It is gated on:
+#   - $dry_run -eq 0
+#   - The framework's source settings.json (workdir/new/.claude/settings.json)
+#     being present
+#   - The downstream's settings.json being present (if absent, the
+#     normal sync flow above already installed the framework copy
+#     verbatim, so no merge needed)
+upstream_settings="$workdir/new/.claude/settings.json"
+project_settings="$project_root/.claude/settings.json"
+if [[ $dry_run -eq 0 && -f "$upstream_settings" && -f "$project_settings" ]]; then
+  settings_merge_log="$(mktemp -t settings-merge-XXXXXX.log)"
+  if python3 - "$upstream_settings" "$project_settings" >"$settings_merge_log" 2>&1 <<'PYMERGE'
+"""Additive merge of framework hook entries into project settings.json.
+
+Reads two file paths from argv: the framework's settings.json (source
+of truth for hook wiring) and the project's settings.json (preserved
+otherwise). Merges missing PreToolUse and SessionStart hooks into the
+project file in place, de-duped by the inner hook ``command`` string.
+Prints a one-line summary per added entry; exit code 0 on success
+(including the no-op case) or 1 on parse error.
+"""
+import json
+import os
+import sys
+
+
+def _command_set(hook_entry):
+    """Set of inner-hook `command` strings for one matcher entry."""
+    out = set()
+    for hk in hook_entry.get("hooks", []) or []:
+        cmd = hk.get("command")
+        if isinstance(cmd, str):
+            out.add(cmd)
+    return out
+
+
+def _entry_key(entry):
+    """Match key for a PreToolUse / SessionStart top-level entry.
+
+    PreToolUse entries discriminate on ``matcher`` (e.g. ``"Write"``).
+    SessionStart entries may have no matcher (the bare default) or a
+    ``"compact"`` matcher. Use the literal matcher (or "" sentinel) so
+    same-matcher framework entries merge into same-matcher project
+    entries instead of being duplicated.
+    """
+    return entry.get("matcher", "") or ""
+
+
+def _merge_hook_section(project_section, upstream_section, section_label):
+    """Merge upstream_section hook entries into project_section in place.
+
+    Returns a list of human-readable strings describing each change.
+    """
+    changes = []
+    project_by_key = {_entry_key(e): e for e in project_section}
+    for up_entry in upstream_section:
+        key = _entry_key(up_entry)
+        if key in project_by_key:
+            proj_entry = project_by_key[key]
+            existing = _command_set(proj_entry)
+            for up_hook in up_entry.get("hooks", []) or []:
+                if not isinstance(up_hook, dict):
+                    continue
+                cmd = up_hook.get("command")
+                if not isinstance(cmd, str) or cmd in existing:
+                    continue
+                proj_entry.setdefault("hooks", []).append(up_hook)
+                existing.add(cmd)
+                label = key if key else "(no matcher)"
+                changes.append(
+                    "{}[{}]: added hook {}".format(section_label, label, cmd)
+                )
+        else:
+            project_section.append(up_entry)
+            label = key if key else "(no matcher)"
+            changes.append(
+                "{}[{}]: added matcher entry".format(section_label, label)
+            )
+            project_by_key[key] = up_entry
+    return changes
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: merge_settings.py <upstream> <project>\n")
+        return 2
+    upstream_path, project_path = sys.argv[1], sys.argv[2]
+    with open(upstream_path, "r", encoding="utf-8") as fh:
+        upstream = json.load(fh)
+    with open(project_path, "r", encoding="utf-8") as fh:
+        project = json.load(fh)
+
+    upstream_hooks = (upstream.get("hooks") or {})
+    project_hooks = project.setdefault("hooks", {})
+
+    all_changes = []
+    for section in ("PreToolUse", "SessionStart"):
+        up_section = upstream_hooks.get(section)
+        if not isinstance(up_section, list):
+            continue
+        proj_section = project_hooks.setdefault(section, [])
+        if not isinstance(proj_section, list):
+            sys.stderr.write(
+                "WARN: project hooks.{} is not a list; skipping section.\n".format(
+                    section
+                )
+            )
+            continue
+        all_changes.extend(
+            _merge_hook_section(proj_section, up_section, section)
+        )
+
+    if not all_changes:
+        print("settings.json: framework hook wiring already current; no changes.")
+        return 0
+
+    # Write atomically: tmp + rename.
+    tmp_path = project_path + ".tmp." + str(os.getpid())
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        json.dump(project, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp_path, project_path)
+    print("settings.json: merged {} framework hook entr{} into project file:".format(
+        len(all_changes), "y" if len(all_changes) == 1 else "ies"
+    ))
+    for line in all_changes:
+        print("  + " + line)
+    return 0
+
+
+sys.exit(main())
+PYMERGE
+  then
+    merge_rc=0
+  else
+    merge_rc=$?
+  fi
+  if [[ $merge_rc -eq 0 ]]; then
+    # Surface the merge summary to the upgrade report.
+    if grep -q '^settings.json: merged' "$settings_merge_log" 2>/dev/null; then
+      echo "ACTION NOTICE: framework hook wiring merged into .claude/settings.json (issue #201):"
+      sed 's/^/  /' "$settings_merge_log"
+    fi
+    # Quiet "no changes" case stays silent; the upgrade report is
+    # otherwise unaffected.
+  else
+    echo "WARN: settings.json additive merge failed (rc=$merge_rc); leaving project file unchanged." >&2
+    sed 's/^/  /' "$settings_merge_log" >&2
+  fi
+  rm -f "$settings_merge_log"
+elif [[ $dry_run -eq 1 && -f "$upstream_settings" && -f "$project_settings" ]]; then
+  echo "(dry-run: would additively merge framework hook entries into .claude/settings.json if any are missing — issue #201)" >&2
+fi
+
 # Stamp the new TEMPLATE_VERSION (only if not dry-run AND there are no conflicts,
 # OR if the user accepts leaving conflicts in place — we do the latter by default).
 if [[ $dry_run -eq 0 ]]; then

--- a/tests/hooks/test-customer-notes-guard.sh
+++ b/tests/hooks/test-customer-notes-guard.sh
@@ -200,6 +200,44 @@ _run_payload "write: file_path tool input" \
 _run_payload "write: nested docs/customer-notes path" \
     "$(mkpayload_path docs/customer-notes/CUSTOMER_NOTES.md)" fire
 
+# ---------------------------------------------------------------------------
+# pathlib write detection (issue #184). Mirror coverage from the sister
+# hook so write_text / write_bytes / Path.open("w") on CUSTOMER_NOTES.md
+# are caught by this hook too.
+# ---------------------------------------------------------------------------
+
+run_cmd_case "write: python3 -c Path.write_text on file (#184)" \
+    "python3 -c 'import pathlib; pathlib.Path(\"CUSTOMER_NOTES.md\").write_text(\"x\")'" fire
+
+run_cmd_case "write: python3 -c Path.write_bytes on file (#184)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").write_bytes(b\"x\")'" fire
+
+run_cmd_case "write: python3 -c Path.open('w') on file (#184)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").open(\"w\").write(\"x\")'" fire
+
+run_cmd_case "write: python3 -c Path.open(mode='w') on file (#184)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").open(mode=\"w\").write(\"x\")'" fire
+
+run_cmd_case "write: python3 heredoc Path.write_text (#184)" \
+    'python3 <<PY
+from pathlib import Path
+Path("CUSTOMER_NOTES.md").write_text("x")
+PY' fire
+
+# Read forms must still proceed.
+run_cmd_case "read: python3 -c Path.read_text on file (#184 negative)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").read_text()'" proceed
+
+run_cmd_case "read: python3 -c Path.open('r') on file (#184 negative)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").open(\"r\").read()'" proceed
+
+run_cmd_case "read: python3 -c Path.open(mode='r') on file (#184 negative)" \
+    "python3 -c 'from pathlib import Path; Path(\"CUSTOMER_NOTES.md\").open(mode=\"r\").read()'" proceed
+
+# Different filename must not trigger.
+run_cmd_case "read: Path.write_text on a different file (#184 negative)" \
+    "python3 -c 'from pathlib import Path; Path(\"OTHER.md\").write_text(\"x\")'" proceed
+
 echo
 echo "customer-notes-guard self-test: $pass passed, $fail failed."
 if [ "$fail" -gt 0 ]; then

--- a/tests/hooks/test-settings-merge.sh
+++ b/tests/hooks/test-settings-merge.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# Self-test for the additive .claude/settings.json merge embedded in
+# scripts/upgrade.sh (issue #201). Extracts the inline python helper
+# from upgrade.sh and exercises it against fixtures that mirror real
+# downstream-project shapes:
+#
+#   - rc8-era project (only SessionStart customer hook present, no
+#     PreToolUse) → expect 4 PreToolUse entries + 2 missing SessionStart
+#     hooks added; customer entries preserved.
+#   - already-current project → expect no changes.
+#   - missing-hooks-block (no `hooks` key at all) → expect both
+#     PreToolUse and SessionStart sections added from upstream.
+#
+# Mirrors test-customer-notes-guard.sh / test-tech-lead-authoring-guard.sh
+# style: pass/fail accounting with a final summary, exit non-zero on
+# any failure.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+UPGRADE_SH="$REPO_ROOT/scripts/upgrade.sh"
+UPSTREAM_SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+pass=0
+fail=0
+failures=()
+
+# Extract the embedded merge helper from upgrade.sh into a tmp file so
+# we can drive it standalone. The python heredoc is delimited by
+# <<'PYMERGE' ... PYMERGE — sed extracts everything between those lines.
+tmp_helper="$(mktemp -t settings-merge-XXXXXX.py)"
+trap 'rm -f "$tmp_helper"' EXIT
+awk '/^PYMERGE$/{flag=0} flag{print} /<<.PYMERGE.$/{flag=1}' "$UPGRADE_SH" > "$tmp_helper"
+if [ ! -s "$tmp_helper" ]; then
+    echo "FAIL  could not extract PYMERGE helper from $UPGRADE_SH"
+    exit 1
+fi
+
+# run_case <name> <fixture-builder-callback> <expect-changed: yes|no> <jq-check-callback>
+#
+# fixture-builder writes a JSON object to $project_settings; jq-check is
+# a bash function that takes $project_settings (post-merge) and returns
+# 0 on success, non-zero on failure (printing diagnostics).
+run_case() {
+    local name=$1
+    local builder=$2
+    local expect_changed=$3
+    local checker=$4
+
+    local dir
+    dir="$(mktemp -d)"
+    local project_settings="$dir/settings.json"
+
+    # Invoke the builder so it writes the project-side starting state.
+    "$builder" "$project_settings"
+
+    local helper_out
+    helper_out="$(python3 "$tmp_helper" "$UPSTREAM_SETTINGS" "$project_settings" 2>&1)"
+    local helper_rc=$?
+
+    local actual_changed
+    if printf '%s\n' "$helper_out" | grep -q '^settings.json: framework hook wiring already current'; then
+        actual_changed="no"
+    elif printf '%s\n' "$helper_out" | grep -q '^settings.json: merged'; then
+        actual_changed="yes"
+    else
+        actual_changed="unknown"
+    fi
+
+    local ok=1
+    if [ "$helper_rc" -ne 0 ]; then
+        ok=0
+    fi
+    if [ "$actual_changed" != "$expect_changed" ]; then
+        ok=0
+    fi
+    if [ "$ok" -eq 1 ] && [ -n "$checker" ]; then
+        if ! "$checker" "$project_settings"; then
+            ok=0
+        fi
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        pass=$((pass + 1))
+        echo "PASS  $name"
+    else
+        fail=$((fail + 1))
+        failures+=("$name (expected_changed=$expect_changed actual_changed=$actual_changed rc=$helper_rc)")
+        echo "FAIL  $name (expected_changed=$expect_changed actual_changed=$actual_changed rc=$helper_rc)"
+        printf '      helper output:\n%s\n' "$helper_out" | sed 's/^/      /'
+    fi
+
+    rm -rf "$dir"
+}
+
+# Fixture builders --------------------------------------------------------
+
+# rc8-era downstream: only the SessionStart version-check hook present,
+# permissions block populated, no PreToolUse entries at all.
+build_rc8_style() {
+    cat > "$1" <<'JSON'
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Read",
+      "Bash(ls *)"
+    ],
+    "deny": [
+      "Bash(rm *)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x ./scripts/version-check.sh ] && ./scripts/version-check.sh 2>&1 || true",
+            "timeout": 10,
+            "statusMessage": "Checking template version..."
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+}
+
+# Already-current downstream: full framework hook wiring already present.
+build_current_style() {
+    cp "$UPSTREAM_SETTINGS" "$1"
+}
+
+# Missing-hooks block entirely: a downstream that only configured
+# permissions / env, no hooks block at all.
+build_no_hooks_block() {
+    cat > "$1" <<'JSON'
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": ["Read"]
+  }
+}
+JSON
+}
+
+# Mixed: some PreToolUse already wired (Write only) — merge should add
+# Edit / MultiEdit / Bash but leave Write intact and not duplicate.
+build_partial_pretooluse() {
+    cat > "$1" <<'JSON'
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/customer-notes-guard.py\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PROJECT_DIR}/scripts/hooks/tech-lead-authoring-guard.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+}
+
+# Checkers --------------------------------------------------------------
+
+# Generic: verify the post-merge file contains the 4 framework
+# PreToolUse matchers and the framework's SessionStart hooks.
+check_full_framework_wiring() {
+    local f=$1
+    python3 - "$f" <<'PYCHK'
+import json, sys
+with open(sys.argv[1]) as fh:
+    s = json.load(fh)
+hooks = s.get("hooks", {})
+pretool = hooks.get("PreToolUse", [])
+matchers = {e.get("matcher") for e in pretool}
+need = {"Write", "Edit", "MultiEdit", "Bash"}
+if not need.issubset(matchers):
+    sys.stderr.write("missing PreToolUse matchers: %s\n" % (need - matchers))
+    sys.exit(1)
+# Each matcher entry must reference both guards.
+for entry in pretool:
+    cmds = [h.get("command", "") for h in entry.get("hooks", [])]
+    if not any("tech-lead-authoring-guard.py" in c for c in cmds):
+        sys.stderr.write("PreToolUse[%s] missing tech-lead-authoring-guard\n" % entry.get("matcher"))
+        sys.exit(1)
+    if not any("customer-notes-guard.py" in c for c in cmds):
+        sys.stderr.write("PreToolUse[%s] missing customer-notes-guard\n" % entry.get("matcher"))
+        sys.exit(1)
+sess = hooks.get("SessionStart", [])
+all_cmds = []
+for e in sess:
+    for h in e.get("hooks", []):
+        all_cmds.append(h.get("command", ""))
+joined = "\n".join(all_cmds)
+need_substrings = ("atomic-question-reminder", "role-routing-reminder")
+for s_ in need_substrings:
+    if s_ not in joined:
+        sys.stderr.write("missing SessionStart hook substring: %s\n" % s_)
+        sys.exit(1)
+PYCHK
+}
+
+# rc8-style: also verify the customer's env + permissions block survived
+# the merge, and the customer's version-check hook is still present.
+check_customer_preserved() {
+    local f=$1
+    if ! check_full_framework_wiring "$f"; then return 1; fi
+    python3 - "$f" <<'PYCHK'
+import json, sys
+with open(sys.argv[1]) as fh:
+    s = json.load(fh)
+if s.get("env", {}).get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") != "1":
+    sys.stderr.write("customer env not preserved\n")
+    sys.exit(1)
+allow = s.get("permissions", {}).get("allow") or []
+deny = s.get("permissions", {}).get("deny") or []
+if "Read" not in allow or "Bash(ls *)" not in allow:
+    sys.stderr.write("customer permissions.allow not preserved\n")
+    sys.exit(1)
+if "Bash(rm *)" not in deny:
+    sys.stderr.write("customer permissions.deny not preserved\n")
+    sys.exit(1)
+PYCHK
+}
+
+# partial: Write entry must NOT have duplicate guard commands.
+check_no_duplicate_write_hooks() {
+    local f=$1
+    if ! check_full_framework_wiring "$f"; then return 1; fi
+    python3 - "$f" <<'PYCHK'
+import json, sys
+with open(sys.argv[1]) as fh:
+    s = json.load(fh)
+pretool = s["hooks"]["PreToolUse"]
+write_entries = [e for e in pretool if e.get("matcher") == "Write"]
+if len(write_entries) != 1:
+    sys.stderr.write("expected 1 Write entry, got %d\n" % len(write_entries))
+    sys.exit(1)
+cmds = [h.get("command") for h in write_entries[0].get("hooks", [])]
+# Each guard must appear exactly once.
+for needle in ("tech-lead-authoring-guard.py", "customer-notes-guard.py"):
+    count = sum(1 for c in cmds if needle in c)
+    if count != 1:
+        sys.stderr.write("%s appears %d times under Write (expected 1)\n" % (needle, count))
+        sys.exit(1)
+PYCHK
+}
+
+# Verifies no rewrite — file content unchanged from build_current_style.
+check_unchanged_from_upstream() {
+    local f=$1
+    if ! diff -q "$f" "$UPSTREAM_SETTINGS" >/dev/null 2>&1; then
+        # The merge may have re-pretty-printed; compare canonical JSON.
+        python3 - "$f" "$UPSTREAM_SETTINGS" <<'PYCHK'
+import json, sys
+with open(sys.argv[1]) as a, open(sys.argv[2]) as b:
+    aj = json.load(a); bj = json.load(b)
+if aj != bj:
+    sys.stderr.write("post-merge file differs from upstream after no-op merge\n")
+    sys.exit(1)
+PYCHK
+    fi
+}
+
+# Test cases -----------------------------------------------------------
+
+run_case "rc8-style downstream: full framework wiring added, customer preserved" \
+    build_rc8_style yes check_customer_preserved
+
+run_case "already-current downstream: no-op merge" \
+    build_current_style no check_unchanged_from_upstream
+
+run_case "no hooks block at all: PreToolUse + SessionStart added" \
+    build_no_hooks_block yes check_full_framework_wiring
+
+run_case "partial PreToolUse (Write only): missing matchers added, Write not duplicated" \
+    build_partial_pretooluse yes check_no_duplicate_write_hooks
+
+# Idempotency: re-running merge after a successful merge is a no-op.
+idempotency_dir="$(mktemp -d)"
+trap 'rm -f "$tmp_helper"; rm -rf "$idempotency_dir"' EXIT
+idempotency_file="$idempotency_dir/settings.json"
+build_rc8_style "$idempotency_file"
+python3 "$tmp_helper" "$UPSTREAM_SETTINGS" "$idempotency_file" >/dev/null 2>&1
+first_rc=$?
+second_out="$(python3 "$tmp_helper" "$UPSTREAM_SETTINGS" "$idempotency_file" 2>&1)"
+second_rc=$?
+if [ "$first_rc" -eq 0 ] && [ "$second_rc" -eq 0 ] \
+   && printf '%s' "$second_out" | grep -q '^settings.json: framework hook wiring already current'; then
+    pass=$((pass + 1))
+    echo "PASS  idempotency: second merge is a no-op"
+else
+    fail=$((fail + 1))
+    failures+=("idempotency: second merge should be no-op (first_rc=$first_rc second_rc=$second_rc out=$second_out)")
+    echo "FAIL  idempotency: second merge should be no-op"
+fi
+
+echo
+echo "settings-merge self-test: $pass passed, $fail failed."
+if [ "$fail" -gt 0 ]; then
+    echo
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+exit 0

--- a/tests/hooks/test-tech-lead-authoring-guard.sh
+++ b/tests/hooks/test-tech-lead-authoring-guard.sh
@@ -649,6 +649,139 @@ run_case "issue#180 regression: python3 -c open(..., 'w') still denies" "" \
     deny
 
 # ---------------------------------------------------------------------------
+# Upstream issue #184 — pathlib write coverage. Path("x").write_text(...),
+# Path("x").write_bytes(...), and Path("x").open("w"|mode="w") were
+# previously not detected as writes.
+# ---------------------------------------------------------------------------
+
+run_case "issue#184: python3 -c Path(p).write_text denies" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').write_text('"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 -c Path(p).write_bytes denies" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').write_bytes(b'"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 -c pathlib.Path(p).write_text denies" "" \
+    '{"tool_input":{"command":"python3 -c \"import pathlib; pathlib.Path('"'"'src/foo.py'"'"').write_text('"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 -c Path(p).open('w') denies" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').open('"'"'w'"'"').write('"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 -c Path(p).open(mode='w') denies" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').open(mode='"'"'w'"'"').write('"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 -c Path(p).open('a') denies (append mode)" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').open('"'"'a'"'"').write('"'"'x'"'"')\""}}' \
+    deny
+
+run_case "issue#184: python3 heredoc Path.write_text denies" "" \
+    '{"tool_input":{"command":"python3 <<EOF\nfrom pathlib import Path\nPath('"'"'src/foo.py'"'"').write_text('"'"'x'"'"')\nEOF"}}' \
+    deny
+
+run_case "issue#184: Path(p).write_text on allow-listed target proceeds" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'docs/OPEN_QUESTIONS.md'"'"').write_text('"'"'x'"'"')\""}}' \
+    proceed
+
+# Negative — read-only pathlib does NOT trip.
+run_case "issue#184 negative: Path(p).read_text proceeds" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').read_text()\""}}' \
+    proceed
+
+run_case "issue#184 negative: Path(p).open('r') proceeds" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').open('"'"'r'"'"').read()\""}}' \
+    proceed
+
+run_case "issue#184 negative: Path(p).open(mode='r') proceeds" "" \
+    '{"tool_input":{"command":"python3 -c \"from pathlib import Path; Path('"'"'src/foo.py'"'"').open(mode='"'"'r'"'"').read()\""}}' \
+    proceed
+
+# ---------------------------------------------------------------------------
+# Upstream issue #205 — HR-8 is project-scoped. Absolute paths outside
+# CLAUDE_PROJECT_DIR are not the guard's jurisdiction (auto-memory, /tmp,
+# skill installation). All three previously denied; now proceed.
+# ---------------------------------------------------------------------------
+
+run_case "issue#205: write to /tmp/foo proceeds (outside project)" "" \
+    '{"tool_input":{"file_path":"/tmp/foo","content":"x"}}' \
+    proceed
+
+run_case "issue#205: write to /tmp/nested/dir/file proceeds" "" \
+    '{"tool_input":{"file_path":"/tmp/issues.json","content":"x"}}' \
+    proceed
+
+# Auto-memory path — under ~/.claude/projects/**/memory/**.
+run_case "issue#205: auto-memory write (~/.claude/projects/...) proceeds" "" \
+    "$(python3 -c 'import json, os; print(json.dumps({"tool_input":{"file_path":os.path.expanduser("~/.claude/projects/-home-quackdcs-test/memory/notes.md"),"content":"x"}}))')" \
+    proceed
+
+run_case "issue#205: MEMORY.md index update proceeds" "" \
+    "$(python3 -c 'import json, os; print(json.dumps({"tool_input":{"file_path":os.path.expanduser("~/.claude/projects/-home-quackdcs-test/memory/MEMORY.md"),"content":"x"}}))')" \
+    proceed
+
+# Skill installation under ~/.claude/skills.
+run_case "issue#205: skill installation (~/.claude/skills/...) proceeds" "" \
+    "$(python3 -c 'import json, os; print(json.dumps({"tool_input":{"file_path":os.path.expanduser("~/.claude/skills/my-skill/skill.md"),"content":"x"}}))')" \
+    proceed
+
+# Bash redirect to /tmp must also proceed (issue #205).
+run_case "issue#205: bash redirect to /tmp/issues.json proceeds" "" \
+    '{"tool_input":{"command":"gh issue list > /tmp/issues.json"}}' \
+    proceed
+
+# Regression: project-scoped path still denies.
+run_case "issue#205 regression: in-project src/foo.py still denies" "" \
+    '{"tool_input":{"file_path":"src/foo.py","content":"x"}}' \
+    deny
+
+# Absolute path INSIDE the project tree still denies.
+run_case "issue#205 regression: absolute-in-project src path still denies" "" \
+    "$(python3 -c 'import json, os; print(json.dumps({"tool_input":{"file_path":os.path.join(os.environ.get("CLAUDE_PROJECT_DIR",""),"src","foo.py"),"content":"x"}}))')" \
+    deny
+
+# ---------------------------------------------------------------------------
+# Upstream issue #206 — /dev/* device paths are not authoring targets.
+# Redirects to /dev/null, /dev/stdout, /dev/stderr, /dev/fd/N must proceed.
+# ---------------------------------------------------------------------------
+
+run_case "issue#206: bash redirect to /dev/null proceeds" "" \
+    '{"tool_input":{"command":"some-command > /dev/null"}}' \
+    proceed
+
+run_case "issue#206: bash redirect to /dev/null with stderr proceeds" "" \
+    '{"tool_input":{"command":"some-command 2>/dev/null"}}' \
+    proceed
+
+run_case "issue#206: bash redirect to /dev/stderr proceeds" "" \
+    '{"tool_input":{"command":"echo bad >/dev/stderr"}}' \
+    proceed
+
+run_case "issue#206: bash redirect to /dev/stdout proceeds" "" \
+    '{"tool_input":{"command":"echo good >/dev/stdout"}}' \
+    proceed
+
+run_case "issue#206: bash redirect to /dev/fd/2 proceeds" "" \
+    '{"tool_input":{"command":"some-command >/dev/fd/2"}}' \
+    proceed
+
+run_case "issue#206: 2>&1 + > /dev/null proceeds" "" \
+    '{"tool_input":{"command":"some-command 2>&1 > /dev/null"}}' \
+    proceed
+
+run_case "issue#206: tee > /dev/null suppression proceeds" "" \
+    '{"tool_input":{"command":"some-command | tee /tmp/log > /dev/null"}}' \
+    proceed
+
+# Combined: redirect to /dev/null PLUS an off-list write — the off-list
+# write still denies. The /dev/null filter must not mask the real write.
+run_case "issue#206 regression: /dev/null + off-list write denies (off-list flagged)" "" \
+    '{"tool_input":{"command":"echo x > src/foo.py 2>/dev/null"}}' \
+    deny
+
+# ---------------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

PR-A of the open-issue burndown — closes four issues in the release-gate hook-behavior bucket.

## Closes

- Closes #201 — `.claude/settings.json` PreToolUse + SessionStart hook wiring missing on rc8→rc13 upgrade (root cause of QuackDCS-class downstream incident)
- Closes #184 — hook coverage gap on `pathlib.Path.write_text()` / `Path(...).open('w')`
- Closes #205 — `tech-lead-authoring-guard.py` denies absolute paths outside `CLAUDE_PROJECT_DIR` (HR-8 should be project-scoped)
- Closes #206 — `tech-lead-authoring-guard.py` denies `> /dev/null` and `/dev/*` redirect targets (false-positive on device path)

## Changes

- `scripts/upgrade.sh` (+171) — additive PreToolUse merge for downstream `.claude/settings.json` on upgrade. Embedded Python merge helper as `<<'PYMERGE'` heredoc (per existing in-script pattern; test extracts and validates via `awk`)
- `scripts/hooks/tech-lead-authoring-guard.py` (+154 / -9 net of fixup) — `_is_outside_project` + `_is_harness_path` two-layer allow-list; `pathlib` write detection; `/dev/*` device filter pre-normalisation
- `scripts/hooks/customer-notes-guard.py` (+27 / -1) — `pathlib` write detection (mirrored)
- `docs/adr/fw-adr-0012-tech-lead-authoring-guard.md` (+19) — addendum naming the harness exceptions and the raw-vs-normalised filter ordering
- `tests/hooks/test-tech-lead-authoring-guard.sh` (+133, 131 total cases)
- `tests/hooks/test-customer-notes-guard.sh` (+38, 43 total cases)
- `tests/hooks/test-settings-merge.sh` (new, 332 lines, 5 cases)

## Implementation notes

- **#201 dedupe key**: full `command` string. Stale customer-side hook forms (e.g. rc8-era `./scripts/version-check.sh`) survive alongside the framework's current form. Idempotent at runtime. Semantic-match was rejected as too aggressive — risks shadowing legitimate customer additions.
- **#205 / #206 two-layer allow-list**: `_is_outside_project()` (pure project-scope) and `_is_harness_path()` (named-surface list: `/tmp`, `/dev`, `~/.claude/projects/`, `~/.claude/skills/`) as separate predicates. The Bash-target device filter (`/dev/*`) applies BEFORE normalisation so `/dev/null` is never expanded against `CLAUDE_PROJECT_DIR`.
- **#184 pathlib coverage**: detects `Path`/`PurePath`/`PosixPath`/`WindowsPath`, bare and `pathlib.`-qualified; `write_text`/`write_bytes` unconditional; `Path(...).open(...)` mirrors the existing mode-char set.
- **Markdown-codeblock stripping** (bonus for #206): not implemented in this PR. The `/dev/*` allow-list already handles the meta-irony case (a `/dev/null` mentioned inside an issue body would not trip the guard). A non-`/dev` path inside a fenced block can still false-positive; deferred as a separate framework issue.

## Test plan

- [x] `tests/hooks/test-tech-lead-authoring-guard.sh` — 131/131 PASS
- [x] `tests/hooks/test-customer-notes-guard.sh` — 43/43 PASS
- [x] `tests/hooks/test-settings-merge.sh` — 5/5 PASS (new)
- [x] `scripts/smoke-test.sh` — 174/174 PASS (no regression)
- [x] code-reviewer: APPROVED-WITH-CHANGES (1 blocking + 3 non-blocking); respin commit `6e148e5` addressed blocking + 1 adjacent non-blocking; re-review APPROVED.

## Follow-up issues filed during this PR

- #207 — agent contracts ship with `model: inherit`; binding default-class table unenforced (rides PR-G in same burndown)
- #208 — `CLAUDE_PROJECT_DIR`-unset fallback path unexercised in tests (framework-friction; CR non-blocking #2)

## Framework-level observations (not addressed here)

- Concurrency hazard: parallel agents sharing one checkout fight over the working tree (observed twice this session — a stash race and a misplaced commit). Worktree-per-dispatch would prevent. Worth a separate framework issue.
- Markdown-codeblock stripping for the Bash-body scanner — deferred.
- Stale customer-version-check hook detection (a one-time `migrations/<version>.sh`-style cleanup) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)