### PR TITLE
fix(pm): normalize token-ledger.md lowercase clutter (#160)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ tests/release-gate/snapshots/*
 
 # Operator-local dogfood fixtures; never commit (project-specific content)
 .dogfood-fixtures/
+
+# Lowercase stale variant of docs/pm/TOKEN_LEDGER.md (#160). Some agent
+# code paths derive the filename by lowercasing the conceptual name; the
+# canonical file is docs/pm/TOKEN_LEDGER.md (uppercase). Ignoring the
+# lowercase variant stops it appearing as untracked on every commit cycle.
+docs/pm/token-ledger.md

--- a/docs/pm/SCHEDULE-EVIDENCE.md
+++ b/docs/pm/SCHEDULE-EVIDENCE.md
@@ -48,7 +48,7 @@ Non-blocking observations (all logged to `docs/pm/LESSONS.md`):
 - Researcher SC-002 margin (20.3%) is 0.3 points above the floor — future researcher edits must re-measure at gate close.
 - code-reviewer "where safe" SC-002 — canonical already lean; no further reduction possible without deleting normative content.
 - Five small content-fidelity observations from T020 M1.1 audit (researcher Job §1 rationale trim, §6 citation-format trim, qa-engineer HR-5 codification, qa-engineer second escalation-format block silently dropped by singular-slug schema, runtime SHA-from-index semantics).
-- Untracked lowercase `docs/pm/token-ledger.md` clutter in working tree; sandbox denied `rm`. Phase-3+ cleanup.
+- Untracked lowercase `docs/pm/token-ledger.md` clutter — resolved in #160: added to `.gitignore`; workaround grep-filters removed from `gate-runner.sh` and `test-gate-pass.sh`.
 
 ## M2 — Token operating model
 

--- a/scripts/lib/gate-runner.sh
+++ b/scripts/lib/gate-runner.sh
@@ -197,13 +197,12 @@ USAGE
 
 # T009 — worktree-clean (precondition). FR-008.
 # Fails if `git status --porcelain` against $GATE_CANDIDATE_TREE is non-empty,
-# excluding the two known-stale untracked files documented in upstream issue
-# #160 (docs/pm/token-ledger.md + tests/prompt-regression/results-*.md) so the
-# gate doesn't false-positive on pre-existing untracked clutter.
+# excluding tests/prompt-regression/results-*.md (generated on demand, not
+# committed). docs/pm/token-ledger.md is now gitignored (#160) and no longer
+# needs an explicit filter here.
 gate_subgate_worktree-clean() {
     cd "$GATE_CANDIDATE_TREE" || return 1
     dirty=$(git status --porcelain 2>&1 \
-        | grep -vE '^\?\? docs/pm/token-ledger\.md$' \
         | grep -vE '^\?\? tests/prompt-regression/results-' \
         || true)
     if [ -z "$dirty" ]; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -178,6 +178,9 @@ check "smoke-test SemVer dotted prerelease ordering" \
 check_semver_sorter "upgrade" "$repo_root/scripts/upgrade.sh"
 check_semver_sorter "version-check" "$repo_root/scripts/version-check.sh"
 check_semver_sorter "stepwise-smoke" "$repo_root/scripts/stepwise-smoke.sh"
+# #160 — canonical token ledger must be uppercase; lowercase stale variant is gitignored.
+check "docs/pm/TOKEN_LEDGER.md present (canonical uppercase, #160)"  test -f "$repo_root/docs/pm/TOKEN_LEDGER.md"
+check "docs/pm/token-ledger.md absent from repo (gitignored, #160)"   bash -c "! git -C '$repo_root' ls-files --error-unmatch docs/pm/token-ledger.md 2>/dev/null"
 
 echo "-- scaffold --"
 ./scripts/scaffold.sh "$target" "Acme Smoke Test" >/dev/null

--- a/tests/release-gate/test-gate-pass.sh
+++ b/tests/release-gate/test-gate-pass.sh
@@ -16,7 +16,6 @@ gate="$repo_root/scripts/pre-release-gate.sh"
 
 # Verify worktree is clean (otherwise this test isn't meaningful).
 dirty=$(git -C "$repo_root" status --porcelain \
-    | grep -vE '^\?\? docs/pm/token-ledger\.md$' \
     | grep -vE '^\?\? tests/prompt-regression/results-' \
     || true)
 if [ -n "$dirty" ]; then


### PR DESCRIPTION
## Summary

Closes #160 — recurring stale lowercase `docs/pm/token-ledger.md` clutter. Mechanism: `.gitignore` suppression (option 1). The lowercase file is now ignored; the canonical `TOKEN_LEDGER.md` continues to be tracked. Dead-code workarounds in `gate-runner.sh` and `test-gate-pass.sh` removed.

## Closes

- Closes #160

## Changes

- `.gitignore` (+6) — new `docs/pm/token-ledger.md` ignore entry
- `scripts/lib/gate-runner.sh` (+4 / -5) — removed dead workaround grep filter
- `scripts/smoke-test.sh` (+3) — two new assertions
- `tests/release-gate/test-gate-pass.sh` (-1) — removed same dead workaround filter
- `docs/pm/SCHEDULE-EVIDENCE.md` (+1 / -1) — closed the cleanup TODO

## Test plan

- [x] `scripts/smoke-test.sh` — 176/176 PASS (was 174; +2 new assertions)
- [x] `scripts/lint-agent-model-routing.sh` — exit 0
- [x] code-reviewer: APPROVED, 2 non-blocking findings filed as #218 (README ref) and #219 (migration eviction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)