### PR TITLE
feat(ci): canonical_sha staleness guard + runtime artefact regeneration (#143)

### DIFF
--- a/.github/workflows/agent-contract-check.yml
+++ b/.github/workflows/agent-contract-check.yml
@@ -40,3 +40,5 @@ jobs:
         run: ./scripts/compile-runtime-agents.sh --verify
       - name: Run compile-runtime-agents --reproducibility-check
         run: ./scripts/compile-runtime-agents.sh --reproducibility-check
+      - name: Run lint-canonical-sha (canonical_sha staleness guard, #143)
+        run: ./scripts/lint-canonical-sha.sh --summary

--- a/.opencode/agents/architect.md
+++ b/.opencode/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 model: claude-sonnet
 canonical_source: .claude/agents/architect.md
-canonical_sha: dae348d42fbcd97399a9a64d509e2c19a040b57d
+canonical_sha: 0887f70684206c1360be4567489cb81a0704c82a
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 model: claude-sonnet
 canonical_source: .claude/agents/code-reviewer.md
-canonical_sha: 0a5e21978fc634778b7e3f016dd7a9c2226836ac
+canonical_sha: 9d76cabe97963fb1faf8234440b69787137924f2
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/onboarding-auditor.md
+++ b/.opencode/agents/onboarding-auditor.md
@@ -2,7 +2,7 @@
 name: onboarding-auditor
 model: claude-sonnet
 canonical_source: .claude/agents/onboarding-auditor.md
-canonical_sha: 0e4bff65733cbbda51d12e98dc3bd826451822ba
+canonical_sha: b419c5732d86348c6bcfffdfc176d638c54d029b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/process-auditor.md
+++ b/.opencode/agents/process-auditor.md
@@ -2,7 +2,7 @@
 name: process-auditor
 model: claude-sonnet
 canonical_source: .claude/agents/process-auditor.md
-canonical_sha: e70d9aa83d1b85bebc91930727bbb8f9d9db4b22
+canonical_sha: efc0a6c2634812c2855c8592a7f85cc6989fc4fa
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/project-manager.md
+++ b/.opencode/agents/project-manager.md
@@ -2,7 +2,7 @@
 name: project-manager
 model: gemini-flash
 canonical_source: .claude/agents/project-manager.md
-canonical_sha: 46606cac39b9889d2b44cd22f2d35ce28c0c084b
+canonical_sha: 1e208b4f05c8318ea13abb2e4829d16478fba921
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -2,7 +2,7 @@
 name: qa-engineer
 model: claude-sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 1ad43bb1185b67379d681c3a9e01e272cfbea7d7
+canonical_sha: 17c6e7fddc643f8540f6e40d5a05c669b9f92d55
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/release-engineer.md
+++ b/.opencode/agents/release-engineer.md
@@ -2,7 +2,7 @@
 name: release-engineer
 model: openai-coding
 canonical_source: .claude/agents/release-engineer.md
-canonical_sha: 3fa9f26ed3f6d2dd3d2255095fc67041c08ab327
+canonical_sha: fc0148746cf4cfe17aaab9dfbc3384d2052e6046
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/researcher.md
+++ b/.opencode/agents/researcher.md
@@ -2,7 +2,7 @@
 name: researcher
 model: gemini-pro
 canonical_source: .claude/agents/researcher.md
-canonical_sha: f208493ecf3b87e69c91f206f43395d7ecbdafed
+canonical_sha: ee61bc7158b1db43526c94906a09afbf09b91118
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/security-engineer.md
+++ b/.opencode/agents/security-engineer.md
@@ -2,7 +2,7 @@
 name: security-engineer
 model: claude-sonnet
 canonical_source: .claude/agents/security-engineer.md
-canonical_sha: ac5ac443f320ca520149add6e934ec19567f7686
+canonical_sha: 19acb9bb6389264cd51f51612e0e95b515228d17
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/software-engineer.md
+++ b/.opencode/agents/software-engineer.md
@@ -2,7 +2,7 @@
 name: software-engineer
 model: openai-coding
 canonical_source: .claude/agents/software-engineer.md
-canonical_sha: 1e96d5be914569c8dc940346f9154db4a9dc262e
+canonical_sha: 020f538d19e0ee2dade2962b66f9de1f5a66c34b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/sre.md
+++ b/.opencode/agents/sre.md
@@ -2,7 +2,7 @@
 name: sre
 model: claude-sonnet
 canonical_source: .claude/agents/sre.md
-canonical_sha: 8a7aa24f9dd59997c306a41d49c2869e241b5517
+canonical_sha: 5aeccebb9be2c46cf475e9d182198f678b9df383
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/tech-lead.md
+++ b/.opencode/agents/tech-lead.md
@@ -2,7 +2,7 @@
 name: tech-lead
 model: claude-sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: a836fb2e81bd1da28942138ea8ffb81364e58d15
+canonical_sha: 7ebb0e4c78d272719b63ceccfdd48716f2ca6387
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/tech-writer.md
+++ b/.opencode/agents/tech-writer.md
@@ -2,7 +2,7 @@
 name: tech-writer
 model: claude-sonnet
 canonical_source: .claude/agents/tech-writer.md
-canonical_sha: d5e4aec324e76ad7b3ee20c5db4c9a074921d531
+canonical_sha: c90e620af4b82d0501acc21fa96b8655d7d12d68
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/architect.md
+++ b/docs/runtime/agents/architect.md
@@ -1,9 +1,9 @@
 ---
 name: architect
 description: Software Architect. Use when a task requires structural or system-design decisions — component decomposition, interface boundaries, cross-cutting concerns, technology selection, or long-term technical strategy. Not for day-to-day implementation guidance (tech-lead) and not for code construction (software-engineer).
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/architect.md
-canonical_sha: dae348d42fbcd97399a9a64d509e2c19a040b57d
+canonical_sha: 0887f70684206c1360be4567489cb81a0704c82a
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/code-reviewer.md
+++ b/docs/runtime/agents/code-reviewer.md
@@ -1,9 +1,9 @@
 ---
 name: code-reviewer
 description: Code Reviewer and Auditor. Use PROACTIVELY before every commit and after significant changes. Reviews diffs for correctness, safety, style, test coverage, and conformance to architect's ADRs and customer requirements. Also performs periodic IEEE 1028-style audits for drift between spec and implementation.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/code-reviewer.md
-canonical_sha: 0a5e21978fc634778b7e3f016dd7a9c2226836ac
+canonical_sha: 9d76cabe97963fb1faf8234440b69787137924f2
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/onboarding-auditor.md
+++ b/docs/runtime/agents/onboarding-auditor.md
@@ -1,9 +1,9 @@
 ---
 name: onboarding-auditor
 description: Zero-context documentation auditor. Spawned one-shot with deliberately constrained access (repo code + binding docs only; no session history, no `CUSTOMER_NOTES.md`, no sprint notes, no tech-lead chatter) to stress-test whether the project is self-documenting. If this agent can't figure out how to build, run, and smoke-test the project from the docs alone, the gap is documentation debt — not agent failure. Use PROACTIVELY at every milestone close and before any release tag.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/onboarding-auditor.md
-canonical_sha: 0e4bff65733cbbda51d12e98dc3bd826451822ba
+canonical_sha: b419c5732d86348c6bcfffdfc176d638c54d029b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/process-auditor.md
+++ b/docs/runtime/agents/process-auditor.md
@@ -1,9 +1,9 @@
 ---
 name: process-auditor
 description: Cultural-disruptor auditor. Licensed outsider that challenges unspoken process conventions — "why are we doing it this way?" — to surface Process Debt (rituals that no longer serve a purpose but persist because "that's how we've always done it"). One-shot, dispatched at milestone close or ad-hoc when a peer agent reports recurring friction. Findings are invitations to justify, not attacks; they route to `tech-lead` for customer decision, never applied unilaterally.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/process-auditor.md
-canonical_sha: e70d9aa83d1b85bebc91930727bbb8f9d9db4b22
+canonical_sha: efc0a6c2634812c2855c8592a7f85cc6989fc4fa
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/project-manager.md
+++ b/docs/runtime/agents/project-manager.md
@@ -1,9 +1,9 @@
 ---
 name: project-manager
 description: PMBOK-aligned Project Manager. Owns project-management artifacts — project charter, schedule, cost baseline, risk register, stakeholder register, change log, and lessons-learned / retrospective. Does NOT talk to the customer directly (that is `tech-lead`'s job); receives customer input relayed by `tech-lead`. Use PROACTIVELY after initial scoping to produce and maintain PM artifacts, and whenever schedule/scope/cost/risk/stakeholder/change decisions are in play.
-model: inherit
+model: haiku
 canonical_source: .claude/agents/project-manager.md
-canonical_sha: 46606cac39b9889d2b44cd22f2d35ce28c0c084b
+canonical_sha: 1e208b4f05c8318ea13abb2e4829d16478fba921
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/qa-engineer.md
+++ b/docs/runtime/agents/qa-engineer.md
@@ -1,9 +1,9 @@
 ---
 name: qa-engineer
 description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 1ad43bb1185b67379d681c3a9e01e272cfbea7d7
+canonical_sha: 17c6e7fddc643f8540f6e40d5a05c669b9f92d55
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/release-engineer.md
+++ b/docs/runtime/agents/release-engineer.md
@@ -1,9 +1,9 @@
 ---
 name: release-engineer
 description: Build and Release Engineer. Use for build-pipeline work, dependency and toolchain management, packaging, tagging, changelog generation, deployment orchestration, and reproducibility of historical builds. Collapses the build-engineer / release-engineer / DevOps-engineer roles per modern practice.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/release-engineer.md
-canonical_sha: 3fa9f26ed3f6d2dd3d2255095fc67041c08ab327
+canonical_sha: fc0148746cf4cfe17aaab9dfbc3384d2052e6046
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/researcher.md
+++ b/docs/runtime/agents/researcher.md
@@ -1,9 +1,9 @@
 ---
 name: researcher
 description: Librarian and researcher. Use when the task requires authoritative information from standards (SWEBOK, ISO, IEEE, ISTQB, SFIA, PMBOK), official vendor/framework documentation, or prior art — and for recording customer-provided domain facts into CUSTOMER_NOTES.md after tech-lead gets them. Does not contact the customer directly.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/researcher.md
-canonical_sha: f208493ecf3b87e69c91f206f43395d7ecbdafed
+canonical_sha: ee61bc7158b1db43526c94906a09afbf09b91118
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/security-engineer.md
+++ b/docs/runtime/agents/security-engineer.md
@@ -1,9 +1,9 @@
 ---
 name: security-engineer
 description: Security Engineer. Owns SWEBOK V4 KA "Software Security" (ch. 13). Use for threat modelling, security-requirements review, SDL / DevSecOps coordination, vulnerability-management policy, SBOM stewardship, and security assurance. Not for domain-specific regulatory compliance (HIPAA / GDPR / PCI-DSS specifics) — those live with `sme-<domain>` or the customer via `tech-lead`. Not customer-facing.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/security-engineer.md
-canonical_sha: ac5ac443f320ca520149add6e934ec19567f7686
+canonical_sha: 19acb9bb6389264cd51f51612e0e95b515228d17
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/software-engineer.md
+++ b/docs/runtime/agents/software-engineer.md
@@ -1,9 +1,9 @@
 ---
 name: software-engineer
 description: Software Engineer / implementer. Use for writing production code, unit tests, bug fixes, small refactors, and integration work. Executes on a specification provided by tech-lead or architect; does not decide what to build.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/software-engineer.md
-canonical_sha: 1e96d5be914569c8dc940346f9154db4a9dc262e
+canonical_sha: 020f538d19e0ee2dade2962b66f9de1f5a66c34b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/sre.md
+++ b/docs/runtime/agents/sre.md
@@ -1,9 +1,9 @@
 ---
 name: sre
 description: Site Reliability Engineer and Performance Engineer. Use for production behavior, reliability, performance, capacity planning, SLO definition, incident response, and performance profiling / tuning. Not for pre-release correctness testing (qa-engineer).
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/sre.md
-canonical_sha: 8a7aa24f9dd59997c306a41d49c2869e241b5517
+canonical_sha: 5aeccebb9be2c46cf475e9d182198f678b9df383
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/tech-lead.md
+++ b/docs/runtime/agents/tech-lead.md
@@ -1,9 +1,9 @@
 ---
 name: tech-lead
 description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: a836fb2e81bd1da28942138ea8ffb81364e58d15
+canonical_sha: 7ebb0e4c78d272719b63ceccfdd48716f2ca6387
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/tech-writer.md
+++ b/docs/runtime/agents/tech-writer.md
@@ -1,9 +1,9 @@
 ---
 name: tech-writer
 description: Technical Writer. Use for user documentation, operator manuals, API/function-block references, how-to guides, changelogs, and release notes. Prose artifacts intended for human readers outside the agent team.
-model: inherit
+model: sonnet
 canonical_source: .claude/agents/tech-writer.md
-canonical_sha: d5e4aec324e76ad7b3ee20c5db4c9a074921d531
+canonical_sha: c90e620af4b82d0501acc21fa96b8655d7d12d68
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/scripts/lint-canonical-sha.sh
+++ b/scripts/lint-canonical-sha.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# scripts/lint-canonical-sha.sh — canonical_sha staleness guard (#143).
+#
+# For each canonical agent source at .claude/agents/<role>.md, compute
+# its current git blob SHA (git rev-parse HEAD:<path>) and compare it
+# against the canonical_sha: frontmatter field in:
+#   docs/runtime/agents/<role>.md
+#   .opencode/agents/<role>.md
+#
+# A mismatch means the canonical was edited and committed but the generated
+# artefact was not regenerated + committed in the same change set.
+#
+# Exit codes:
+#   0  all canonical_sha fields match current HEAD blob SHAs
+#   1  one or more mismatches (diagnostic printed to stderr)
+#   2  usage / environment error (no git, no agents dir, etc.)
+#
+# Usage:
+#   scripts/lint-canonical-sha.sh [--summary] [--agents-dir <path>]
+#     [--runtime-dir <path>] [--opencode-dir <path>]
+#
+# Flags:
+#   --summary              emit a final PASS/FAIL summary line on stdout
+#   --agents-dir <path>    canonical sources (default: .claude/agents)
+#   --runtime-dir <path>   compact runtime artefacts (default: docs/runtime/agents)
+#   --opencode-dir <path>  opencode adapter artefacts (default: .opencode/agents)
+#   --no-opencode          skip .opencode/agents/ check
+#   -h | --help            this help
+#
+# POSIX-sh only: no bashisms; LANG=C/LC_ALL=C.
+# Requires: git (for rev-parse HEAD:<path>)
+
+set -eu
+
+LANG=C
+LC_ALL=C
+export LANG LC_ALL
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+AGENTS_DIR="${REPO_ROOT}/.claude/agents"
+RUNTIME_DIR="${REPO_ROOT}/docs/runtime/agents"
+OPENCODE_DIR="${REPO_ROOT}/.opencode/agents"
+SUMMARY=0
+NO_OPENCODE=0
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/lint-canonical-sha.sh [--summary] [--agents-dir <path>]
+         [--runtime-dir <path>] [--opencode-dir <path>] [--no-opencode]
+
+Checks that every generated agent artefact carries a canonical_sha: that
+matches the current git blob SHA of its canonical source file.
+
+Flags:
+  --summary              emit a final PASS/FAIL summary line
+  --agents-dir DIR       canonical sources (default: .claude/agents)
+  --runtime-dir DIR      compact runtime artefacts (default: docs/runtime/agents)
+  --opencode-dir DIR     opencode adapter artefacts (default: .opencode/agents)
+  --no-opencode          skip .opencode/agents/ check
+  -h | --help            this help
+
+Exit codes:
+  0  all canonical_sha fields are current
+  1  one or more mismatches
+  2  usage / environment error
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --summary) SUMMARY=1; shift ;;
+        --agents-dir)
+            [ $# -ge 2 ] || { usage; exit 2; }
+            AGENTS_DIR="$2"; shift 2 ;;
+        --runtime-dir)
+            [ $# -ge 2 ] || { usage; exit 2; }
+            RUNTIME_DIR="$2"; shift 2 ;;
+        --opencode-dir)
+            [ $# -ge 2 ] || { usage; exit 2; }
+            OPENCODE_DIR="$2"; shift 2 ;;
+        --no-opencode) NO_OPENCODE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'lint-canonical-sha: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+done
+
+# ---- Environment checks ---------------------------------------------------
+
+if ! command -v git >/dev/null 2>&1; then
+    printf 'lint-canonical-sha: git not found on PATH\n' >&2
+    exit 2
+fi
+
+if [ ! -d "${AGENTS_DIR}" ]; then
+    printf 'lint-canonical-sha: agents dir not found: %s\n' "${AGENTS_DIR}" >&2
+    exit 2
+fi
+
+if [ ! -d "${RUNTIME_DIR}" ]; then
+    printf 'lint-canonical-sha: runtime dir not found: %s\n' "${RUNTIME_DIR}" >&2
+    exit 2
+fi
+
+if [ "${NO_OPENCODE}" -eq 0 ] && [ ! -d "${OPENCODE_DIR}" ]; then
+    printf 'lint-canonical-sha: opencode dir not found: %s\n' "${OPENCODE_DIR}" >&2
+    exit 2
+fi
+
+# Resolve the git work-tree root so rev-parse paths are relative to it.
+# Use AGENTS_DIR (not REPO_ROOT) so --agents-dir overrides pointing at a
+# different repo (e.g. test fixtures) resolve the correct git root.
+GIT_ROOT="$(git -C "${AGENTS_DIR}" rev-parse --show-toplevel 2>/dev/null)" || {
+    printf 'lint-canonical-sha: could not determine git root under %s\n' "${AGENTS_DIR}" >&2
+    exit 2
+}
+
+# ---- Helper: extract canonical_sha from a generated artefact frontmatter --
+# Prints the 40-hex SHA or empty string on failure.
+extract_canonical_sha() {
+    artefact="$1"
+    # Parse YAML frontmatter: lines between the first and second '---' sentinel.
+    awk '
+        BEGIN { state = "pre" }
+        {
+            if (state == "pre") {
+                if ($0 == "---") { state = "fm"; next }
+                exit
+            }
+            if (state == "fm") {
+                if ($0 == "---") { exit }
+                if ($0 ~ /^canonical_sha:[ \t]*[0-9a-f]{40}[ \t]*$/) {
+                    val = $0
+                    sub(/^canonical_sha:[ \t]*/, "", val)
+                    sub(/[ \t]*$/, "", val)
+                    print val
+                    exit
+                }
+            }
+        }
+    ' "${artefact}"
+}
+
+# ---- Helper: compute relative path from GIT_ROOT for rev-parse ----------
+# git rev-parse HEAD:<path> requires a path relative to the repo root.
+# Use shell parameter expansion (not sed) to strip the prefix as a literal
+# string — sed would treat special regex chars in GIT_ROOT (e.g. '.') as
+# wildcards.
+rel_to_git_root() {
+    abs="$1"
+    printf '%s' "${abs#${GIT_ROOT}/}"
+}
+
+# ---- Main check loop ------------------------------------------------------
+
+overall_fail=0
+
+for canonical in "${AGENTS_DIR}"/*.md; do
+    [ -f "${canonical}" ] || continue
+    base="$(basename "${canonical}" .md)"
+    # Skip sme-template and any non-kebab filenames (same filter as compiler).
+    case "${base}" in
+        sme-template) continue ;;
+        *[!a-z0-9-]*|"") continue ;;
+    esac
+
+    # Compute the current HEAD blob SHA for this canonical.
+    rel_path="$(rel_to_git_root "${canonical}")"
+    current_sha="$(git -C "${GIT_ROOT}" rev-parse "HEAD:${rel_path}" 2>/dev/null || true)"
+    if [ -z "${current_sha}" ] || \
+       ! printf '%s' "${current_sha}" | grep -qE '^[0-9a-f]{40}$'; then
+        printf 'lint-canonical-sha: WARN: could not resolve git blob SHA for %s; skipping\n' \
+            "${rel_path}" >&2
+        continue
+    fi
+
+    # Check compact runtime artefact.
+    runtime_artefact="${RUNTIME_DIR}/${base}.md"
+    if [ ! -f "${runtime_artefact}" ]; then
+        printf 'lint-canonical-sha: MISSING_ARTEFACT: %s (no paired runtime contract)\n' \
+            "${runtime_artefact}" >&2
+        overall_fail=1
+    else
+        recorded_sha="$(extract_canonical_sha "${runtime_artefact}")"
+        if [ -z "${recorded_sha}" ]; then
+            printf 'lint-canonical-sha: NO_SHA_FIELD: %s (canonical_sha: field absent or malformed)\n' \
+                "${runtime_artefact}" >&2
+            overall_fail=1
+        elif [ "${recorded_sha}" != "${current_sha}" ]; then
+            printf 'lint-canonical-sha: STALE: %s\n  recorded canonical_sha: %s\n  current  HEAD blob SHA: %s\n  Fix: rerun scripts/compile-runtime-agents.sh and commit both files together.\n' \
+                "${runtime_artefact}" "${recorded_sha}" "${current_sha}" >&2
+            overall_fail=1
+        fi
+    fi
+
+    # Check opencode adapter artefact.
+    if [ "${NO_OPENCODE}" -eq 0 ]; then
+        opencode_artefact="${OPENCODE_DIR}/${base}.md"
+        if [ ! -f "${opencode_artefact}" ]; then
+            printf 'lint-canonical-sha: MISSING_ARTEFACT: %s (no paired opencode adapter)\n' \
+                "${opencode_artefact}" >&2
+            overall_fail=1
+        else
+            recorded_sha="$(extract_canonical_sha "${opencode_artefact}")"
+            if [ -z "${recorded_sha}" ]; then
+                printf 'lint-canonical-sha: NO_SHA_FIELD: %s (canonical_sha: field absent or malformed)\n' \
+                    "${opencode_artefact}" >&2
+                overall_fail=1
+            elif [ "${recorded_sha}" != "${current_sha}" ]; then
+                printf 'lint-canonical-sha: STALE: %s\n  recorded canonical_sha: %s\n  current  HEAD blob SHA: %s\n  Fix: rerun scripts/compile-runtime-agents.sh and commit both files together.\n' \
+                    "${opencode_artefact}" "${recorded_sha}" "${current_sha}" >&2
+                overall_fail=1
+            fi
+        fi
+    fi
+done
+
+if [ "${SUMMARY}" -eq 1 ]; then
+    if [ "${overall_fail}" -eq 0 ]; then
+        printf 'lint-canonical-sha: PASS\n'
+    else
+        printf 'lint-canonical-sha: FAIL\n'
+    fi
+fi
+
+exit "${overall_fail}"

--- a/tests/lint/test-canonical-sha.sh
+++ b/tests/lint/test-canonical-sha.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/lint/test-canonical-sha.sh — self-test for
+# scripts/lint-canonical-sha.sh (#143 T072-style fixture test).
+#
+# Cases:
+#   1. Happy path: all artefacts have matching canonical_sha -> PASS (exit 0)
+#   2. Stale runtime artefact: canonical edited+committed, runtime not updated
+#      -> FAIL (exit 1) with STALE diagnostic naming both SHAs
+#   3. Stale opencode artefact only: runtime current, opencode stale -> FAIL
+#   4. Missing runtime artefact: canonical exists but no runtime file -> FAIL
+#   5. Missing canonical_sha field in runtime artefact -> FAIL
+#   6. Missing canonical file for which a runtime exists: no canonical -> WARN
+#      (not a FAIL; the canonical is absent, not stale)
+#   7. --no-opencode flag: opencode stale but --no-opencode set -> PASS
+#   8. --summary flag: FAIL summary line printed on stderr mismatch
+#
+# Each case builds an isolated git repo fixture in a tempdir containing:
+#   .claude/agents/<role>.md      (canonical)
+#   docs/runtime/agents/<role>.md  (runtime artefact with frontmatter)
+#   .opencode/agents/<role>.md    (opencode adapter with frontmatter)
+# All files are committed to HEAD so rev-parse works.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LINT="$REPO_ROOT/scripts/lint-canonical-sha.sh"
+
+pass=0
+fail=0
+failures=()
+
+# --------------------------------------------------------------------------
+# run_case <name> <expect-exit: 0|1|2>
+# run with the env var FIXTURE_DIR set before calling; remaining args
+# are passed to the lint script.
+# --------------------------------------------------------------------------
+run_case() {
+    local name="$1"
+    local expect_exit="$2"
+    shift 2
+
+    local actual_exit=0
+    "$LINT" "$@" >/dev/null 2>&1 || actual_exit=$?
+
+    if [ "$actual_exit" -eq "$expect_exit" ]; then
+        pass=$((pass + 1))
+        echo "PASS  $name"
+    else
+        fail=$((fail + 1))
+        failures+=("$name (expected exit=$expect_exit actual=$actual_exit)")
+        echo "FAIL  $name (expected exit=$expect_exit actual=$actual_exit)"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# make_fixture_repo <tmpdir>
+# Creates a minimal git repo under $tmpdir/repo with the standard layout.
+# Returns the repo path on stdout (for capture with $(...)).
+# Does NOT commit anything — callers do that after populating.
+# --------------------------------------------------------------------------
+make_fixture_repo() {
+    local base="$1"
+    local repo="$base/repo"
+    mkdir -p "$repo"
+    git -C "$repo" init -q
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    mkdir -p "$repo/.claude/agents"
+    mkdir -p "$repo/docs/runtime/agents"
+    mkdir -p "$repo/.opencode/agents"
+    printf '%s' "$repo"
+}
+
+# --------------------------------------------------------------------------
+# write_canonical <repo> <role> <content>
+# --------------------------------------------------------------------------
+write_canonical() {
+    local repo="$1" role="$2" content="$3"
+    printf '%s\n' "$content" > "$repo/.claude/agents/${role}.md"
+}
+
+# --------------------------------------------------------------------------
+# write_runtime_artefact <repo> <role> <canonical_sha>
+# Writes a minimal generated runtime contract with the given canonical_sha.
+# --------------------------------------------------------------------------
+write_runtime_artefact() {
+    local repo="$1" role="$2" sha="$3"
+    cat > "$repo/docs/runtime/agents/${role}.md" << EOF
+---
+name: ${role}
+description: Test contract for ${role}.
+model: inherit
+canonical_source: .claude/agents/${role}.md
+canonical_sha: ${sha}
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Body text.
+EOF
+}
+
+# --------------------------------------------------------------------------
+# write_opencode_artefact <repo> <role> <canonical_sha>
+# Writes a minimal generated opencode adapter with the given canonical_sha.
+# --------------------------------------------------------------------------
+write_opencode_artefact() {
+    local repo="$1" role="$2" sha="$3"
+    cat > "$repo/.opencode/agents/${role}.md" << EOF
+---
+name: ${role}
+model: claude-sonnet
+canonical_source: .claude/agents/${role}.md
+canonical_sha: ${sha}
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read \`.claude/agents/${role}.md\` (canonical role contract).
+Act only as that role.
+EOF
+}
+
+# --------------------------------------------------------------------------
+# commit_all <repo> <message>
+# Stages everything and commits.
+# --------------------------------------------------------------------------
+commit_all() {
+    local repo="$1" msg="$2"
+    git -C "$repo" add -A
+    git -C "$repo" commit -q -m "$msg"
+}
+
+# --------------------------------------------------------------------------
+# get_blob_sha <repo> <rel_path>
+# Returns the git blob SHA at HEAD for the given path.
+# --------------------------------------------------------------------------
+get_blob_sha() {
+    local repo="$1" rel_path="$2"
+    git -C "$repo" rev-parse "HEAD:${rel_path}"
+}
+
+# ==========================================================================
+# Case 1: Happy path — all artefacts current -> PASS
+# ==========================================================================
+TMPDIR1="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR1"' EXIT INT TERM HUP
+REPO1="$(make_fixture_repo "$TMPDIR1")"
+
+write_canonical "$REPO1" "soft-eng" "canonical body v1"
+commit_all "$REPO1" "add canonical"
+SHA1="$(get_blob_sha "$REPO1" ".claude/agents/soft-eng.md")"
+write_runtime_artefact "$REPO1" "soft-eng" "$SHA1"
+write_opencode_artefact "$REPO1" "soft-eng" "$SHA1"
+commit_all "$REPO1" "add artefacts"
+
+run_case "happy-path: all artefacts current" 0 \
+    --agents-dir "$REPO1/.claude/agents" \
+    --runtime-dir "$REPO1/docs/runtime/agents" \
+    --opencode-dir "$REPO1/.opencode/agents"
+
+# ==========================================================================
+# Case 2: Stale runtime artefact — canonical committed with new content,
+#         runtime not updated -> FAIL with STALE diagnostic
+# ==========================================================================
+TMPDIR2="$(mktemp -d)"
+REPO2="$(make_fixture_repo "$TMPDIR2")"
+
+# First commit: canonical + artefacts in sync.
+write_canonical "$REPO2" "soft-eng" "canonical body v1"
+commit_all "$REPO2" "add canonical v1"
+SHA2_v1="$(get_blob_sha "$REPO2" ".claude/agents/soft-eng.md")"
+write_runtime_artefact "$REPO2" "soft-eng" "$SHA2_v1"
+write_opencode_artefact "$REPO2" "soft-eng" "$SHA2_v1"
+commit_all "$REPO2" "add artefacts synced to v1"
+
+# Second commit: canonical updated, artefacts NOT updated (stale).
+write_canonical "$REPO2" "soft-eng" "canonical body v2 — new content"
+commit_all "$REPO2" "update canonical to v2 without refreshing artefacts"
+# Artefacts still record SHA2_v1 but HEAD canonical is now v2.
+
+# Verify that the STALE diagnostic fires.
+STALE_OUT2="$(mktemp)"
+ACTUAL_EXIT2=0
+"$LINT" \
+    --agents-dir "$REPO2/.claude/agents" \
+    --runtime-dir "$REPO2/docs/runtime/agents" \
+    --opencode-dir "$REPO2/.opencode/agents" \
+    >"$STALE_OUT2" 2>&1 || ACTUAL_EXIT2=$?
+
+STALE_FOUND2=0
+if grep -q "STALE:" "$STALE_OUT2" && grep -q "recorded canonical_sha:" "$STALE_OUT2"; then
+    STALE_FOUND2=1
+fi
+rm -f "$STALE_OUT2"
+
+if [ "$ACTUAL_EXIT2" -eq 1 ] && [ "$STALE_FOUND2" -eq 1 ]; then
+    pass=$((pass + 1))
+    echo "PASS  stale-runtime: STALE diagnostic + exit 1"
+else
+    fail=$((fail + 1))
+    failures+=("stale-runtime: STALE diagnostic + exit 1 (exit=$ACTUAL_EXIT2 stale_found=$STALE_FOUND2)")
+    echo "FAIL  stale-runtime: STALE diagnostic + exit 1 (exit=$ACTUAL_EXIT2 stale_found=$STALE_FOUND2)"
+fi
+
+# ==========================================================================
+# Case 3: Only opencode artefact is stale (runtime is current) -> FAIL
+# ==========================================================================
+TMPDIR3="$(mktemp -d)"
+REPO3="$(make_fixture_repo "$TMPDIR3")"
+
+write_canonical "$REPO3" "soft-eng" "canonical body v1"
+commit_all "$REPO3" "add canonical v1"
+SHA3_v1="$(get_blob_sha "$REPO3" ".claude/agents/soft-eng.md")"
+write_runtime_artefact "$REPO3" "soft-eng" "$SHA3_v1"
+write_opencode_artefact "$REPO3" "soft-eng" "$SHA3_v1"
+commit_all "$REPO3" "add artefacts synced to v1"
+
+# Update canonical + runtime only; opencode left stale.
+write_canonical "$REPO3" "soft-eng" "canonical body v2"
+commit_all "$REPO3" "update canonical to v2"
+SHA3_v2="$(get_blob_sha "$REPO3" ".claude/agents/soft-eng.md")"
+write_runtime_artefact "$REPO3" "soft-eng" "$SHA3_v2"
+# opencode still has v1 SHA
+commit_all "$REPO3" "update runtime to v2 but not opencode"
+
+run_case "stale-opencode-only: opencode artefact stale -> FAIL" 1 \
+    --agents-dir "$REPO3/.claude/agents" \
+    --runtime-dir "$REPO3/docs/runtime/agents" \
+    --opencode-dir "$REPO3/.opencode/agents"
+
+# ==========================================================================
+# Case 4: Missing runtime artefact -> FAIL
+# ==========================================================================
+TMPDIR4="$(mktemp -d)"
+REPO4="$(make_fixture_repo "$TMPDIR4")"
+
+write_canonical "$REPO4" "soft-eng" "canonical body"
+commit_all "$REPO4" "add canonical only"
+# No runtime or opencode artefact.
+
+run_case "missing-runtime: no runtime artefact -> FAIL" 1 \
+    --agents-dir "$REPO4/.claude/agents" \
+    --runtime-dir "$REPO4/docs/runtime/agents" \
+    --opencode-dir "$REPO4/.opencode/agents"
+
+# ==========================================================================
+# Case 5: Missing canonical_sha field in runtime artefact -> FAIL
+# ==========================================================================
+TMPDIR5="$(mktemp -d)"
+REPO5="$(make_fixture_repo "$TMPDIR5")"
+
+write_canonical "$REPO5" "soft-eng" "canonical body"
+commit_all "$REPO5" "add canonical"
+SHA5="$(get_blob_sha "$REPO5" ".claude/agents/soft-eng.md")"
+
+# Write a runtime artefact with no canonical_sha field.
+cat > "$REPO5/docs/runtime/agents/soft-eng.md" << 'EOF'
+---
+name: soft-eng
+description: Test.
+model: inherit
+generator: scripts/compile-runtime-agents.sh
+classification: generated
+---
+
+Body.
+EOF
+write_opencode_artefact "$REPO5" "soft-eng" "$SHA5"
+commit_all "$REPO5" "add artefacts — runtime missing canonical_sha"
+
+run_case "missing-sha-field: no canonical_sha in runtime -> FAIL" 1 \
+    --agents-dir "$REPO5/.claude/agents" \
+    --runtime-dir "$REPO5/docs/runtime/agents" \
+    --opencode-dir "$REPO5/.opencode/agents"
+
+# ==========================================================================
+# Case 6: --no-opencode flag: opencode artefact stale but flag suppresses -> PASS
+# ==========================================================================
+# Reuse REPO3 state (opencode stale, runtime current at v2).
+run_case "no-opencode-flag: opencode stale but --no-opencode set -> PASS" 0 \
+    --agents-dir "$REPO3/.claude/agents" \
+    --runtime-dir "$REPO3/docs/runtime/agents" \
+    --no-opencode
+
+# ==========================================================================
+# Case 7: --summary flag emits FAIL line on mismatch
+# ==========================================================================
+# Reuse REPO2 (stale runtime).
+SUMMARY_OUT7="$(mktemp)"
+ACTUAL_EXIT7=0
+"$LINT" \
+    --summary \
+    --agents-dir "$REPO2/.claude/agents" \
+    --runtime-dir "$REPO2/docs/runtime/agents" \
+    --opencode-dir "$REPO2/.opencode/agents" \
+    >"$SUMMARY_OUT7" 2>/dev/null || ACTUAL_EXIT7=$?
+
+SUMMARY_FAIL_FOUND7=0
+if grep -q "lint-canonical-sha: FAIL" "$SUMMARY_OUT7"; then
+    SUMMARY_FAIL_FOUND7=1
+fi
+rm -f "$SUMMARY_OUT7"
+
+if [ "$ACTUAL_EXIT7" -ne 0 ] && [ "$SUMMARY_FAIL_FOUND7" -eq 1 ]; then
+    pass=$((pass + 1))
+    echo "PASS  summary-fail-line: FAIL summary printed + non-zero exit"
+else
+    fail=$((fail + 1))
+    failures+=("summary-fail-line (exit=$ACTUAL_EXIT7 fail_line_found=$SUMMARY_FAIL_FOUND7)")
+    echo "FAIL  summary-fail-line (exit=$ACTUAL_EXIT7 fail_line_found=$SUMMARY_FAIL_FOUND7)"
+fi
+
+# ==========================================================================
+# Case 8: --summary flag emits PASS line when all current
+# ==========================================================================
+# Reuse REPO1 (all current).
+SUMMARY_OUT8="$(mktemp)"
+ACTUAL_EXIT8=0
+"$LINT" \
+    --summary \
+    --agents-dir "$REPO1/.claude/agents" \
+    --runtime-dir "$REPO1/docs/runtime/agents" \
+    --opencode-dir "$REPO1/.opencode/agents" \
+    >"$SUMMARY_OUT8" 2>/dev/null || ACTUAL_EXIT8=$?
+
+SUMMARY_PASS_FOUND8=0
+if grep -q "lint-canonical-sha: PASS" "$SUMMARY_OUT8"; then
+    SUMMARY_PASS_FOUND8=1
+fi
+rm -f "$SUMMARY_OUT8"
+
+if [ "$ACTUAL_EXIT8" -eq 0 ] && [ "$SUMMARY_PASS_FOUND8" -eq 1 ]; then
+    pass=$((pass + 1))
+    echo "PASS  summary-pass-line: PASS summary printed + zero exit"
+else
+    fail=$((fail + 1))
+    failures+=("summary-pass-line (exit=$ACTUAL_EXIT8 pass_line_found=$SUMMARY_PASS_FOUND8)")
+    echo "FAIL  summary-pass-line (exit=$ACTUAL_EXIT8 pass_line_found=$SUMMARY_PASS_FOUND8)"
+fi
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo ""
+echo "Results: $pass passed, $fail failed"
+
+if [ "${#failures[@]}" -gt 0 ]; then
+    echo "Failures:"
+    for f in "${failures[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+
+exit 0

--- a/tests/lint/test-canonical-sha.sh
+++ b/tests/lint/test-canonical-sha.sh
@@ -12,10 +12,15 @@
 #   3. Stale opencode artefact only: runtime current, opencode stale -> FAIL
 #   4. Missing runtime artefact: canonical exists but no runtime file -> FAIL
 #   5. Missing canonical_sha field in runtime artefact -> FAIL
-#   6. Missing canonical file for which a runtime exists: no canonical -> WARN
-#      (not a FAIL; the canonical is absent, not stale)
-#   7. --no-opencode flag: opencode stale but --no-opencode set -> PASS
-#   8. --summary flag: FAIL summary line printed on stderr mismatch
+#   6. --no-opencode flag: opencode stale but --no-opencode set -> PASS
+#   7. --summary flag: FAIL summary line printed on stdout when stale -> FAIL
+#   8. --summary flag: PASS summary line printed on stdout when current -> PASS
+#
+# NOTE: orphan detection (runtime artefact exists but canonical is absent)
+# is NOT covered here; that gap is filed as a follow-up issue.
+# (lint detects STALE / MISSING_ARTEFACT / NO_SHA_FIELD but does NOT detect
+# MISSING_CANONICAL — a runtime artefact exists for which no canonical source
+# exists.)
 #
 # Each case builds an isolated git repo fixture in a tempdir containing:
 #   .claude/agents/<role>.md      (canonical)
@@ -146,10 +151,21 @@ get_blob_sha() {
 }
 
 # ==========================================================================
+# Single parent tempdir — all per-case dirs live under it.
+# Trap removes the entire tree regardless of which case fails or exits early.
+# ==========================================================================
+PARENT_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$PARENT_TMPDIR"' EXIT INT TERM HUP
+
+TMPDIR1="$PARENT_TMPDIR/tmpdir1"; mkdir -p "$TMPDIR1"
+TMPDIR2="$PARENT_TMPDIR/tmpdir2"; mkdir -p "$TMPDIR2"
+TMPDIR3="$PARENT_TMPDIR/tmpdir3"; mkdir -p "$TMPDIR3"
+TMPDIR4="$PARENT_TMPDIR/tmpdir4"; mkdir -p "$TMPDIR4"
+TMPDIR5="$PARENT_TMPDIR/tmpdir5"; mkdir -p "$TMPDIR5"
+
+# ==========================================================================
 # Case 1: Happy path — all artefacts current -> PASS
 # ==========================================================================
-TMPDIR1="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR1"' EXIT INT TERM HUP
 REPO1="$(make_fixture_repo "$TMPDIR1")"
 
 write_canonical "$REPO1" "soft-eng" "canonical body v1"
@@ -168,7 +184,6 @@ run_case "happy-path: all artefacts current" 0 \
 # Case 2: Stale runtime artefact — canonical committed with new content,
 #         runtime not updated -> FAIL with STALE diagnostic
 # ==========================================================================
-TMPDIR2="$(mktemp -d)"
 REPO2="$(make_fixture_repo "$TMPDIR2")"
 
 # First commit: canonical + artefacts in sync.
@@ -211,7 +226,6 @@ fi
 # ==========================================================================
 # Case 3: Only opencode artefact is stale (runtime is current) -> FAIL
 # ==========================================================================
-TMPDIR3="$(mktemp -d)"
 REPO3="$(make_fixture_repo "$TMPDIR3")"
 
 write_canonical "$REPO3" "soft-eng" "canonical body v1"
@@ -237,7 +251,6 @@ run_case "stale-opencode-only: opencode artefact stale -> FAIL" 1 \
 # ==========================================================================
 # Case 4: Missing runtime artefact -> FAIL
 # ==========================================================================
-TMPDIR4="$(mktemp -d)"
 REPO4="$(make_fixture_repo "$TMPDIR4")"
 
 write_canonical "$REPO4" "soft-eng" "canonical body"
@@ -252,7 +265,6 @@ run_case "missing-runtime: no runtime artefact -> FAIL" 1 \
 # ==========================================================================
 # Case 5: Missing canonical_sha field in runtime artefact -> FAIL
 # ==========================================================================
-TMPDIR5="$(mktemp -d)"
 REPO5="$(make_fixture_repo "$TMPDIR5")"
 
 write_canonical "$REPO5" "soft-eng" "canonical body"


### PR DESCRIPTION
## Summary

PR-143 of the open-issue burndown — adds CI guard for `canonical_sha` staleness on `docs/runtime/agents/` + `.opencode/agents/`, AND regenerates the 26 runtime artefacts that PR-G left stale.

## Closes

- Closes #143

## Commits

| SHA | Scope |
|---|---|
| `90e54e2` | Original: `scripts/lint-canonical-sha.sh` (POSIX sh detector, 230 lines), `tests/lint/test-canonical-sha.sh` (8 cases, 361 lines), `.github/workflows/agent-contract-check.yml` (+2-line step) |
| `69e112a` | CR fixup: trap covers all temp dirs (single PARENT_TMPDIR); test header / case labels match implementation |
| `e9a408d` | Runtime regen: 26 files (13 `docs/runtime/agents/` + 13 `.opencode/agents/`) — `canonical_sha:` frontmatter SHA + `model:` field updated to reflect PR-G's agent-contract changes |

## Why the regen ships in the same PR

The new CI lint check (`scripts/lint-canonical-sha.sh`) ran against current `main` exits 1 with 26 STALE diagnostics — pre-existing staleness from PR-G (#207 Part A) where agent contracts were updated but `docs/runtime/agents/generated/` and `.opencode/agents/` weren't regenerated. Merging the lint without the regen would break CI on every subsequent PR. Folding the regen in keeps `main` green at all times.

## Test plan

- [x] `tests/lint/test-canonical-sha.sh` — 8/8 PASS
- [x] `scripts/lint-canonical-sha.sh --summary` against the worktree — exit 0 (was exit 1 with 26 STALE)
- [x] `scripts/lint-agent-model-routing.sh --summary` — PASS
- [x] `scripts/smoke-test.sh` — 174/174 PASS
- [x] Renderer (`scripts/compile-runtime-agents.sh`) deterministic — re-run produces zero diff
- [x] code-reviewer: APPROVED on the cluster + APPROVED on the respin fixup

## Non-blocking finding (filed as #223)

`scripts/lint-canonical-sha.sh` does not detect orphan runtime artefacts (runtime exists for a role whose canonical source has been deleted). Pre-existing gap; no observed orphan today. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)