### PR TITLE
docs(roadmap): create V2 deferred section + close #202

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -367,3 +367,11 @@ Things that may interrupt the linear plan:
 | 2026-05-04 | Tagged and pushed v1.0.0-rc6 for #84, #104, and #105; final remains blocked on downstream validation and the checklist gates. | `release-engineer` |
 | 2026-05-04 | Prepared v1.0.0-rc7 candidate for issue #116 concise specialist-brief/no-full-context-fork scope; Claude Code / Codex parity evidence remains a final gate. | `release-engineer` |
 | 2026-05-06 | Added v1.0.0-rc8 release-state boundary for upgrade-flow, hook, Codex-adapter, and CLAUDE.md size-cull fixes; final now depends on the rc8/final-checklist state. | `tech-writer` |
+
+## V2 deferred
+
+Issues filed against the v1.0.0 framework that require harness-level changes, architectural pivots, or capability beyond v1.0.0's scope. Each entry links its issue and a one-line rationale. v2 work tracking begins here; new entries land via the standard `defer-to-v2` disposition path (FR-006 of `specs/011-issue-backlog-triage/spec.md`).
+
+| Issue | Title | Rationale for v2 deferral |
+|-------|-------|---------------------------|
+| [#202](https://github.com/occamsshavingkit/sw-dev-team-template/issues/202) | tech-lead authoring guard silently reverts specialist-agent writes in canonical scope | Fix requires Claude Code harness to expose agent identity (e.g., `CLAUDE_AGENT_TYPE` env var) in PreToolUse events. No such surface exists today. FW-ADR-0012 § ADR-internal follow-ups already records this as a known v1.0.0 deferred item. Current mitigation: tech-lead applies as tool-bridge with `SWDT_AGENT_PUSH=<role>` inline. Architect disposition 2026-05-16. |


### PR DESCRIPTION
## Summary

Creates the `## V2 deferred` anchor section in `ROADMAP.md` per Q2 ruling and FR-006 of `specs/011-issue-backlog-triage/spec.md`. First entry: #202.

## Closes

- Closes #202 — tech-lead authoring guard silently reverts specialist-agent writes in canonical scope (defer-to-v2)

## Architect verdict 2026-05-16

Issue #202 is real and still reproducible against current `main` (PR #210 / PR-A added project-scope and harness-path predicates but did NOT address the sub-agent-identity gap). Fix requires Claude Code harness to expose agent identity (e.g., `CLAUDE_AGENT_TYPE` env var) in PreToolUse events — no such surface exists today.

FW-ADR-0012 § ADR-internal follow-ups already records this as a known v1.0.0 deferred item ("A sub-agent writing to a path it does not own is a separate violation class… Out of scope for v1"). Closing as `defer-to-v2` matches the ADR's recorded intent; closing as `wontfix` would contradict it.

Current mitigation: tech-lead applies as tool-bridge with `SWDT_AGENT_PUSH=<role>` inline on Bash; non-Bash specialists return their proposed diff to tech-lead for application. Observed working in 2026-05-16 burndown session.

When the harness exposes per-agent identity, `_agent_push_role()` in `scripts/hooks/tech-lead-authoring-guard.py` can be extended to read it and implicitly authorise writes whose path is owned by the named role per `_OWNERSHIP_RULES`. A new ADR would be required at that time.

## V2 deferred surface

The new section follows the pattern: one row per deferred issue with a one-line rationale. Future v2-deferrals append entries here and link `ROADMAP.md#v2-deferred` in their close-comment per FR-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)