### PR TITLE
fix(ci): improve-template protected-files regex + numeric validator (#144 #149)

### DIFF
--- a/.github/workflows/improve-template.yml
+++ b/.github/workflows/improve-template.yml
@@ -121,7 +121,7 @@ jobs:
           # Build the protected-files allowlist as a single regex.
           protected_paths='^(CLAUDE\.md|AGENTS\.md|VERSION|TEMPLATE_MANIFEST\.lock|\.claude/agents/|docs/adr/|docs/framework-project-boundary\.md|docs/model-routing-guidelines\.md|\.github/workflows/|migrations/)'
           customer_truth='^(CUSTOMER_NOTES\.md|docs/OPEN_QUESTIONS\.md|docs/intake-log\.md)$'
-          hard_rule_pattern='^(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
+          hard_rule_pattern='(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
           # Extract changed paths from the proposal diff.
           changed_paths=$(grep '^diff --git' /tmp/proposal.diff | awk '{print $4}' | sed 's|^b/||' || true)
           violations=""
@@ -138,12 +138,15 @@ jobs:
               fi
             fi
             # Content check: flag any file (not already caught by path) that
-            # contains Hard-Rule-bearing text (FR-027 anchor 11).
+            # adds Hard-Rule-bearing text in the diff (FR-027 anchor 11).
+            # Grep only diff +lines to avoid false-positives from unchanged HR text.
             if ! echo "${p}" | grep -Eq "${protected_paths}" && \
-               ! echo "${p}" | grep -Eq "${customer_truth}" && \
-               [ -f "${p}" ] && grep -Eq "${hard_rule_pattern}" "${p}"; then
-              if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
-                violations="${violations} ${p}(hard-rule-content)"
+               ! echo "${p}" | grep -Eq "${customer_truth}"; then
+              added_lines=$(git diff "$base"..."$head" -- "${p}" | grep -E '^\+[^+]' | sed 's/^+//')
+              if echo "${added_lines}" | grep -Eq "${hard_rule_pattern}"; then
+                if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
+                  violations="${violations} ${p}(hard-rule-content)"
+                fi
               fi
             fi
           done

--- a/.github/workflows/improve-template.yml
+++ b/.github/workflows/improve-template.yml
@@ -46,6 +46,12 @@ jobs:
         run: |
           set -eu
           if [ -n "${ISSUE_NUMBER:-}" ]; then
+            case "${ISSUE_NUMBER}" in
+              *[!0-9]*)
+                echo "improve-template: invalid issue_number '${ISSUE_NUMBER}' (expected positive integer)" >&2
+                exit 2
+                ;;
+            esac
             echo "issue=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
           else
             # Pick the highest-reaction open template-gap issue.
@@ -115,6 +121,7 @@ jobs:
           # Build the protected-files allowlist as a single regex.
           protected_paths='^(CLAUDE\.md|AGENTS\.md|VERSION|TEMPLATE_MANIFEST\.lock|\.claude/agents/|docs/adr/|docs/framework-project-boundary\.md|docs/model-routing-guidelines\.md|\.github/workflows/|migrations/)'
           customer_truth='^(CUSTOMER_NOTES\.md|docs/OPEN_QUESTIONS\.md|docs/intake-log\.md)$'
+          hard_rule_pattern='^(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
           # Extract changed paths from the proposal diff.
           changed_paths=$(grep '^diff --git' /tmp/proposal.diff | awk '{print $4}' | sed 's|^b/||' || true)
           violations=""
@@ -128,6 +135,15 @@ jobs:
             if echo "${p}" | grep -Eq "${customer_truth}"; then
               if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
                 violations="${violations} ${p}"
+              fi
+            fi
+            # Content check: flag any file (not already caught by path) that
+            # contains Hard-Rule-bearing text (FR-027 anchor 11).
+            if ! echo "${p}" | grep -Eq "${protected_paths}" && \
+               ! echo "${p}" | grep -Eq "${customer_truth}" && \
+               [ -f "${p}" ] && grep -Eq "${hard_rule_pattern}" "${p}"; then
+              if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
+                violations="${violations} ${p}(hard-rule-content)"
               fi
             fi
           done

--- a/tests/workflows/fixtures/hard-rule-content-no-proposal.diff
+++ b/tests/workflows/fixtures/hard-rule-content-no-proposal.diff
@@ -1,0 +1,8 @@
+diff --git a/docs/templates/intake-log-template.md b/docs/templates/intake-log-template.md
+index aaaaaaa..bbbbbbb 100644
+--- a/docs/templates/intake-log-template.md
++++ b/docs/templates/intake-log-template.md
+@@ -1,3 +1,4 @@
+ # Intake Log Template
++some new line
+ Some existing content.

--- a/tests/workflows/fixtures/hard-rule-content-with-proposal.diff
+++ b/tests/workflows/fixtures/hard-rule-content-with-proposal.diff
@@ -4,7 +4,7 @@ index aaaaaaa..bbbbbbb 100644
 +++ b/docs/templates/intake-log-template.md
 @@ -1,3 +1,4 @@
  # Intake Log Template
-+some new line
++Hard Rule #1: only tech-lead interfaces with the customer.
  Some existing content.
 diff --git a/docs/proposals/task-001.md b/docs/proposals/task-001.md
 new file mode 100644

--- a/tests/workflows/fixtures/hard-rule-content-with-proposal.diff
+++ b/tests/workflows/fixtures/hard-rule-content-with-proposal.diff
@@ -1,0 +1,16 @@
+diff --git a/docs/templates/intake-log-template.md b/docs/templates/intake-log-template.md
+index aaaaaaa..bbbbbbb 100644
+--- a/docs/templates/intake-log-template.md
++++ b/docs/templates/intake-log-template.md
+@@ -1,3 +1,4 @@
+ # Intake Log Template
++some new line
+ Some existing content.
+diff --git a/docs/proposals/task-001.md b/docs/proposals/task-001.md
+new file mode 100644
+index 0000000..ccccccc
+--- /dev/null
++++ b/docs/proposals/task-001.md
+@@ -0,0 +1,3 @@
++# Proposal task-001
++This paired proposal authorises the change to intake-log-template.md.

--- a/tests/workflows/fixtures/hard-rule-unchanged-no-proposal.diff
+++ b/tests/workflows/fixtures/hard-rule-unchanged-no-proposal.diff
@@ -2,7 +2,8 @@ diff --git a/docs/templates/intake-log-template.md b/docs/templates/intake-log-t
 index aaaaaaa..bbbbbbb 100644
 --- a/docs/templates/intake-log-template.md
 +++ b/docs/templates/intake-log-template.md
-@@ -1,3 +1,4 @@
- # Intake Log Template
-+Hard Rule #1: only tech-lead interfaces with the customer.
+@@ -70,6 +70,7 @@ some middle section
+ ## Hard rules (binding)
+ 1. Only tech-lead interfaces with the customer.
++This is a non-hard-rule addition.
  Some existing content.

--- a/tests/workflows/test-improve-template-logic.sh
+++ b/tests/workflows/test-improve-template-logic.sh
@@ -49,6 +49,7 @@ protected_check() {
     diff_file=$1
     protected_paths='^(CLAUDE\.md|AGENTS\.md|VERSION|TEMPLATE_MANIFEST\.lock|\.claude/agents/|docs/adr/|docs/framework-project-boundary\.md|docs/model-routing-guidelines\.md|\.github/workflows/|migrations/)'
     customer_truth='^(CUSTOMER_NOTES\.md|docs/OPEN_QUESTIONS\.md|docs/intake-log\.md)$'
+    hard_rule_pattern='^(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
     changed_paths=$(grep '^diff --git' "${diff_file}" | awk '{print $4}' | sed 's|^b/||' || true)
     violations=""
     for p in ${changed_paths}; do
@@ -62,11 +63,57 @@ protected_check() {
                 violations="${violations} ${p}"
             fi
         fi
+        # Content check: flag any file (not already caught by path) that
+        # contains Hard-Rule-bearing text (FR-027 anchor 11, issue #144).
+        if ! echo "${p}" | grep -Eq "${protected_paths}" && \
+           ! echo "${p}" | grep -Eq "${customer_truth}" && \
+           [ -f "${p}" ] && grep -Eq "${hard_rule_pattern}" "${p}"; then
+            if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
+                violations="${violations} ${p}(hard-rule-content)"
+            fi
+        fi
     done
     if [ -n "${violations}" ]; then
         return 1
     fi
     return 0
+}
+
+# ----- numeric_validator_check ---------------------------------------------
+# Mirrors workflow "Identify target issue" numeric validation (issue #149).
+# Returns 0 = valid (positive integer or empty), 1 = invalid.
+numeric_validator_check() {
+    issue_number=$1
+    if [ -n "${issue_number}" ]; then
+        case "${issue_number}" in
+            *[!0-9]*)
+                return 1
+                ;;
+        esac
+    fi
+    return 0
+}
+
+# ----- run_numeric ---------------------------------------------------------
+# Args: label input-string expected (PASS|FAIL)
+run_numeric() {
+    label=$1
+    input=$2
+    expected=$3
+    if numeric_validator_check "${input}"; then
+        actual="PASS"
+    else
+        actual="FAIL"
+    fi
+    if [ "${expected}" = "${actual}" ]; then
+        verdict="OK"
+        pass_count=$((pass_count + 1))
+    else
+        verdict="MISMATCH"
+        fail_count=$((fail_count + 1))
+    fi
+    printf 'numeric[%s]: input="%s" expected=%s actual=%s | %s\n' \
+        "${label}" "${input}" "${expected}" "${actual}" "${verdict}"
 }
 
 # ----- run_one -------------------------------------------------------------
@@ -114,6 +161,17 @@ run_one "protected-no-proposal"       PASS  FAIL
 run_one "protected-with-proposal"     PASS  PASS
 run_one "customer-truth-no-proposal"  PASS  FAIL
 run_one "customer-truth-with-proposal" PASS PASS
+run_one "hard-rule-content-no-proposal"  PASS FAIL
+run_one "hard-rule-content-with-proposal" PASS PASS
+
+# Numeric validator tests (issue #149)
+run_numeric "valid-integer"   "123"          PASS
+run_numeric "zero"            "0"            PASS
+run_numeric "empty"           ""             PASS
+run_numeric "alpha"           "abc"          FAIL
+run_numeric "inject-newline"  "12
+extra"        FAIL
+run_numeric "semicolon"       "12;rm -rf /" FAIL
 
 printf 'test-improve-template-logic: %d pass, %d fail\n' "${pass_count}" "${fail_count}"
 

--- a/tests/workflows/test-improve-template-logic.sh
+++ b/tests/workflows/test-improve-template-logic.sh
@@ -46,10 +46,12 @@ size_cap_check() {
 # Mirrors workflow "Protected-files / customer-truth check" step.
 # Returns 0 = OK, 1 = violation.
 protected_check() {
+    _orig_dir="$(pwd)"
+    cd "$(git rev-parse --show-toplevel)"
     diff_file=$1
     protected_paths='^(CLAUDE\.md|AGENTS\.md|VERSION|TEMPLATE_MANIFEST\.lock|\.claude/agents/|docs/adr/|docs/framework-project-boundary\.md|docs/model-routing-guidelines\.md|\.github/workflows/|migrations/)'
     customer_truth='^(CUSTOMER_NOTES\.md|docs/OPEN_QUESTIONS\.md|docs/intake-log\.md)$'
-    hard_rule_pattern='^(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
+    hard_rule_pattern='(## Hard [Rr]ules?|Hard Rule #|MUST not|MUST NOT)'
     changed_paths=$(grep '^diff --git' "${diff_file}" | awk '{print $4}' | sed 's|^b/||' || true)
     violations=""
     for p in ${changed_paths}; do
@@ -64,18 +66,23 @@ protected_check() {
             fi
         fi
         # Content check: flag any file (not already caught by path) that
-        # contains Hard-Rule-bearing text (FR-027 anchor 11, issue #144).
+        # adds Hard-Rule-bearing text in the diff (FR-027 anchor 11, issue #144).
+        # Grep only diff +lines to avoid false-positives from unchanged HR text.
         if ! echo "${p}" | grep -Eq "${protected_paths}" && \
-           ! echo "${p}" | grep -Eq "${customer_truth}" && \
-           [ -f "${p}" ] && grep -Eq "${hard_rule_pattern}" "${p}"; then
-            if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
-                violations="${violations} ${p}(hard-rule-content)"
+           ! echo "${p}" | grep -Eq "${customer_truth}"; then
+            added_lines=$(grep -E '^\+[^+]' "${diff_file}" | sed 's/^+//')
+            if echo "${added_lines}" | grep -Eq "${hard_rule_pattern}"; then
+                if ! echo "${changed_paths}" | grep -Eq '^docs/proposals/.+\.md$'; then
+                    violations="${violations} ${p}(hard-rule-content)"
+                fi
             fi
         fi
     done
     if [ -n "${violations}" ]; then
+        cd "${_orig_dir}"
         return 1
     fi
+    cd "${_orig_dir}"
     return 0
 }
 
@@ -163,6 +170,8 @@ run_one "customer-truth-no-proposal"  PASS  FAIL
 run_one "customer-truth-with-proposal" PASS PASS
 run_one "hard-rule-content-no-proposal"  PASS FAIL
 run_one "hard-rule-content-with-proposal" PASS PASS
+# W2 fix: file already has HR text in unchanged lines; diff adds non-HR content -> PASS
+run_one "hard-rule-unchanged-no-proposal" PASS PASS
 
 # Numeric validator tests (issue #149)
 run_numeric "valid-integer"   "123"          PASS


### PR DESCRIPTION
Closes #144 (protected-files regex tightening + diff-only grep) + #149 (numeric validator with case-pattern rejection).

5 files, 2 commits (initial + CR respin). CR APPROVED on respin with one non-blocking observation about pre-existing test/yml asymmetry (not introduced; flag for follow-up).

Follow-up: #227 (leading-zero numeric validator W3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)