### PR TITLE
fix(dogfood): stub-vs-driver coupling check + jq parse-failure FAIL (#194 #195)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright 2026 occamsshavingkit/sw-dev-team-template contributors -->
+
+## Summary
+
+<!-- One-paragraph description of what this PR does. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`tests/release-gate/`, `tests/hooks/`, smoke suite).
+- [ ] CHANGELOG entry added (if user-visible change).
+- [ ] **If this PR adds or removes flags in `scripts/upgrade.sh`:** the stub at
+  `tests/release-gate/dogfood-examples/_shared/upgrade.sh` is updated to match.
+  Stub and driver flag sets must stay in lockstep — drift causes the dogfood
+  capture to fail-loud only when the capture is next exercised, which may be
+  days after the driver change lands. (Issue #194.)

--- a/tests/release-gate/dogfood-downstream.sh
+++ b/tests/release-gate/dogfood-downstream.sh
@@ -308,6 +308,17 @@ if [ -f "$CONFLICTS_PATH" ]; then
     # key order, and nested structures. Falls back to a tighter regex
     # when jq is unavailable.
     if command -v jq >/dev/null 2>&1; then
+        # Probe: if the file exists but is not valid JSON, FAIL immediately.
+        # `jq empty` is the canonical "validate JSON, produce no output"
+        # idiom. Distinguishes "file missing" (legitimate zero conflicts)
+        # from "file malformed" (data-integrity failure that must not
+        # silently become zero). Without this probe the `?` guard below
+        # would swallow a parse error and report 0 conflicts on a corrupt
+        # conflict log — a silent false-clean. (Issue #195.)
+        if ! jq empty "$CONFLICTS_PATH" 2>/dev/null; then
+            echo "FATAL: $CONFLICTS_PATH exists but is not valid JSON — cannot determine conflict count" >&2
+            exit 1
+        fi
         # The file shape is an object whose `.entries` field is an
         # array of entry objects (see scripts/upgrade.sh writer and
         # tests/release-gate/snapshots/v1.0.0-rc12/with-accepted-local/


### PR DESCRIPTION
Closes #194 (PR template checklist for stub-vs-driver coupling) + #195 (jq empty probe).

CR APPROVED with 2 non-blocking suggestions (jq stderr-suppression cosmetic; regex-fallback path comment). No blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)