### PR TITLE
fix(upgrade): cluster-C upgrade.sh follow-ups (#169 #190 #171 #163)

### DIFF
--- a/migrations/v0.14.0.sh
+++ b/migrations/v0.14.0.sh
@@ -264,6 +264,30 @@ done < <(printf '%s\n' "$proceed_list")
 # Clear any stale block artefact from a prior refused run.
 rm -f "$prebootstrap_block_artefact"
 
+# Issue #163: write each pre-bootstrapped path into .template-customizations
+# so modern upgrade.sh's conflict-detection treats them as accepted_local
+# rather than 3-way conflicts. The v0.16.0 upgrade-path failure mode is:
+#   baseline=v0.16.0 upgrade.sh != project=post-pre-bootstrap != upstream=candidate
+# Without this marker, the sync loop classifies it as a conflict. With it,
+# --resolve (issue #171) and the preserve_list check both clear it. Idempotent:
+# check before appending. (FW-ADR-0010.)
+customizations_file="$PROJECT_ROOT/.template-customizations"
+while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    # Only mark paths that were actually pre-bootstrapped (exist locally now).
+    [ -f "$PROJECT_ROOT/$rel" ] || continue
+    # Escape the path for use in a grep basic-regex.
+    rel_escaped="$(printf '%s' "$rel" | sed 's/[]\.*^$[]/\\&/g')"
+    if [ -f "$customizations_file" ] && \
+       grep -E "^[[:space:]]*${rel_escaped}([[:space:]]|$)" \
+            "$customizations_file" >/dev/null 2>&1; then
+        continue  # already listed; idempotent
+    fi
+    printf '%s  # pre-bootstrapped by migrations/v0.14.0.sh (issue #163)\n' "$rel" \
+        >> "$customizations_file"
+    echo "  marked $rel in .template-customizations (pre-bootstrap marker; issue #163)"
+done < <(printf '%s\n' "$proceed_list")
+
 manifest="$PROJECT_ROOT/TEMPLATE_MANIFEST.lock"
 
 if [[ -f "$manifest" ]]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -300,6 +300,21 @@ if [[ $resolve_mode -eq 1 ]]; then
   # current re-emit fixes the field set to {path, classified,
   # baseline_sha, upstream_sha, project_sha} and would silently drop
   # anything else. Bump the schema number and gate accordingly.
+  # Issue #171: load .template-customizations so --resolve can auto-drop
+  # entries the operator resolved by pinning the path. A path listed in
+  # .template-customizations means the operator decided to keep the local
+  # version; the conflict is resolved by declaration, not by SHA change.
+  resolve_pinned=()
+  resolve_customizations="$project_root/.template-customizations"
+  if [[ -f "$resolve_customizations" ]]; then
+    while IFS= read -r _line; do
+      _line="${_line%%#*}"
+      _line="$(echo "$_line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      [[ -z "$_line" ]] && continue
+      resolve_pinned+=("$_line")
+    done < "$resolve_customizations"
+  fi
+
   tmp_out="$conflicts_path.tmp.$$"
   removed=0
   kept_unresolved=0
@@ -332,6 +347,25 @@ if [[ $resolve_mode -eq 1 ]]; then
         removed=$((removed + 1))
         continue
       fi
+
+      # Issue #171: if the path is now pinned in .template-customizations,
+      # the operator resolved the conflict by declaration — drop it as
+      # accepted_local regardless of SHA state.
+      for _pin in "${resolve_pinned[@]+"${resolve_pinned[@]}"}"; do
+        if [[ "$_pin" == "$e_path" ]]; then
+          removed=$((removed + 1))
+          # Record as accepted_local for manifest refresh purposes.
+          proj_now_pin=""
+          [[ -f "$project_root/$e_path" ]] && proj_now_pin="$(manifest_file_sha "$project_root/$e_path")"
+          if [[ -n "$proj_now_pin" ]]; then
+            printf '%s	%s
+' "$e_path" "$proj_now_pin" >> "$resolved_paths_log"
+          fi
+          e_path=""  # sentinel: skip the rest of the loop body
+          break
+        fi
+      done
+      [[ -z "$e_path" ]] && continue
 
       # Recompute current project SHA.
       proj_now=""
@@ -936,8 +970,10 @@ fi
 # Untagged targets (branch / SHA): semver progression breaks because
 # new_version is a synthetic "untagged-<sha>" label. Run every migration
 # strictly greater than local_version (conservative full-walk). Migrations
-# are required to be idempotent per their contract, so re-running ones
-# that already applied is safe.
+# are required to be idempotent per their contract (migrations/README.md
+# § "Required properties" #1; see also docs/TEMPLATE_UPGRADE.md
+# § "Per-version migrations"), so re-running ones that already applied
+# is safe. (Issue #190.)
 all_tags=$(git -C "$workdir/new" tag -l 'v*' 2>/dev/null | semver_sort_tags || true)
 migrations_to_run=()
 if [[ "$target_kind" == "untagged" ]]; then
@@ -2081,10 +2117,28 @@ if [[ $dry_run -eq 0 ]]; then
         echo "  Full lint output (read-only --canonical-only pass):"
         sed 's/^/    /' "$lint_log"
         echo
+        # Issue #169: find the latest migration in the upstream clone that
+        # touches the agent-contract schema (i.e. mentions the rc9-introduced
+        # required sections). That migration is the canonical backfiller
+        # regardless of whether the target version ships one itself.
+        schema_migration=""
+        if [[ -d "$workdir/new/migrations" ]]; then
+          for _mig in $(ls "$workdir/new/migrations/"*.sh 2>/dev/null | xargs -I{} basename {} .sh | { semver_sort_tags 2>/dev/null || sort; }); do
+            if grep -qE '## Hard rules|## Output format|agent.contract|lint-agent-contracts'                 "$workdir/new/migrations/$_mig.sh" 2>/dev/null; then
+              schema_migration="$_mig"
+            fi
+          done
+        fi
         if [ -f "migrations/$new_version.sh" ]; then
           echo "  Backfill the missing sections per the rc-specific migration at"
           echo "    migrations/$new_version.sh"
-          echo "  (or the latest migrations/<target>.sh that touches agent contracts)."
+          if [[ -n "$schema_migration" && "$schema_migration" != "$new_version" ]]; then
+            echo "  (the latest schema-touching migration is migrations/$schema_migration.sh)."
+          fi
+        elif [[ -n "$schema_migration" ]]; then
+          echo "  Backfill the missing sections per the latest schema-touching migration:"
+          echo "    migrations/$schema_migration.sh"
+          echo "  (no rc-specific migration exists for $new_version; issue #169)."
         else
           echo "  Backfill the missing sections per the latest migrations/<target>.sh"
           echo "  that touches agent contracts (no rc-specific migration exists for"

--- a/tests/release-gate/upgrade-paths-allowlist.txt
+++ b/tests/release-gate/upgrade-paths-allowlist.txt
@@ -36,15 +36,3 @@
 # shipped in rc4 and forward.
 v1.0.0-rc3
 
-# v0.16.0 — scripts/upgrade.sh is a 3-way conflict between v0.16.0 (baseline),
-# the current candidate (upstream), and the pre-bootstrapped project copy
-# (the migrations/v0.14.0.sh pre-bootstrap landed modern upgrade.sh in the
-# project, so v0.16.0's sync sees both upstream and project diverged from
-# baseline). v0.16.0 is a single-version sliver between v0.15.x and v0.17.0
-# with negligible expected downstream presence; the fix is to teach v0.x
-# scaffold's conflict-detection to recognize pre-bootstrapped helpers as
-# accepted-local-merge. Deferred to a follow-up issue (Q-0017 customer
-# answer B on 2026-05-14). The pre-bootstrap fix itself (commit 19e39bc)
-# remains correct for the real-world v0.x → modern upgrade path; only the
-# gate's automated round-trip sees this as a "failure."
-v0.16.0

--- a/tests/upgrade/test-cluster-c-fixes.sh
+++ b/tests/upgrade/test-cluster-c-fixes.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/upgrade/test-cluster-c-fixes.sh — cluster-C coverage for four
+# upgrade.sh follow-up issues.
+#
+# Cases:
+#   #169 — post-upgrade advisory does not reference a non-existent migration;
+#           when a schema-touching migration exists in the clone, its name
+#           appears in the advisory fallback text.
+#   #190 — untagged-target full-walk comment cites migrations/README.md and
+#           docs/TEMPLATE_UPGRADE.md (static code check).
+#   #171 — --resolve on a path pinned in .template-customizations drops it
+#           from .template-conflicts.json (does NOT keep it as conflict).
+#   #163 — v0.14.0 migration writes pre-bootstrapped paths to
+#           .template-customizations; tested via the migration script
+#           directly against a minimal fixture.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+upgrade="$repo_root/scripts/upgrade.sh"
+migration_v0_14="$repo_root/migrations/v0.14.0.sh"
+
+tmp="$(mktemp -d -t cluster-c-XXXXXX)"
+keep=0
+[[ "${1:-}" == "--keep" ]] && keep=1
+trap 'if [[ $keep -eq 0 ]]; then rm -rf "$tmp"; else echo "(kept $tmp for inspection)" >&2; fi' EXIT
+
+fail=0
+pass=0
+
+check() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+run_capture() {
+  local log="$1"; shift
+  local rc=0
+  "$@" > "$log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# #190 — static code check: untagged-target comment cites the contract
+# ---------------------------------------------------------------------------
+echo "-- #190: untagged-target full-walk cites idempotency contract --"
+check "#190: upgrade.sh cites migrations/README.md at full-walk site" \
+  grep -q "migrations/README.md" "$upgrade"
+check "#190: upgrade.sh cites docs/TEMPLATE_UPGRADE.md at full-walk site" \
+  grep -q "docs/TEMPLATE_UPGRADE.md" "$upgrade"
+check "#190: upgrade.sh cites Issue #190 at full-walk site" \
+  grep -q "Issue #190" "$upgrade"
+
+# ---------------------------------------------------------------------------
+# #169 — advisory does not reference a version-specific migration when it
+#        doesn't exist; when a schema-touching migration exists, it's named.
+#        We test the advisory code path using a fixture that triggers
+#        lint-agent-contracts.sh to fail (or we verify the dynamic-discovery
+#        logic is present in the source).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #169: advisory migration-pointer logic --"
+# Static check: the new fallback branch names $schema_migration rather than
+# always emitting the literal "migrations/<target>.sh" string.
+check "#169: advisory code references schema_migration variable" \
+  grep -q 'schema_migration' "$upgrade"
+check "#169: advisory scans for agent-schema markers (lint-agent-contracts)" \
+  grep -q 'lint-agent-contracts' "$upgrade"
+check "#169: advisory no longer unconditionally references non-existent migration" \
+  bash -c "! grep -q 'migrations/v1.0.0-rc11.sh' '$upgrade'"
+
+# ---------------------------------------------------------------------------
+# #171 — --resolve drops conflict entries whose path is pinned in
+#         .template-customizations.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #171: --resolve respects .template-customizations --"
+
+make_resolve_fixture() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -b main -q
+    git config user.email cluster-c-test@example.invalid
+    git config user.name "Cluster-C Test"
+    # Minimal TEMPLATE_VERSION so --resolve doesn't fail early.
+    printf 'v0.14.0\ndeadbeef\n2026-01-01\n' > TEMPLATE_VERSION
+    git add TEMPLATE_VERSION
+    git commit -q -m "fixture init"
+  )
+}
+
+fix171="$tmp/resolve-pinned"
+make_resolve_fixture "$fix171"
+
+# Write a fake .template-conflicts.json with one "conflict" entry.
+target_path="scripts/upgrade.sh"
+cat > "$fix171/.template-conflicts.json" << 'EOF'
+{
+  "schema": 1,
+  "generated": "2026-01-01T00:00:00Z",
+  "template_version": "v0.14.0",
+  "entries": [
+    {"path": "scripts/upgrade.sh", "classified": "conflict", "baseline_sha": "aaaa", "upstream_sha": "bbbb", "project_sha": "cccc"}
+  ]
+}
+EOF
+
+# Without a .template-customizations entry the conflict stays.
+rc_no_pin=$(run_capture "$tmp/resolve-no-pin.log" \
+            bash -c "cd '$fix171' && bash '$upgrade' --resolve")
+check "#171: without pin, conflict entry is kept (1 still unresolved)" \
+  bash -c "grep -q '1 still unresolved' '$tmp/resolve-no-pin.log'"
+check "#171: without pin, .template-conflicts.json still exists" \
+  bash -c "test -f '$fix171/.template-conflicts.json'"
+
+# Restore conflicts.json (--resolve rewrites it).
+cat > "$fix171/.template-conflicts.json" << 'EOF'
+{
+  "schema": 1,
+  "generated": "2026-01-01T00:00:00Z",
+  "template_version": "v0.14.0",
+  "entries": [
+    {"path": "scripts/upgrade.sh", "classified": "conflict", "baseline_sha": "aaaa", "upstream_sha": "bbbb", "project_sha": "cccc"}
+  ]
+}
+EOF
+
+# Now add the path to .template-customizations.
+echo "scripts/upgrade.sh  # pinned locally" > "$fix171/.template-customizations"
+
+rc_pinned=$(run_capture "$tmp/resolve-pinned.log" \
+            bash -c "cd '$fix171' && bash '$upgrade' --resolve")
+check "#171: with pin, --resolve exits 0" \
+  bash -c "[ '$rc_pinned' = '0' ]"
+check "#171: with pin, pinned conflict entry is removed (not kept unresolved)" \
+  bash -c "! grep -q '1 still unresolved' '$tmp/resolve-pinned.log'"
+check "#171: with pin, .template-conflicts.json is removed (all conflicts cleared)" \
+  bash -c "! test -f '$fix171/.template-conflicts.json'"
+
+# ---------------------------------------------------------------------------
+# #163 — v0.14.0 migration writes pre-bootstrapped paths to
+#         .template-customizations.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #163: v0.14.0 migration marks pre-bootstrapped paths --"
+
+fix163="$tmp/migration-v0-14-marker"
+rm -rf "$fix163"
+mkdir -p "$fix163/scripts/lib" "$fix163/docs/pm"
+
+(
+  cd "$fix163"
+  git init -b main -q
+  git config user.email cluster-c-test@example.invalid
+  git config user.name "Cluster-C Test"
+  printf 'v0.16.0\ndeadbeef\n2026-01-01\n' > TEMPLATE_VERSION
+  # Seed a scripts/upgrade.sh that differs from "upstream" (simulates v0.16.0 version).
+  mkdir -p scripts
+  echo "# v0.16.0 upgrade.sh" > scripts/upgrade.sh
+  chmod +x scripts/upgrade.sh
+  touch docs/pm/pre-release-gate-overrides.md
+  git add .
+  git commit -q -m "fixture init"
+)
+
+# Build a minimal WORKDIR_NEW with a different scripts/upgrade.sh (candidate).
+workdir_new="$tmp/workdir-new"
+mkdir -p "$workdir_new/scripts/lib"
+echo "# candidate upgrade.sh" > "$workdir_new/scripts/upgrade.sh"
+chmod +x "$workdir_new/scripts/upgrade.sh"
+echo "# candidate lib" > "$workdir_new/scripts/lib/manifest.sh"
+
+# Build WORKDIR_OLD (v0.16.0 baseline).
+workdir_old="$tmp/workdir-old"
+mkdir -p "$workdir_old/scripts"
+echo "# v0.16.0 upgrade.sh" > "$workdir_old/scripts/upgrade.sh"
+
+# Run the migration. It should install the candidate upgrade.sh and mark it.
+rc_mig=$(run_capture "$tmp/migration-v0-14.log" \
+         bash -c "
+           export PROJECT_ROOT='$fix163'
+           export WORKDIR_NEW='$workdir_new'
+           export WORKDIR_OLD='$workdir_old'
+           export OLD_VERSION='v0.16.0'
+           export NEW_VERSION='v1.0.0-rc14'
+           export TARGET_VERSION='v0.14.0'
+           bash '$migration_v0_14'
+         ")
+check "#163: migration exits 0" \
+  bash -c "[ '$rc_mig' = '0' ]"
+check "#163: migration creates/updates .template-customizations" \
+  bash -c "test -f '$fix163/.template-customizations'"
+check "#163: scripts/upgrade.sh is listed in .template-customizations" \
+  bash -c "grep -qE '^scripts/upgrade\.sh' '$fix163/.template-customizations'"
+check "#163: .template-customizations entry mentions issue #163" \
+  bash -c "grep -q 'issue #163' '$fix163/.template-customizations'"
+
+# Idempotency: run migration again — no duplicate entries.
+rc_mig2=$(run_capture "$tmp/migration-v0-14-idem.log" \
+          bash -c "
+            export PROJECT_ROOT='$fix163'
+            export WORKDIR_NEW='$workdir_new'
+            export WORKDIR_OLD='$workdir_old'
+            export OLD_VERSION='v0.16.0'
+            export NEW_VERSION='v1.0.0-rc14'
+            export TARGET_VERSION='v0.14.0'
+            bash '$migration_v0_14'
+          ")
+count=$(grep -cE '^scripts/upgrade\.sh' "$fix163/.template-customizations" 2>/dev/null || echo 0)
+check "#163: idempotent — scripts/upgrade.sh appears exactly once in .template-customizations" \
+  bash -c "[ '$count' = '1' ]"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "PASS: $pass"
+echo "FAIL: $fail"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR-C of the open-issue burndown — four release-gate-upgrade-flow follow-ups on `scripts/upgrade.sh` and the v0.14.0 migration.

## Closes

- Closes #169 — stale `migrations/v1.0.0-rc11.sh` reference in post-upgrade advisory
- Closes #190 — migration idempotency contract cite at the new untagged-target full-walk site
- Closes #171 — `--resolve` now consults `.template-customizations` to prune pinned-path conflicts
- Closes #163 — v0.16.0 upgrade-path conflict; v0.14.0 migration writes pre-bootstrapped paths to `.template-customizations` (option (a) per the issue body)

## Changes

- `scripts/upgrade.sh` (+57 / -5) — #169 stale-ref removal; #190 idempotency cite; #171 `--resolve` pinned-path skip
- `migrations/v0.14.0.sh` (+24) — write pre-bootstrapped paths to `.template-customizations` for #163
- `tests/release-gate/upgrade-paths-allowlist.txt` (-12) — v0.16.0 entry removed (no longer needed once #163 fix is in)
- `tests/upgrade/test-cluster-c-fixes.sh` (+234, new, 16 cases)

## Test plan

- [x] `tests/upgrade/test-cluster-c-fixes.sh` — 16/16 PASS
- [x] `tests/upgrade/test-branch-guard.sh` — 12/12 PASS (no regression on #203)
- [x] `tests/upgrade/test-version-check.sh` — 24/24 PASS (no regression on PR-B)
- [x] `scripts/smoke-test.sh` — 174/174 PASS
- [x] `scripts/lint-agent-model-routing.sh` — exit 0 (no regression on PR-G)
- [x] code-reviewer: APPROVED (no blocking; 3 non-blocking observations)

## Non-blocking observations (no follow-up issue warranted)

- `scripts/upgrade.sh:362` — `printf '%s^I%s\n'` (literal tab) vs adjacent `printf '%s\t%s\n'` (escape). Cosmetic; same output byte.
- Migration filename discovery loop uses `xargs` + word-split iteration — fragile by convention but safe given the stable `v*-rcN.sh` naming scheme.
- `test-cluster-c-fixes.sh:79` — static absence check for `v1.0.0-rc11.sh` in source; dynamic-advisory path covered indirectly by smoke-test rather than end-to-end. Acceptable.
- SE's flagged "trailing-comment pattern" concern: CR verified both `preserve_list` loading and `--resolve` reader already strip `# ` comments. No in-repo test breaks.

## Implementation note: #163 mechanism choice

Option (a) — `migrations/v0.14.0.sh` writes the pre-bootstrapped paths (`scripts/upgrade.sh`, `scripts/lib/*`) to `.template-customizations` immediately after the atomic install. Cleaner than option (b) (three-way SHA pattern recognition in verify): the marker is consumed by both the new `--resolve` skip-path (#171) and the existing `preserve_list` check in the sync loop, without any special-casing for v0.16.0's specific pattern. Idempotent on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade conflict resolution to better recognize and preserve locally customized files during template updates.
  * Enhanced handling of pinned paths in the upgrade workflow.

* **Documentation**
  * Updated upgrade advisory guidance for custom configuration files.

* **Tests**
  * Added comprehensive validation for upgrade conflict resolution and path preservation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->