### PR TITLE
chore(gitignore): mark prompt-regression results + token-ledger as session output (#189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,9 @@ tests/release-gate/snapshots/*
 # Operator-local dogfood fixtures; never commit (project-specific content)
 .dogfood-fixtures/
 
-# Lowercase stale variant of docs/pm/TOKEN_LEDGER.md (#160). Some agent
-# code paths derive the filename by lowercasing the conceptual name; the
-# canonical file is docs/pm/TOKEN_LEDGER.md (uppercase). Ignoring the
-# lowercase variant stops it appearing as untracked on every commit cycle.
+# Session output — ephemeral artifacts (issue #189 customer ruling 2026-05-16)
+# docs/pm/token-ledger.md was previously ignored as a lowercase stale variant
+# of TOKEN_LEDGER.md (#160). Q-0014 ruling supersedes: both patterns are
+# declared ephemeral session output and intentionally not tracked.
 docs/pm/token-ledger.md
+tests/prompt-regression/results-*.md

--- a/docs/pm/README.md
+++ b/docs/pm/README.md
@@ -68,3 +68,20 @@ See `scripts/log-fallback.sh --help` for the full flag set including
 | `SCHEDULE-ARCHIVE.md` | Superseded schedule snapshots. |
 | `dispatch-log.md` | Per-PR dispatch and close record for multi-PR burndowns. |
 | `pre-release-gate-overrides.md` | Bypass audit log for `scripts/pre-release-gate.sh`. |
+
+## Session-output artifacts (gitignored)
+
+Two file patterns are intentionally **not tracked** in git, declared as
+ephemeral session output per issue #189 (customer ruling 2026-05-16):
+
+- `docs/pm/token-ledger.md` — session-output notes (transient working notes,
+  not a durable artifact). Use `docs/pm/token-ledger/prompts/` if you want
+  structured tracked prompt records.
+- `tests/prompt-regression/results-*.md` — daily prompt-regression run
+  results. Each run produces a results file; the test runs themselves are
+  authoritative, not the report files.
+
+If you find these files tracked in a downstream project that pre-dates
+this convention, run `git rm --cached <path>` to untrack without deleting
+the local copy. Follow-up issue #219 tracks an automated migration for
+downstreams.


### PR DESCRIPTION
## Summary

- `.gitignore`: replaces stale issue-#160 comment on `docs/pm/token-ledger.md` and adds `tests/prompt-regression/results-*.md` under a new "Session output" heading, per customer ruling Q-0014 (2026-05-16)
- `docs/pm/README.md`: adds "Session-output artifacts (gitignored)" section documenting both patterns and pointing downstreams to `git rm --cached` with follow-up issue #219 for automated migration
- No files were tracked that required `git rm --cached`; both patterns verified firing via `git check-ignore -v`

Closes #189

## Test plan

- [ ] `git check-ignore -v docs/pm/token-ledger.md` reports `.gitignore:57`
- [ ] `git check-ignore -v tests/prompt-regression/results-2026-05-13.md` reports `.gitignore:58`
- [ ] `git ls-files docs/pm/token-ledger.md tests/prompt-regression/results-*.md` returns empty (nothing tracked)
- [ ] `docs/pm/README.md` contains the "Session-output artifacts (gitignored)" section with correct downstream migration note referencing #219

Do NOT merge — code-reviewer goes next.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to explain transient session artifacts and their handling.

* **Chores**
  * Updated project configuration to properly exclude generated session output files from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->