### PR TITLE
docs(researcher): trim Job #6 pronoun-verification to manual; clear SC-002 (#151)

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -138,33 +138,11 @@ deliverables).
 6. **Pronoun verification for teammate names.** When a teammate name
    goes into `docs/AGENT_NAMES.md`, verify pronouns against an
    authoritative source and record the citation in the row's
-   `Source` column. Source hierarchy (use the highest available):
-
-   - **Living persons** — (a) the person's own public
-     self-identification (official-site bio, verified profile,
-     first-person interview); (b) their label / publisher /
-     agency / employer bio; (c) a reference encyclopedia entry
-     **when that entry itself cites (a) or (b)** — record the URL
-     plus the date you checked it.
-   - **Historical figures** — a reference biography. Accept the
-     era's conventional pronouns as the default unless a modern
-     reference explicitly reconsiders them; in that case, cite
-     the reference and note the reconsideration.
-   - **Fictional characters** — the canon source (creator's
-     published work or the official franchise's current canonical
-     site).
-
-   Citation format in the `Source` column: one line — "<title of
-   source>, <URL or reference>, as of <YYYY-MM-DD>".
-
-   If pronouns cannot be verified to this bar, flag to `tech-lead`,
-   who either asks the customer to pick a different member of the
-   category or records the use of "they / them" as a documented
-   fallback in `CUSTOMER_NOTES.md`. Do not silently guess or default
-   to "they / them" without that record.
-
-   Re-verify pronouns before a new version of the project's
-   `AGENT_NAMES.md` ships if > 12 months since last check.
+   `Source` column. Source hierarchy, citation format, fallback
+   handling, and re-verification cadence: see
+   `docs/agents/manual/researcher-manual.md` § "Pronoun verification".
+   If pronouns cannot be verified to the manual's bar, flag to
+   `tech-lead`. Do not silently guess.
 7. **Archival + size budgets (binding).** Binding docs accumulate
    closed rows and grow past their useful density. You own rolling
    the closed content out.

--- a/docs/agents/manual/researcher-manual.md
+++ b/docs/agents/manual/researcher-manual.md
@@ -72,3 +72,45 @@ for clarification.
 **Context / implications:**
 - <only what the customer stated, or direct process context>
 ```
+
+## Pronoun verification
+
+Canonical contract Job #6 (the binding rule "verify pronouns against an
+authoritative source and record the citation") points here for the
+source hierarchy, citation format, fallback handling, and re-verification
+cadence. The detail moved from canonical to manual on 2026-05-16 (issue
+#151, SC-002 trim) — the binding *rule* still lives in the contract; only
+the procedural elaboration moved here.
+
+### Source hierarchy (use the highest available)
+
+- **Living persons** — (a) the person's own public self-identification
+  (official-site bio, verified profile, first-person interview);
+  (b) their label / publisher / agency / employer bio; (c) a reference
+  encyclopedia entry **when that entry itself cites (a) or (b)** —
+  record the URL plus the date you checked it.
+- **Historical figures** — a reference biography. Accept the era's
+  conventional pronouns as the default unless a modern reference
+  explicitly reconsiders them; in that case, cite the reference and
+  note the reconsideration.
+- **Fictional characters** — the canon source (creator's published work
+  or the official franchise's current canonical site).
+
+### Citation format
+
+One line in the `Source` column of `docs/AGENT_NAMES.md`:
+
+> "<title of source>, <URL or reference>, as of <YYYY-MM-DD>"
+
+### Fallback handling
+
+If pronouns cannot be verified to the bar above, the canonical contract
+requires flagging to `tech-lead`. From there, `tech-lead` either asks
+the customer to pick a different member of the category or records the
+use of "they / them" as a documented fallback in `CUSTOMER_NOTES.md`.
+Do not silently guess or default to "they / them" without that record.
+
+### Re-verification cadence
+
+Re-verify pronouns before a new version of the project's
+`docs/AGENT_NAMES.md` ships if > 12 months since the last check.

--- a/docs/pm/LESSONS.md
+++ b/docs/pm/LESSONS.md
@@ -399,6 +399,13 @@ grandfathering needed if the regex is tightened first.
 
 ## M2.3 researcher SC-002 exception (2026-05-13)
 
+**Status (2026-05-16, issue #151 fix-and-close):** CLOSED. Pronoun-verification
+block moved from canonical to `docs/agents/manual/researcher-manual.md`
+§ "Pronoun verification" per the deferral plan below. Runtime word count
+dropped from 1653 → 1494; SC-002 margin now 25.1% (103-word headroom).
+The original entry below is retained as the historical record.
+
+
 T034 added the FR-009 memory-first-lookup patterns to
 `.claude/agents/researcher.md`. The four canonical patterns are binding
 governance and cannot be elided. Effect on the runtime contract:

--- a/docs/pm/token-economy-baseline.md
+++ b/docs/pm/token-economy-baseline.md
@@ -75,7 +75,7 @@ R-4 (rationale-absorption pattern).
 | Agent | M0 baseline (canonical) | Post-M1.1 canonical | Generated runtime contract | Reduction (runtime vs M0) |
 |---|---:|---:|---:|---|
 | tech-lead | 3909 words | 2320 | 2251 | 42.4% — **passes SC-001 (≥30%)** |
-| researcher | 1996 words | 1604 | 1590 | 20.3% — **passes SC-002 (≥20%)** (post-T024 archival-mechanic rule added +22 words; clears the floor by 0.3 points) |
+| researcher | 1996 words | 1604 | 1494 | **25.1% — passes SC-002 (≥20%)** (post-T034 breach to 1653/17.2% recovered via issue #151 pronoun-block extraction to manual on 2026-05-16; SC-002 cleared by 103 words) |
 | code-reviewer | 528 words | 535 | 520 | 1.5% — **SC-002 "where safe" clause invoked** (canonical was already lean; no rationale to extract; further reduction would require deleting normative content) |
 | qa-engineer | 1061 words | 737 | 663 | 37.5% — **passes SC-002 (≥20%)**; +178 words added via T017 follow-up to create explicit `## Hard rules` section for schema completeness |
 
@@ -87,9 +87,11 @@ R-4 (rationale-absorption pattern).
   `docs/agents/manual/tech-lead-manual.md` and shrinking the canonical
   contract under `.claude/agents/tech-lead.md` to normative routing and
   hard-rule references only.
-- **researcher — PASS (SC-002).** Runtime 1590 vs M0 1996 = 20.3%
-  reduction, above the SC-002 ≥20% floor by 0.3 points. Rationale and
-  Tier-1 source guidance moved to `docs/agents/manual/researcher-manual.md`.
+- **researcher — PASS (SC-002).** Runtime 1494 vs M0 1996 = 25.1%
+  reduction, above the SC-002 ≥20% floor by 5.1 points. Rationale,
+  Tier-1 source guidance, and (as of 2026-05-16, issue #151) the
+  pronoun-verification procedure moved to
+  `docs/agents/manual/researcher-manual.md`.
   Post-T024 added a 5-line archive-mechanic rule (+22 runtime words);
   margin is intentionally close to the floor — future researcher edits
   must re-measure SC-002 at gate close.

--- a/docs/runtime/agents/researcher.md
+++ b/docs/runtime/agents/researcher.md
@@ -138,33 +138,11 @@ deliverables).
 6. **Pronoun verification for teammate names.** When a teammate name
    goes into `docs/AGENT_NAMES.md`, verify pronouns against an
    authoritative source and record the citation in the row's
-   `Source` column. Source hierarchy (use the highest available):
-
-   - **Living persons** — (a) the person's own public
-     self-identification (official-site bio, verified profile,
-     first-person interview); (b) their label / publisher /
-     agency / employer bio; (c) a reference encyclopedia entry
-     **when that entry itself cites (a) or (b)** — record the URL
-     plus the date you checked it.
-   - **Historical figures** — a reference biography. Accept the
-     era's conventional pronouns as the default unless a modern
-     reference explicitly reconsiders them; in that case, cite
-     the reference and note the reconsideration.
-   - **Fictional characters** — the canon source (creator's
-     published work or the official franchise's current canonical
-     site).
-
-   Citation format in the `Source` column: one line — "<title of
-   source>, <URL or reference>, as of <YYYY-MM-DD>".
-
-   If pronouns cannot be verified to this bar, flag to `tech-lead`,
-   who either asks the customer to pick a different member of the
-   category or records the use of "they / them" as a documented
-   fallback in `CUSTOMER_NOTES.md`. Do not silently guess or default
-   to "they / them" without that record.
-
-   Re-verify pronouns before a new version of the project's
-   `AGENT_NAMES.md` ships if > 12 months since last check.
+   `Source` column. Source hierarchy, citation format, fallback
+   handling, and re-verification cadence: see
+   `docs/agents/manual/researcher-manual.md` § "Pronoun verification".
+   If pronouns cannot be verified to the manual's bar, flag to
+   `tech-lead`. Do not silently guess.
 7. **Archival + size budgets (binding).** Binding docs accumulate
    closed rows and grow past their useful density. You own rolling
    the closed content out.


### PR DESCRIPTION
## Summary

Customer ruling 2026-05-16 on Q-0013 (#151 SC-002 margin disposition): **trim**.

Moves the Job #6 procedural detail from canonical (`.claude/agents/researcher.md`) into `docs/agents/manual/researcher-manual.md` § "Pronoun verification". The binding rule (verify pronouns against an authoritative source) stays in canonical; source hierarchy, citation format, fallback handling, and re-verification cadence move to the manual companion. Same M1.1 rationale-absorption pattern applied to other agents.

## Runtime impact (SC-002)

| Measure | Before this PR | After this PR |
|---|---:|---:|
| Runtime words | 1655 | **1494** |
| SC-002 floor (20% of 1996) | 1597 | 1597 |
| Reduction from baseline | 17.2% (breach) | **25.1% (pass)** |
| Margin to floor | −56 words | **+103 words** |

LESSONS §M2.3 (the recorded "where-safe exception") is marked **CLOSED** with the new measurement; the historical entry is retained as the record.

`token-economy-baseline.md` researcher row + summary updated.

`scripts/compile-runtime-agents.sh --verify` — 13/13 clean.

Closes #151

## Test plan

- [x] `compile-runtime-agents.sh --verify` returns 0 (13 OK, 0 FAIL)
- [x] `wc -w docs/runtime/agents/researcher.md` ≤ 1597
- [x] LESSONS §M2.3 records the close-out
- [x] token-economy-baseline.md researcher row reflects 1494 / 25.1%
- [ ] code-reviewer APPROVED
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)