### PR TITLE
docs(pm): proactive PM dispatch after merges (#136)

### DIFF
--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -120,8 +120,11 @@ Default mode for routine PM updates. Implements rolling-wave planning
 on the session-anchored cadence in `CLAUDE.md` "Time-based cadences".
 Rationale split deferred — see `docs/agents/manual/project-manager-manual.md`.
 
-- **Trigger.** Customer asks for "PM update" / "where are we", or a
-  milestone just closed.
+- **Triggers (automatic).** After every merged PR; before every release/gate PR;
+  when a milestone closes; when status artifacts become stale. `tech-lead`
+  dispatches PM after specialist work lands to keep schedule/roadmap current.
+  **No waiting for customer request** — PM is proactive.
+- **Triggers (explicit).** Customer asks for "PM update" / "where are we".
 - **Inputs.** `git log --since=<last-pm-pass> --oneline`; merged PR
   titles; the `SCHEDULE.md` row(s) with status `in-progress`;
   `OPEN_QUESTIONS.md` rows whose status changed since last pass; row-
@@ -134,6 +137,7 @@ Rationale split deferred — see `docs/agents/manual/project-manager-manual.md`.
   mode. Full rereads are reserved for milestone-close passes, and
   those should consume evidence/archive files rather than re-touring
   closed rows.
+
 
 ## Interfaces
 

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -123,7 +123,7 @@ Rationale split deferred — see `docs/agents/manual/project-manager-manual.md`.
 - **Triggers (automatic).** After every merged PR; before every release/gate PR;
   when a milestone closes; when status artifacts become stale. `tech-lead`
   dispatches PM after specialist work lands to keep schedule/roadmap current.
-  **No waiting for customer request** — PM is proactive.
+  **PM does not wait for a customer request** — PM is proactive.
 - **Triggers (explicit).** Customer asks for "PM update" / "where are we".
 - **Inputs.** `git log --since=<last-pm-pass> --oneline`; merged PR
   titles; the `SCHEDULE.md` row(s) with status `in-progress`;

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -112,8 +112,7 @@ facility from the top-level `tech-lead` session.
 5. **Own technical delivery.** Track done / blocked / waiting-on-human.
    `project-manager` owns schedule / cost / risk / stakeholder state.
 
-
-5.1. **Dispatch project-manager after every merge.** After a PR merges,
+6. **Dispatch project-manager after every merge.** After a PR merges,
    check whether it touches scope/schedule/status (typical: activity-close
    PRs, evidence PRs, release PRs). If yes, dispatch `project-manager`
    for a delta-pass before the next task dispatch. Session-anchored rule:
@@ -122,14 +121,14 @@ facility from the top-level `tech-lead` session.
    `ROADMAP.md`, and `SCHEDULE-EVIDENCE.md` current so the team does not
    rediscover status during blocking analysis.
 
-6. **Verify specialist completion.** Check expected file changes exist
+7. **Verify specialist completion.** Check expected file changes exist
    (`git status` / diff). Zero-output returns, future-tense summaries
    ("next I will…", "let me…"), or planned-work descriptions are
    failed dispatches — retry with a smaller brief. After accepting a
    result, close that specialist promptly; dispatch the next queued
    wave as slots free.
 
-7. **Close the loop** with a short summary: what shipped, what didn't,
+8. **Close the loop** with a short summary: what shipped, what didn't,
    why. End non-trivial turns with the Turn Ledger (schema in the
    manual).
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -112,6 +112,16 @@ facility from the top-level `tech-lead` session.
 5. **Own technical delivery.** Track done / blocked / waiting-on-human.
    `project-manager` owns schedule / cost / risk / stakeholder state.
 
+
+5.1. **Dispatch project-manager after every merge.** After a PR merges,
+   check whether it touches scope/schedule/status (typical: activity-close
+   PRs, evidence PRs, release PRs). If yes, dispatch `project-manager`
+   for a delta-pass before the next task dispatch. Session-anchored rule:
+   if multiple PRs merge in the same turn, batch the PM pass (one delta
+   pass covers all merges since the last pass). This keeps `SCHEDULE.md`,
+   `ROADMAP.md`, and `SCHEDULE-EVIDENCE.md` current so the team does not
+   rediscover status during blocking analysis.
+
 6. **Verify specialist completion.** Check expected file changes exist
    (`git status` / diff). Zero-output returns, future-tense summaries
    ("next I will…", "let me…"), or planned-work descriptions are

--- a/.opencode/agents/project-manager.md
+++ b/.opencode/agents/project-manager.md
@@ -2,7 +2,7 @@
 name: project-manager
 model: gemini-flash
 canonical_source: .claude/agents/project-manager.md
-canonical_sha: 1e208b4f05c8318ea13abb2e4829d16478fba921
+canonical_sha: f34b23e4d4e0e6946abd0de98d13975f55a53938
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/tech-lead.md
+++ b/.opencode/agents/tech-lead.md
@@ -2,7 +2,7 @@
 name: tech-lead
 model: claude-sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 7ebb0e4c78d272719b63ceccfdd48716f2ca6387
+canonical_sha: 4e4a309f6267b16ae7923cea05febd1c33d098cf
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/pm/SCHEDULE.md
+++ b/docs/pm/SCHEDULE.md
@@ -15,7 +15,7 @@ This file is updated whenever a PR merges that affects milestone status,
 scope, or forecasts. Update cadence: **after every merged PR** via
 `project-manager` delta-pass dispatch from `tech-lead`. Target
 freshness: schedule and roadmap reflect the repository HEAD state within
-one session turn, never stale by more than one active work window.
+one session turn, never stale by more than one session turn.
 
 Live forecast dates in this table track actual slip; do not edit baseline
 dates once a milestone is baselined. Use `CHANGES.md` to record variance

--- a/docs/pm/SCHEDULE.md
+++ b/docs/pm/SCHEDULE.md
@@ -9,6 +9,18 @@ root). Spec directory: `specs/006-template-improvement-program/`.
 Working branches in this sub-repo: `feat/m0-baseline` (M0),
 `feat/m1-token-quick-wins` (M1, Phase 3 US1).
 
+## Freshness expectation
+
+This file is updated whenever a PR merges that affects milestone status,
+scope, or forecasts. Update cadence: **after every merged PR** via
+`project-manager` delta-pass dispatch from `tech-lead`. Target
+freshness: schedule and roadmap reflect the repository HEAD state within
+one session turn, never stale by more than one active work window.
+
+Live forecast dates in this table track actual slip; do not edit baseline
+dates once a milestone is baselined. Use `CHANGES.md` to record variance
+and `SCHEDULE-EVIDENCE.md` to archive closed milestones and their evidence.
+
 ## Milestone list
 
 | ID | Milestone | Baseline date | Forecast date | Status | Exit criterion |

--- a/docs/runtime/agents/project-manager.md
+++ b/docs/runtime/agents/project-manager.md
@@ -3,7 +3,7 @@ name: project-manager
 description: PMBOK-aligned Project Manager. Owns project-management artifacts — project charter, schedule, cost baseline, risk register, stakeholder register, change log, and lessons-learned / retrospective. Does NOT talk to the customer directly (that is `tech-lead`'s job); receives customer input relayed by `tech-lead`. Use PROACTIVELY after initial scoping to produce and maintain PM artifacts, and whenever schedule/scope/cost/risk/stakeholder/change decisions are in play.
 model: haiku
 canonical_source: .claude/agents/project-manager.md
-canonical_sha: 1e208b4f05c8318ea13abb2e4829d16478fba921
+canonical_sha: f34b23e4d4e0e6946abd0de98d13975f55a53938
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/tech-lead.md
+++ b/docs/runtime/agents/tech-lead.md
@@ -3,7 +3,7 @@ name: tech-lead
 description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
 model: sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 7ebb0e4c78d272719b63ceccfdd48716f2ca6387
+canonical_sha: 4e4a309f6267b16ae7923cea05febd1c33d098cf
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated
@@ -77,14 +77,23 @@ preference is required. Do not silently choose, and do not spawn
 5. **Own technical delivery.** Track done / blocked / waiting-on-human.
    `project-manager` owns schedule / cost / risk / stakeholder state.
 
-6. **Verify specialist completion.** Check expected file changes exist
+6. **Dispatch project-manager after every merge.** After a PR merges,
+   check whether it touches scope/schedule/status (typical: activity-close
+   PRs, evidence PRs, release PRs). If yes, dispatch `project-manager`
+   for a delta-pass before the next task dispatch. Session-anchored rule:
+   if multiple PRs merge in the same turn, batch the PM pass (one delta
+   pass covers all merges since the last pass). This keeps `SCHEDULE.md`,
+   `ROADMAP.md`, and `SCHEDULE-EVIDENCE.md` current so the team does not
+   rediscover status during blocking analysis.
+
+7. **Verify specialist completion.** Check expected file changes exist
    (`git status` / diff). Zero-output returns, future-tense summaries
    ("next I will…", "let me…"), or planned-work descriptions are
    failed dispatches — retry with a smaller brief. After accepting a
    result, close that specialist promptly; dispatch the next queued
    wave as slots free.
 
-7. **Close the loop** with a short summary: what shipped, what didn't,
+8. **Close the loop** with a short summary: what shipped, what didn't,
    why. End non-trivial turns with the Turn Ledger (schema in the
    manual).
 


### PR DESCRIPTION
## Summary

- Split PM delta-pass triggers into automatic (after every merged PR, before release PRs, on milestone close) and explicit (customer request)
- Add Job #5.1 to tech-lead.md: dispatch project-manager after every merge that affects scope/status; batch within a turn
- Add "Freshness expectation" section to docs/pm/SCHEDULE.md to set customer expectations for schedule currency

Closes #136

## Test plan

- [x] Verify all three file edits match proposal text (ISSUE-136-PROPOSED-DIFFS.md)
- [x] Confirm PM delta-pass section split is clear and binding
- [x] Confirm tech-lead Job #5.1 is specific (check scope/schedule/status) and session-anchored (batch rule)
- [x] Confirm SCHEDULE.md freshness section sets explicit cadence and target window