### PR TITLE
docs(runtime): regenerate researcher mirror post-#248 (stale canonical_sha recovery)

### DIFF
--- a/.opencode/agents/researcher.md
+++ b/.opencode/agents/researcher.md
@@ -2,7 +2,7 @@
 name: researcher
 model: gemini-pro
 canonical_source: .claude/agents/researcher.md
-canonical_sha: ee61bc7158b1db43526c94906a09afbf09b91118
+canonical_sha: 630ec80090481ceb351e6bc5a318b99217c56481
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/pm/LESSONS.md
+++ b/docs/pm/LESSONS.md
@@ -402,7 +402,7 @@ grandfathering needed if the regex is tightened first.
 **Status (2026-05-16, issue #151 fix-and-close):** CLOSED. Pronoun-verification
 block moved from canonical to `docs/agents/manual/researcher-manual.md`
 § "Pronoun verification" per the deferral plan below. Runtime word count
-dropped from 1653 → 1494; SC-002 margin now 25.1% (103-word headroom).
+dropped from 1655 → 1494; SC-002 margin now 25.1% (103-word headroom).
 The original entry below is retained as the historical record.
 
 

--- a/docs/runtime/agents/researcher.md
+++ b/docs/runtime/agents/researcher.md
@@ -3,7 +3,7 @@ name: researcher
 description: Librarian and researcher. Use when the task requires authoritative information from standards (SWEBOK, ISO, IEEE, ISTQB, SFIA, PMBOK), official vendor/framework documentation, or prior art — and for recording customer-provided domain facts into CUSTOMER_NOTES.md after tech-lead gets them. Does not contact the customer directly.
 model: sonnet
 canonical_source: .claude/agents/researcher.md
-canonical_sha: ee61bc7158b1db43526c94906a09afbf09b91118
+canonical_sha: 630ec80090481ceb351e6bc5a318b99217c56481
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated


### PR DESCRIPTION
## Summary

Fixes the agent-contract CI failure introduced by PR #248. The runtime mirror and `.opencode` adapter for `researcher` were committed with the parent commit's canonical_sha, then auto-merge proceeded despite the gate failure (gate is signaling, not branch-protected).

This commit regenerates both mirrors against the post-merge HEAD so `canonical_sha` matches the now-correct blob. Also corrects a 1653 → 1655 word-count discrepancy in LESSONS §M2.3.

`scripts/compile-runtime-agents.sh --verify` — 13/13 clean.

## Test plan

- [x] `--verify` returns 0 (all 13 agents)
- [x] `wc -w docs/runtime/agents/researcher.md` → 1494 (≤1597 floor)
- [x] LESSONS §M2.3 word count matches actual pre-trim runtime (1655)
- [ ] CI green this time

## Root-cause note

This is the second recurrence of the stale-canonical_sha pitfall (PR #234, PR #248). Filing a follow-up issue for `release-engineer` to add a pre-commit guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)