### PR TITLE
fix: bug-wave 2026-06-02 — #222 #276 #288 #254 (upgrade/manifest/release-gate)

### DIFF
--- a/docs/agents/manual/release-engineer-manual.md
+++ b/docs/agents/manual/release-engineer-manual.md
@@ -242,10 +242,20 @@ M8 owners ledger, release-engineer row):
 3. Commit both files as the "tag-cut step 1" commit.
 4. **Human verification:** confirm `cat VERSION` == intended tag name
    (see pre-tag checklist above).
-5. Run `scripts/pre-release-gate.sh` against that commit.
-6. If PASS: run `tests/release-gate/dogfood-downstream.sh` against that commit.
-7. If dogfood PASS: `git tag -a v1.0.0-rcN -m "v1.0.0-rcN"` at that commit.
-8. `git push origin main && git push origin v1.0.0-rcN`.
+5. Regenerate fixture snapshots (required after every VERSION bump — snapshots
+   are gitignored and the gate will fast-fail without them):
+   ```
+   bash scripts/generate-fixture-snapshots.sh
+   ```
+   This materialises `tests/release-gate/snapshots/<version>/` on disk.
+   Run this BEFORE `pre-release-gate.sh`; the `upgrade-matrix-fresh` sub-gate
+   will exit immediately with an actionable error if this step is skipped
+   (issue #288 — converts a silent ~13-min scaffold stall into a ~1-min
+   "you forgot step X" error).
+6. Run `scripts/pre-release-gate.sh` against that commit.
+7. If PASS: run `tests/release-gate/dogfood-downstream.sh` against that commit.
+8. If dogfood PASS: `git tag -a v1.0.0-rcN -m "v1.0.0-rcN"` at that commit.
+9. `git push origin main && git push origin v1.0.0-rcN`.
 
 Post-tag `VERSION` bumps to the next development version are correct
 only for stable/final releases where the next commit starts a new MINOR

--- a/migrations/v1.0.0-rc13.sh
+++ b/migrations/v1.0.0-rc13.sh
@@ -270,4 +270,40 @@ done < <(printf '%s\n' "$proceed_list")
 # Clear any stale block artefact from a prior refused run.
 rm -f "$prebootstrap_block_artefact"
 
+# Issue #254: write each bootstrap-critical path that is present in the
+# project into .template-customizations so the candidate upgrade.sh sync
+# loop treats them as accepted_local rather than 3-way conflicts.
+#
+# The failure mode this closes:
+#   When upgrading FROM v0.16.0, the v0.16.0 upgrade.sh self-bootstrap
+#   exec's the candidate upgrade.sh BEFORE the migrations loop runs.
+#   The re-exec'd candidate skips v0.14.0.sh (v0.14.0 < v0.16.0), so the
+#   marker-writing block in v0.14.0.sh never fires. The sync loop then
+#   sees scripts/upgrade.sh as baseline=v0.16.0 / project=candidate /
+#   upstream=candidate — project==upstream but baseline!=project, which
+#   with no marker present routes to the accepted_via_manifest path. If
+#   the manifest SHA also doesn't match, the file lands in conflicts[] and
+#   --verify exits 1. (Issue #163 original fix; issue #254 extends it.)
+#
+# We write the marker here unconditionally for every bootstrap-critical
+# path that is present in the project, regardless of whether THIS
+# migration's proceed list installed it or the caller's self-bootstrap did.
+# Idempotent: check before appending. (FW-ADR-0010.)
+customizations_file="$PROJECT_ROOT/.template-customizations"
+marker_comment="# pre-bootstrapped by migrations/v1.0.0-rc13.sh (issue #254)"
+while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    # Only mark paths that exist locally (present after pre-bootstrap).
+    [ -f "$PROJECT_ROOT/$rel" ] || continue
+    # Escape the path for use in a grep extended-regex.
+    rel_escaped="$(printf '%s' "$rel" | sed 's/[]\.*^$[]/\\&/g')"
+    if [ -f "$customizations_file" ] && \
+       grep -E "^[[:space:]]*${rel_escaped}([[:space:]]|$)" \
+            "$customizations_file" >/dev/null 2>&1; then
+        continue  # already listed; idempotent
+    fi
+    printf '%s  %s\n' "$rel" "$marker_comment" >> "$customizations_file"
+    echo "  marked $rel in .template-customizations (pre-bootstrap marker; issue #254)"
+done < <(printf '%s\n' "$prebootstrap_paths")
+
 exit 0

--- a/scripts/lib/gate-tags.sh
+++ b/scripts/lib/gate-tags.sh
@@ -367,6 +367,13 @@ gate_subgate_upgrade-paths() {
 #   the gate if any committed snapshot diverges from a fresh regen.
 #   Bounded by upgrade-paths' ~8 min budget (FR-005); the --check path
 #   uses the same scaffold-and-mutate pipeline as a generation run.
+#
+#   Pre-flight (issue #288): before launching the expensive generator
+#   pipeline, verify the clean/ snapshot for the current VERSION exists
+#   on disk.  A missing snapshot means the generator was not run after the
+#   VERSION bump; we fast-fail immediately with an actionable message so
+#   the operator pays <1 min to diagnose instead of ~13 min for the full
+#   scaffold-and-mutate loop to exhaust before reporting MISSING.
 gate_subgate_upgrade-matrix-fresh() {
     cd "$GATE_CANDIDATE_TREE" || return 1
     generator="$GATE_CANDIDATE_TREE/scripts/generate-fixture-snapshots.sh"
@@ -374,6 +381,26 @@ gate_subgate_upgrade-matrix-fresh() {
         echo "upgrade-matrix-fresh: $generator missing or not executable"
         return 1
     fi
+
+    # ----- Pre-flight: current-VERSION snapshot existence check (issue #288) ----
+    # Read the VERSION file once; skip the check only if VERSION is absent
+    # (edge case: brand-new repo with no VERSION file yet).
+    if [ -f "$GATE_CANDIDATE_TREE/VERSION" ]; then
+        current_version="$(tr -d '[:space:]' < "$GATE_CANDIDATE_TREE/VERSION")"
+        if [ -n "$current_version" ]; then
+            clean_snapshot="$GATE_CANDIDATE_TREE/tests/release-gate/snapshots/$current_version/clean"
+            if [ ! -d "$clean_snapshot" ]; then
+                echo "upgrade-matrix-fresh: pre-flight FAIL — snapshot missing for current VERSION."
+                echo "  Missing: tests/release-gate/snapshots/$current_version/clean/"
+                echo "  Snapshots are gitignored and must be regenerated after every VERSION bump."
+                echo "  Fix: run  bash scripts/generate-fixture-snapshots.sh"
+                echo "  Then re-run the gate."
+                return 1
+            fi
+        fi
+    fi
+    # -----------------------------------------------------------------------
+
     # Run --check; capture stderr (the generator's diagnostic surface).
     if "$generator" --check 2>&1; then
         return 0

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -11,7 +11,10 @@
 #
 # Exports:
 #   manifest_ship_files <repo>           - list shipped files, sorted
-#   manifest_file_sha   <abs-path>       - sha256 hex of one file
+#   manifest_file_sha   <abs-path>       - sha256 hex of one file (raw)
+#   manifest_file_sha_normalized         - sha256 hex, stripping runtime-
+#     <abs-path> <repo-rel-path>           mutable "activity" from handoff
+#                                          JSON before hashing (issue #276)
 #   manifest_write      <repo> <out>     - write manifest from repo
 #   manifest_verify     <repo> <manifest-path>
 #                                        - verify; rc 0/1/2/3
@@ -74,6 +77,52 @@ manifest_ship_files() {
 # SHA256 of a file (hex hash only, no filename).
 manifest_file_sha() {
   sha256sum "$1" | awk '{print $1}'
+}
+
+# SHA256 of a file after stripping the runtime-mutable "activity" key
+# from handoff JSON files (issue #276).
+#
+# handoff-record-activity.py appends to docs/handoffs/*.json on every
+# PreToolUse/PostToolUse boundary, making the file's content hash
+# change at runtime even though the durable contract portions
+# (status/mode/allowed_paths/hard_rule_traces/acceptance_criteria/
+# verification) are framework-managed and should remain verified.
+#
+# Files matching docs/handoffs/*.json are normalized before hashing:
+# the top-level "activity" key and its entire array value are removed
+# from the JSON, and the result is re-serialised with sorted keys so
+# the hash is stable regardless of field ordering. All other files are
+# hashed from raw bytes (identical to manifest_file_sha).
+#
+# This function is applied symmetrically in manifest_write and
+# manifest_verify so the hash in the manifest and the hash at verify
+# time are computed identically — preserving durable-contract
+# verification while ignoring runtime telemetry.
+manifest_file_sha_normalized() {
+  local path="$1"
+  local relpath="${2:-}"
+  # Normalize only docs/handoffs/*.json files.
+  if [[ "$relpath" =~ ^docs/handoffs/[^/]+\.json$ ]] \
+     || [[ -z "$relpath" && "$path" =~ /docs/handoffs/[^/]+\.json$ ]]; then
+    # Use python3 (required by the hook layer already) to strip
+    # "activity", sort keys, and emit canonical JSON.  Falls back to
+    # raw sha256sum if python3 is unavailable so the function never
+    # silently produces a wrong answer — it fails loudly instead.
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - "$path" <<'PYEOF' | sha256sum | awk '{print $1}'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    doc = json.load(f)
+doc.pop("activity", None)
+print(json.dumps(doc, sort_keys=True, ensure_ascii=False))
+PYEOF
+    else
+      echo "ERROR: manifest_file_sha_normalized: python3 not found; cannot normalize $path" >&2
+      return 1
+    fi
+  else
+    sha256sum "$path" | awk '{print $1}'
+  fi
 }
 
 # Decide whether the destination release declares <path> as a fresh-write.
@@ -197,7 +246,7 @@ manifest_write() {
     while IFS= read -r f; do
       [[ -z "$f" ]] && continue
       if [[ -f "$project_repo/$f" ]]; then
-        printf '%s  %s\n' "$(manifest_file_sha "$project_repo/$f")" "$f"
+        printf '%s  %s\n' "$(manifest_file_sha_normalized "$project_repo/$f" "$f")" "$f"
       fi
     done < <(manifest_ship_files "$paths_repo" "$project_repo")
   } > "$out"
@@ -250,7 +299,7 @@ manifest_verify() {
       continue
     fi
     local actual
-    actual="$(manifest_file_sha "$repo/$path")"
+    actual="$(manifest_file_sha_normalized "$repo/$path" "$path")"
     if [[ "$actual" != "${expected[$path]}" ]]; then
       printf 'drift:    %s\n  expected %s\n  actual   %s\n' "$path" "${expected[$path]}" "$actual"
       drift=1

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -4,6 +4,8 @@
 #
 # scripts/lib/manifest.sh — shared TEMPLATE_MANIFEST.lock helpers.
 #
+# Requires: python3 (for manifest_file_sha_normalized on handoff JSON files)
+#
 # Per FW-ADR-0002 (upgrade content verification, hash-based, manifest-
 # primary). Sourced by scripts/upgrade.sh (write at upgrade-end +
 # verify at --verify) and scripts/scaffold.sh (write at scaffold-end
@@ -109,13 +111,34 @@ manifest_file_sha_normalized() {
     # raw sha256sum if python3 is unavailable so the function never
     # silently produces a wrong answer — it fails loudly instead.
     if command -v python3 >/dev/null 2>&1; then
-      python3 - "$path" <<'PYEOF' | sha256sum | awk '{print $1}'
+      # Capture normalized JSON from python3 separately so a non-zero exit
+      # (malformed JSON, I/O error) is detected before it reaches sha256sum.
+      # Without this intermediate capture, a failing python3 still pipes an
+      # empty stream into sha256sum, which would produce the sha256 of the
+      # empty string — a silently wrong hash that could be persisted to the
+      # manifest lock.  Fail-closed: return 1 on any error.
+      local _normalized_json
+      _normalized_json="$(python3 - "$path" <<'PYEOF'
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     doc = json.load(f)
 doc.pop("activity", None)
 print(json.dumps(doc, sort_keys=True, ensure_ascii=False))
 PYEOF
+      )" || {
+        echo "ERROR: manifest_file_sha_normalized: python3 failed normalizing $path" >&2
+        return 1
+      }
+      local _hash
+      _hash="$(printf '%s\n' "$_normalized_json" | sha256sum | awk '{print $1}')"
+      # Sanity-check: a valid sha256 hex is exactly 64 lowercase hex chars.
+      # An empty or malformed hash here means sha256sum itself failed or the
+      # pipeline was silently truncated; refuse to return a bad value.
+      if [[ ! "$_hash" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "ERROR: manifest_file_sha_normalized: hash validation failed for $path (got '${_hash}')" >&2
+        return 1
+      fi
+      printf '%s\n' "$_hash"
     else
       echo "ERROR: manifest_file_sha_normalized: python3 not found; cannot normalize $path" >&2
       return 1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1601,6 +1601,31 @@ if [[ -f "$_prerun_conflicts_path" ]]; then
     [[ -n "$_c_path" ]] || continue
     prior_conflict_sha["$_c_path"]="$_c_proj"
   done < "$_prerun_conflicts_path"
+  # Issue #222: sanity-check the parse result.  If the file is non-empty
+  # AND contains raw "classified": "conflict" markers BUT we extracted
+  # zero keys, the file is malformed (e.g. truncated mid-write by a
+  # prior kill).  Continuing would leave the #200 rerun-safety guard
+  # silently disarmed, so hard-fail here — consistent with the script's
+  # other integrity checks (pre-bootstrap, preservation-vs-manifest,
+  # --verify).  The three-condition gate is intentional: a legitimate
+  # conflicts file whose entries are all accepted_local/local_only_kept
+  # is non-empty with zero conflict keys and must NOT trigger this block.
+  # Residual risk: a truncation that corrupts the "classified": "conflict"
+  # token itself is indistinguishable from a no-conflict file and will not
+  # trip this gate.  Full JSON-schema validation would close that gap but
+  # is a larger change; tracked as a follow-up (issue #222 notes).
+  if [[ ${#prior_conflict_sha[@]} -eq 0 ]] \
+      && [[ -s "$_prerun_conflicts_path" ]] \
+      && grep -q '"classified": "conflict"' "$_prerun_conflicts_path"; then
+    echo "ERROR: issue #222: $_prerun_conflicts_path is non-empty and contains conflict markers but the line-parser extracted zero prior_conflict_sha keys — the file is likely malformed or truncated mid-write." >&2
+    echo "       The #200 rerun-safety guard cannot fire for the affected entries." >&2
+    echo "       Repair steps:" >&2
+    echo "         1. Inspect $_prerun_conflicts_path for truncation or corruption." >&2
+    echo "         2. If the tracked conflicts are gone (hand-merged or abandoned), delete the file and re-run." >&2
+    echo "         3. If the file is repairable, restore valid JSON and re-run." >&2
+    echo "         4. Run scripts/upgrade.sh --resolve after any hand-merges to clear resolved entries." >&2
+    exit 1
+  fi
 fi
 unset _prerun_conflicts_path _c_line _c_path _c_proj
 
@@ -2242,7 +2267,11 @@ EOF
         for f in "${accepted_local[@]}"; do emit_entry "$f" "accepted_local"; done
       fi
       printf '\n  ]\n}\n'
-    } > "$conflicts_path"
+    } > "$conflicts_path.tmp.$$"
+    # Issue #222: atomic rename so a kill mid-write never leaves a
+    # truncated file on disk that the #200 parser would silently
+    # misread as "no prior conflicts".
+    mv "$conflicts_path.tmp.$$" "$conflicts_path"
   else
     # No tracked entries — remove any stale file from a prior upgrade.
     rm -f "$conflicts_path"

--- a/tests/release-gate/generator-tests/test-matrix-fresh-preflight.sh
+++ b/tests/release-gate/generator-tests/test-matrix-fresh-preflight.sh
@@ -21,6 +21,10 @@
 # does NOT require a clean worktree (unlike fixtures 06/07/08 in
 # test-gate-fail-each.sh which must commit + reset --hard).
 #
+# VERSION-mutation hygiene: the restore trap removes VERSION when it was
+# originally absent, and byte-for-byte restores it when it was present.
+# This keeps the working tree clean regardless of how the test exits.
+#
 # Owned by release-engineer (procedure gap, issue #288).
 
 set -eu
@@ -34,16 +38,26 @@ fail=0
 PREFLIGHT_MSG="pre-flight FAIL"
 FIX_CMD="bash scripts/generate-fixture-snapshots.sh"
 
-# Preserve real VERSION content for restore.
+# ---------------------------------------------------------------------------
+# Hermetic VERSION save/restore
+# ---------------------------------------------------------------------------
 version_file="$repo_root/VERSION"
+version_was_present=0
+real_version=""
 if [ -f "$version_file" ]; then
+    version_was_present=1
     real_version="$(cat "$version_file")"
-else
-    real_version=""
 fi
 
 restore_version() {
-    printf '%s' "$real_version" > "$version_file"
+    if [ "$version_was_present" -eq 1 ]; then
+        # printf '%s\n' matches the original: command substitution strips the
+        # trailing newline from cat's output, so we add it back on restore.
+        printf '%s\n' "$real_version" > "$version_file"
+    else
+        # File did not exist before — remove it so the tree is clean.
+        rm -f "$version_file"
+    fi
 }
 trap restore_version EXIT
 

--- a/tests/release-gate/generator-tests/test-matrix-fresh-preflight.sh
+++ b/tests/release-gate/generator-tests/test-matrix-fresh-preflight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/release-gate/generator-tests/test-matrix-fresh-preflight.sh —
+# unit test for the upgrade-matrix-fresh pre-flight snapshot check
+# (issue #288, gate-tags.sh gate_subgate_upgrade-matrix-fresh).
+#
+# Asserts:
+#   (a) When the current-VERSION clean/ snapshot is ABSENT from disk,
+#       the sub-gate exits non-zero immediately with a message that names
+#       the missing path and the fix command.
+#   (b) When the current-VERSION clean/ snapshot is PRESENT on disk,
+#       the pre-flight does NOT emit the fast-fail message (the sub-gate
+#       may still fail for drift reasons, but not the pre-flight branch).
+#
+# Strategy: manipulate the GATE_CANDIDATE_TREE's VERSION file to point at
+# a synthetic version whose snapshot never exists (absent case), then
+# point it at a version whose snapshot does exist (present case).
+# Invokes the sub-gate directly by sourcing the library, so this test
+# does NOT require a clean worktree (unlike fixtures 06/07/08 in
+# test-gate-fail-each.sh which must commit + reset --hard).
+#
+# Owned by release-engineer (procedure gap, issue #288).
+
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+gate="$repo_root/scripts/pre-release-gate.sh"
+
+pass=0
+fail=0
+
+PREFLIGHT_MSG="pre-flight FAIL"
+FIX_CMD="bash scripts/generate-fixture-snapshots.sh"
+
+# Preserve real VERSION content for restore.
+version_file="$repo_root/VERSION"
+if [ -f "$version_file" ]; then
+    real_version="$(cat "$version_file")"
+else
+    real_version=""
+fi
+
+restore_version() {
+    printf '%s' "$real_version" > "$version_file"
+}
+trap restore_version EXIT
+
+# ---------------------------------------------------------------------------
+# Case (a): absent snapshot — pre-flight must fire
+# ---------------------------------------------------------------------------
+fake_version="v0.0.0-matrix-fresh-preflight-test-$$"
+printf '%s\n' "$fake_version" > "$version_file"
+
+absent_out=$("$gate" --only upgrade-matrix-fresh 2>&1) || absent_rc=$?
+absent_rc=${absent_rc:-0}
+
+restore_version
+
+if [ "$absent_rc" -eq 0 ]; then
+    echo "  FAIL: [preflight-absent] gate exited 0 — pre-flight should have returned non-zero"
+    fail=$((fail + 1))
+else
+    missing_path="tests/release-gate/snapshots/$fake_version/clean/"
+    ok=1
+    if ! printf '%s' "$absent_out" | grep -qF "$missing_path"; then
+        echo "  FAIL: [preflight-absent] output does not name missing path '$missing_path'"
+        printf '%s\n' "$absent_out" | grep -i 'missing\|snapshot\|Missing' | head -5 | sed 's/^/         /' >&2
+        ok=0
+    fi
+    if ! printf '%s' "$absent_out" | grep -qF "$FIX_CMD"; then
+        echo "  FAIL: [preflight-absent] output does not name fix command '$FIX_CMD'"
+        printf '%s\n' "$absent_out" | grep -i 'generate\|fix\|run' | head -5 | sed 's/^/         /' >&2
+        ok=0
+    fi
+    if [ "$ok" -eq 1 ]; then
+        echo "  PASS: [preflight-absent] pre-flight fires on absent snapshot (rc=$absent_rc); message names path and fix"
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Case (b): present snapshot — pre-flight must NOT fire
+# ---------------------------------------------------------------------------
+# Find a version whose clean/ snapshot exists on disk.
+snapshots_root="$repo_root/tests/release-gate/snapshots"
+present_version=""
+for d in "$snapshots_root"/*/clean; do
+    [ -d "$d" ] || continue
+    # Extract the version component (parent dir name).
+    v="$(basename "$(dirname "$d")")"
+    present_version="$v"
+    break
+done
+
+if [ -z "$present_version" ]; then
+    echo "  SKIP: [preflight-present] no clean/ snapshot exists on disk — run generate-fixture-snapshots.sh first"
+else
+    printf '%s\n' "$present_version" > "$version_file"
+    present_out=$("$gate" --only upgrade-matrix-fresh 2>&1) || true
+    restore_version
+
+    if printf '%s' "$present_out" | grep -qF "$PREFLIGHT_MSG"; then
+        echo "  FAIL: [preflight-present] pre-flight message fired even though clean/ snapshot exists for $present_version"
+        printf '%s\n' "$present_out" | grep "$PREFLIGHT_MSG" | head -3 | sed 's/^/         /' >&2
+        fail=$((fail + 1))
+    else
+        echo "  PASS: [preflight-present] pre-flight silent when clean/ snapshot present (VERSION=$present_version)"
+        pass=$((pass + 1))
+    fi
+fi
+
+echo
+echo "------------------------------------------------------------"
+echo "test-matrix-fresh-preflight: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/release-gate/test-gate-fail-each.sh
+++ b/tests/release-gate/test-gate-fail-each.sh
@@ -403,22 +403,41 @@ fi
 # pre-release-gate.sh directly).
 
 fixture09_version_file="$repo_root/VERSION"
+fixture09_version_was_present=0
 if [ -f "$fixture09_version_file" ]; then
+    fixture09_version_was_present=1
     fixture09_real_version="$(cat "$fixture09_version_file")"
 else
     fixture09_real_version=""
 fi
 
+# Hermetic restore: remove VERSION when it was originally absent; otherwise
+# restore exact original bytes.  Used both in the inline restore below and
+# in the revert-trap registration so the tree is clean however the test exits.
+fixture09_restore_version() {
+    if [ "$fixture09_version_was_present" -eq 1 ]; then
+        # printf '%s\n' matches the original: command substitution strips the
+        # trailing newline from cat's output, so we add it back on restore.
+        printf '%s\n' "$fixture09_real_version" > "$fixture09_version_file"
+    else
+        rm -f "$fixture09_version_file"
+    fi
+}
+
 # --- 09-a: snapshot ABSENT — expect fast-fail ---
 fixture09_fake_version="v0.0.0-fixture-09-$$"
 printf '%s\n' "$fixture09_fake_version" > "$fixture09_version_file"
-register_revert "printf '%s\n' '$fixture09_real_version' > '$fixture09_version_file'"
+if [ "$fixture09_version_was_present" -eq 1 ]; then
+    register_revert "printf '%s\n' '${fixture09_real_version}' > '${fixture09_version_file}'"
+else
+    register_revert "rm -f '${fixture09_version_file}'"
+fi
 
 fixture09_out=$("$gate" --only upgrade-matrix-fresh 2>&1) || fixture09_rc=$?
 fixture09_rc=${fixture09_rc:-0}
 
 # Restore immediately (don't wait for trap).
-printf '%s\n' "$fixture09_real_version" > "$fixture09_version_file"
+fixture09_restore_version
 revert_actions=()
 
 if [ "$fixture09_rc" -eq 0 ]; then

--- a/tests/release-gate/test-gate-fail-each.sh
+++ b/tests/release-gate/test-gate-fail-each.sh
@@ -375,6 +375,107 @@ else
     fail=$((fail + 1))
 fi
 
+# ----- Fixture 09: current-VERSION clean/ snapshot absent → upgrade-matrix-fresh fast-fail --
+# Issue #288: gate_subgate_upgrade-matrix-fresh must detect a missing
+# tests/release-gate/snapshots/<VERSION>/clean/ directory early — BEFORE
+# launching the expensive scaffold-and-mutate loop — and exit with a clear
+# actionable message naming the missing path and the fix command.
+#
+# Strategy:
+#   (a) ABSENT case: temporarily move the VERSION's clean/ dir aside (or
+#       create a synthetic VERSION whose snapshot never exists).  Run the
+#       gate with --only upgrade-matrix-fresh.  Assert: non-zero exit AND
+#       the fast-fail message is present in the output.
+#   (b) PRESENT case: restore (or keep) the real snapshot dir and confirm
+#       the pre-flight does NOT trigger (gate output must NOT contain the
+#       fast-fail message).
+#
+# We always use a synthetic VERSION value (fixture-09-<PID>) to avoid
+# touching production snapshot directories.  The synthetic version has no
+# snapshot on disk by definition, so the absent-snapshot condition is
+# guaranteed without any filesystem surgery.
+#
+# Synthetic VERSION is written to the VERSION file for the duration of the
+# fixture, then restored.  The worktree-clean sub-gate would block
+# --only upgrade-matrix-fresh from running; we use --only to bypass all
+# other sub-gates (the gate's flag is honoured outside strict mode, and
+# the pre-push hook's strict mode is irrelevant here — we invoke
+# pre-release-gate.sh directly).
+
+fixture09_version_file="$repo_root/VERSION"
+if [ -f "$fixture09_version_file" ]; then
+    fixture09_real_version="$(cat "$fixture09_version_file")"
+else
+    fixture09_real_version=""
+fi
+
+# --- 09-a: snapshot ABSENT — expect fast-fail ---
+fixture09_fake_version="v0.0.0-fixture-09-$$"
+printf '%s\n' "$fixture09_fake_version" > "$fixture09_version_file"
+register_revert "printf '%s\n' '$fixture09_real_version' > '$fixture09_version_file'"
+
+fixture09_out=$("$gate" --only upgrade-matrix-fresh 2>&1) || fixture09_rc=$?
+fixture09_rc=${fixture09_rc:-0}
+
+# Restore immediately (don't wait for trap).
+printf '%s\n' "$fixture09_real_version" > "$fixture09_version_file"
+revert_actions=()
+
+if [ "$fixture09_rc" -eq 0 ]; then
+    echo "  FAIL: [09a-matrix-fresh-absent] gate exited 0 — expected non-zero (pre-flight should have fired)"
+    fail=$((fail + 1))
+else
+    # Verify the fast-fail message names both the missing path and the fix command.
+    missing_path="tests/release-gate/snapshots/$fixture09_fake_version/clean/"
+    fix_cmd="bash scripts/generate-fixture-snapshots.sh"
+    msg_ok=1
+    if ! printf '%s' "$fixture09_out" | grep -qF "$missing_path"; then
+        echo "  FAIL: [09a-matrix-fresh-absent] fast-fail message does not name missing path '$missing_path'"
+        echo "       output: $(printf '%s' "$fixture09_out" | grep 'Missing\|missing\|snapshot' | head -5 || echo '<no match>')"
+        msg_ok=0
+    fi
+    if ! printf '%s' "$fixture09_out" | grep -qF "$fix_cmd"; then
+        echo "  FAIL: [09a-matrix-fresh-absent] fast-fail message does not name fix command '$fix_cmd'"
+        echo "       output: $(printf '%s' "$fixture09_out" | grep 'generate\|Fix\|run' | head -5 || echo '<no match>')"
+        msg_ok=0
+    fi
+    if [ "$msg_ok" -eq 1 ]; then
+        echo "  PASS: [09a-matrix-fresh-absent] pre-flight fires on absent snapshot (rc=$fixture09_rc); message names path and fix"
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+    fi
+fi
+
+# --- 09-b: snapshot PRESENT — pre-flight must NOT trigger fast-fail ---
+# Use the real version.  If its clean/ snapshot dir exists on disk, confirm
+# that running --only upgrade-matrix-fresh does NOT emit the pre-flight
+# fast-fail message (the sub-gate may still fail for other reasons — drift,
+# etc. — but the fast-fail message must be absent).
+#
+# If the real VERSION's clean/ snapshot is absent (e.g., fresh clone after
+# a bump with no regen), this sub-case cannot verify the "present" path and
+# is skipped with a clear note.
+if [ -n "$fixture09_real_version" ]; then
+    real_clean="$repo_root/tests/release-gate/snapshots/$fixture09_real_version/clean"
+    if [ -d "$real_clean" ]; then
+        fixture09b_out=$("$gate" --only upgrade-matrix-fresh 2>&1) || true
+        preflight_msg="pre-flight FAIL"
+        if printf '%s' "$fixture09b_out" | grep -qF "$preflight_msg"; then
+            echo "  FAIL: [09b-matrix-fresh-present] pre-flight message triggered even though clean/ snapshot exists"
+            echo "       output: $(printf '%s' "$fixture09b_out" | grep "$preflight_msg" | head -3)"
+            fail=$((fail + 1))
+        else
+            echo "  PASS: [09b-matrix-fresh-present] pre-flight silent when clean/ snapshot present (VERSION=$fixture09_real_version)"
+            pass=$((pass + 1))
+        fi
+    else
+        echo "  SKIP: [09b-matrix-fresh-present] real clean/ snapshot not on disk — regen not yet run; cannot verify present-path"
+    fi
+else
+    echo "  SKIP: [09b-matrix-fresh-present] VERSION file absent or empty — skipping present-path check"
+fi
+
 echo
 echo "------------------------------------------------------------"
 echo "test-gate-fail-each: $pass passed, $fail failed"

--- a/tests/release-gate/upgrade-paths-allowlist.txt
+++ b/tests/release-gate/upgrade-paths-allowlist.txt
@@ -36,22 +36,6 @@
 # shipped in rc4 and forward.
 v1.0.0-rc3
 
-# v0.16.0 — scripts/upgrade.sh 3-way conflict; the fix in f163897
-# (migrations/v0.14.0.sh marker-writing, issue #163) is broken by
-# migration ordering: v0.16.0's upgrade.sh self-bootstraps (exec's as
-# candidate upgrade.sh) before the migrations loop runs, so the
-# re-execed candidate skips v0.14.0.sh (v0.14.0 < v0.16.0 boundary)
-# and the .template-customizations marker is never written. The sync
-# loop then sees a 3-way conflict on scripts/upgrade.sh
-# (baseline=v0.16.0, project=candidate after pre-bootstrap,
-# upstream=candidate); --verify finds the persisted conflict entry and
-# exits 1. Root cause logged in follow-up issue [see rc14 PR body].
-# v0.16.0 is a single-version sliver between v0.15.x and v0.17.0 with
-# negligible expected downstream presence. Real fix requires a migration
-# at a boundary > v0.16.0 (e.g., v0.17.0.sh or a sync-loop preserve
-# heuristic). Restored for rc14 cut; re-allowlisted from rc11/rc12/rc13.
-v0.16.0
-
 # v0.17.0 — frozen-tag self-bootstrap defect: same shift-2/re-exec argv-drop
 # defect as v1.0.0-rc3 (see entry above). At v0.17.0, scripts/pre-release-gate.sh
 # executed `exec bash "$0" "$@"` AFTER a prior `shift 2` had already consumed

--- a/tests/upgrade/test-conflicts-parser-sanity-issue-222.sh
+++ b/tests/upgrade/test-conflicts-parser-sanity-issue-222.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/upgrade/test-conflicts-parser-sanity-issue-222.sh — regression for
+# issue #222: malformed/truncated .template-conflicts.json that contains raw
+# "classified": "conflict" markers but is unparseable by the line-level loop
+# must hard-fail (exit 1) with a clear repair-steps message.
+#
+# Background:
+#   The writer in upgrade.sh formerly used `} > "$conflicts_path"` — a
+#   truncate-then-write that can leave a partial file on disk if the process
+#   is killed mid-write.  The parser uses a line-level grep/sed loop with no
+#   JSON-validity check.  A truncated file can produce zero prior_conflict_sha
+#   keys even when raw conflict markers are present, causing the #200
+#   rerun-safety guard to silently fail open.
+#
+#   Fix (issue #222, two parts):
+#     A. Writer: atomic tmp+rename (`conflicts_path.tmp.$$` → rename).
+#     B. Parser: after the loop, if file is non-empty AND contains raw
+#        "classified": "conflict" markers AND extracted zero keys →
+#        exit 1 with repair-steps message.
+#
+# Cases:
+#   #222-static-A  — upgrade.sh contains the ERROR exit-1 guard.
+#   #222-static-B  — upgrade.sh uses atomic tmp file (conflicts_path.tmp.$$).
+#   #222-static-C  — atomic mv of conflicts_path.tmp.$$ present.
+#   #222-static-D  — guard checks prior_conflict_sha count == 0.
+#   #222-unit-A    — well-formed file with a conflict entry → guard does
+#                    NOT fire (exit 0, no ERROR message).
+#   #222-unit-B    — truncated file: raw "classified": "conflict" present but
+#                    "path" is on a separate line so sed yields nothing →
+#                    guard fires (exit 1, ERROR message emitted).
+#   #222-unit-C    — empty file → guard does NOT fire (exit 0).
+#   #222-unit-D    — non-empty file with only accepted_local entries and zero
+#                    conflict markers → guard does NOT fire (false-positive
+#                    protection per the 3-condition gate requirement).
+#
+# Why inline unit tests instead of end-to-end invocation of upgrade.sh:
+#   upgrade.sh requires a live upstream clone (network) to proceed past the
+#   pre-bootstrap block to the parser at ~line 1592.  The parser logic is
+#   self-contained and short enough to replicate directly; this keeps the
+#   test offline and fast while still exercising the exact condition branches
+#   added by the fix.  The static checks confirm the guard code is actually
+#   present in upgrade.sh.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+upgrade="$repo_root/scripts/upgrade.sh"
+
+tmp="$(mktemp -d -t upgrade-issue-222-XXXXXX)"
+keep=0
+[[ "${1:-}" == "--keep" ]] && keep=1
+trap 'if [[ $keep -eq 0 ]]; then rm -rf "$tmp"; else echo "(kept $tmp for inspection)" >&2; fi' EXIT
+
+fail=0
+pass=0
+
+check() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Static checks (issue #222 implementation presence)
+# ---------------------------------------------------------------------------
+echo "-- #222 static checks --"
+
+check "#222-static-A: ERROR exit-1 guard for issue #222 present in upgrade.sh" \
+  grep -q "ERROR: issue #222" "$upgrade"
+
+check "#222-static-B: writer uses atomic tmp file (conflicts_path.tmp.\$\$)" \
+  grep -q 'conflicts_path\.tmp\.\$\$' "$upgrade"
+
+check "#222-static-C: atomic mv of conflicts_path.tmp.\$\$ into conflicts_path" \
+  grep -qP 'mv "\$conflicts_path\.tmp\.\$\$" "\$conflicts_path"' "$upgrade"
+
+check "#222-static-D: guard checks prior_conflict_sha count == 0" \
+  grep -q 'prior_conflict_sha\[@\]\}' "$upgrade"
+
+# ---------------------------------------------------------------------------
+# Inline unit tests: replicate the exact guard logic from upgrade.sh so we
+# can exercise the condition branches without network access.
+#
+# The guard (as implemented in upgrade.sh after the fix):
+#
+#   if [[ ${#prior_conflict_sha[@]} -eq 0 ]] \
+#       && [[ -s "$path" ]] \
+#       && grep -q '"classified": "conflict"' "$path"; then
+#     echo "ERROR: issue #222: ..." >&2
+#     ...
+#     exit 1
+#   fi
+#
+# run_guard returns the exit code and writes combined stdout+stderr to a log.
+# ---------------------------------------------------------------------------
+
+run_guard() {
+  local conflicts_file="$1"
+  local log="$2"
+  local rc=0
+  bash -c '
+    set -u
+    conflicts_file="$1"
+    declare -A prior_conflict_sha=()
+    if [[ -f "$conflicts_file" ]]; then
+      while IFS= read -r _c_line; do
+        [[ "$_c_line" == *'"'"'"classified": "conflict"'"'"'* ]] || continue
+        _c_path="$(printf "%s" "$_c_line" | sed -n '"'"'s/.*"path": "\([^"]*\)".*/\1/p'"'"')"
+        _c_proj="$(printf "%s" "$_c_line" | sed -n '"'"'s/.*"project_sha": "\([^"]*\)".*/\1/p'"'"')"
+        [[ -n "$_c_path" ]] || continue
+        prior_conflict_sha["$_c_path"]="$_c_proj"
+      done < "$conflicts_file"
+      if [[ ${#prior_conflict_sha[@]} -eq 0 ]] \
+          && [[ -s "$conflicts_file" ]] \
+          && grep -q '"'"'"classified": "conflict"'"'"' "$conflicts_file"; then
+        echo "ERROR: issue #222: $conflicts_file is non-empty and contains conflict markers but the line-parser extracted zero prior_conflict_sha keys — the file is likely malformed or truncated mid-write." >&2
+        echo "       The #200 rerun-safety guard cannot fire for the affected entries." >&2
+        echo "       Repair steps:" >&2
+        echo "         1. Inspect $conflicts_file for truncation or corruption." >&2
+        echo "         2. If the tracked conflicts are gone (hand-merged or abandoned), delete the file and re-run." >&2
+        echo "         3. If the file is repairable, restore valid JSON and re-run." >&2
+        echo "         4. Run scripts/upgrade.sh --resolve after any hand-merges to clear resolved entries." >&2
+        exit 1
+      fi
+    fi
+  ' _ "$conflicts_file" > "$log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Case #222-unit-A: well-formed file with a conflict entry → guard must NOT
+# fire (exit 0, no ERROR).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #222-unit-A: well-formed conflict entry → no hard-fail --"
+
+cat > "$tmp/well-formed.json" << 'EOF'
+{
+  "schema": 1,
+  "generated": "2026-01-01T00:00:00Z",
+  "template_version": "v1.0.0-rc13",
+  "entries": [
+    {"path": "CLAUDE.md", "classified": "conflict", "baseline_sha": "aaaa", "upstream_sha": "bbbb", "project_sha": "cccc"}
+  ]
+}
+EOF
+
+rc_a="$(run_guard "$tmp/well-formed.json" "$tmp/case-a.log")"
+check "#222-unit-A: exit 0 for well-formed file" \
+  bash -c '[ '"$rc_a"' -eq 0 ]'
+check "#222-unit-A: no ERROR message for well-formed file" \
+  bash -c '! grep -q "ERROR: issue #222" '"$tmp/case-a.log"
+
+# ---------------------------------------------------------------------------
+# Case #222-unit-B: truncated file — "classified": "conflict" present in raw
+# text but "path" is on a separate line, so sed yields "" for _c_path and the
+# key is never stored.  Guard must fire: exit 1 + ERROR message.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #222-unit-B: truncated file with raw conflict marker, no extractable path → hard-fail --"
+
+cat > "$tmp/truncated.json" << 'EOF'
+{
+  "schema": 1,
+  "generated": "2026-01-01T00:00:00Z",
+  "template_version": "v1.0.0-rc13",
+  "entries": [
+    {"path":
+      "CLAUDE.md",
+      "classified": "conflict",
+      "baseline_sha": "aaaa"
+EOF
+# File ends here — truncated mid-entry.
+
+rc_b="$(run_guard "$tmp/truncated.json" "$tmp/case-b.log")"
+check "#222-unit-B: exit 1 for truncated file with conflict marker" \
+  bash -c '[ '"$rc_b"' -eq 1 ]'
+check "#222-unit-B: ERROR message emitted naming the file" \
+  bash -c 'grep -q "ERROR: issue #222" '"$tmp/case-b.log"
+check "#222-unit-B: ERROR message mentions #200 rerun-safety guard" \
+  bash -c 'grep -q "#200" '"$tmp/case-b.log"
+check "#222-unit-B: repair steps included in output" \
+  bash -c 'grep -q "Repair steps" '"$tmp/case-b.log"
+
+# ---------------------------------------------------------------------------
+# Case #222-unit-C: empty file → guard must NOT fire (exit 0).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #222-unit-C: empty .template-conflicts.json → no hard-fail --"
+
+: > "$tmp/empty.json"
+rc_c="$(run_guard "$tmp/empty.json" "$tmp/case-c.log")"
+check "#222-unit-C: exit 0 for empty file" \
+  bash -c '[ '"$rc_c"' -eq 0 ]'
+check "#222-unit-C: no ERROR message for empty file" \
+  bash -c '! grep -q "ERROR: issue #222" '"$tmp/case-c.log"
+
+# ---------------------------------------------------------------------------
+# Case #222-unit-D: non-empty file with only accepted_local entries, zero
+# conflict markers → guard must NOT fire (false-positive protection).
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- #222-unit-D: accepted_local-only file → no hard-fail (false-positive guard) --"
+
+cat > "$tmp/accepted-local.json" << 'EOF'
+{
+  "schema": 1,
+  "generated": "2026-01-01T00:00:00Z",
+  "template_version": "v1.0.0-rc13",
+  "entries": [
+    {"path": "CLAUDE.md", "classified": "accepted_local", "baseline_sha": "aaaa", "upstream_sha": "bbbb", "project_sha": "cccc"},
+    {"path": "docs/foo.md", "classified": "local_only_kept", "baseline_sha": "", "upstream_sha": "", "project_sha": "dddd"}
+  ]
+}
+EOF
+
+rc_d="$(run_guard "$tmp/accepted-local.json" "$tmp/case-d.log")"
+check "#222-unit-D: exit 0 for accepted_local-only file" \
+  bash -c '[ '"$rc_d"' -eq 0 ]'
+check "#222-unit-D: no ERROR message for accepted_local-only file" \
+  bash -c '! grep -q "ERROR: issue #222" '"$tmp/case-d.log"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "PASS: $pass"
+echo "FAIL: $fail"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
+++ b/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
+#
+# tests/upgrade/test-manifest-handoff-activity-issue-276.sh
+#
+# Issue #276: TEMPLATE_MANIFEST.lock must not report drift when the
+# runtime-mutable "activity" array in docs/handoffs/*.json changes,
+# but MUST still detect changes to the durable contract portions
+# (status, mode, allowed_paths, hard_rule_traces, acceptance_criteria,
+# verification).
+#
+# IEEE 1008-1987 §3.2 — features under test:
+#   F1. manifest_file_sha_normalized strips "activity" before hashing.
+#   F2. A change to the "activity" array produces the same normalized
+#       hash (no drift reported by manifest_verify).
+#   F3. A change to the durable "status" field IS detected (drift
+#       reported) — the normalization does not blind the manifest to
+#       real contract changes.
+#   F4. A file outside docs/handoffs/ is hashed raw (normalization is
+#       not applied to unrelated files).
+#   F5. manifest_write records the normalized hash for handoff JSON
+#       files, so a subsequent manifest_verify passes even after the
+#       activity array has been appended to.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+manifest_lib="$repo_root/scripts/lib/manifest.sh"
+# shellcheck source=scripts/lib/manifest.sh
+source "$manifest_lib"
+
+tmp="$(mktemp -d -t manifest-276-XXXXXX)"
+keep=0
+[[ "${1:-}" == "--keep" ]] && keep=1
+trap 'if [[ $keep -eq 0 ]]; then rm -rf "$tmp"; else echo "(kept $tmp for inspection)" >&2; fi' EXIT
+
+fail=0
+pass=0
+
+check() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+check_output() {
+  # check_output <label> <expected-pattern> <cmd...>
+  local label="$1"; shift
+  local pattern="$1"; shift
+  local out
+  out=$("$@" 2>&1) || true
+  if echo "$out" | grep -qF "$pattern"; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label (pattern='$pattern' not found in output)" >&2
+    echo "        output was: $out" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+check_not_output() {
+  local label="$1"; shift
+  local pattern="$1"; shift
+  local out
+  out=$("$@" 2>&1) || true
+  if ! echo "$out" | grep -qF "$pattern"; then
+    echo "  PASS: $label"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $label (unwanted pattern='$pattern' found in output)" >&2
+    echo "        output was: $out" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a minimal handoff JSON with an empty activity array.
+# ---------------------------------------------------------------------------
+HANDOFF_RELPATH="docs/handoffs/test-276-handoff.json"
+mkdir -p "$tmp/docs/handoffs"
+
+cat > "$tmp/$HANDOFF_RELPATH" << 'EOF'
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "test-276",
+  "status": "active",
+  "activity": [],
+  "verification": {
+    "tests": []
+  }
+}
+EOF
+
+# ---------------------------------------------------------------------------
+# F1. manifest_file_sha_normalized strips "activity" before hashing.
+#     Verify that two files differing only in "activity" produce the same hash.
+# ---------------------------------------------------------------------------
+echo "-- F1: normalized hash ignores activity array --"
+
+cat > "$tmp/handoff-with-activity.json" << 'EOF'
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "test-276",
+  "status": "active",
+  "activity": [{"name": "Bash: ls", "result": "passed", "actor_role": "hook"}],
+  "verification": {
+    "tests": []
+  }
+}
+EOF
+
+cat > "$tmp/handoff-no-activity.json" << 'EOF'
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "test-276",
+  "status": "active",
+  "activity": [],
+  "verification": {
+    "tests": []
+  }
+}
+EOF
+
+sha_with=$(manifest_file_sha_normalized "$tmp/handoff-with-activity.json" "docs/handoffs/handoff-with-activity.json")
+sha_without=$(manifest_file_sha_normalized "$tmp/handoff-no-activity.json" "docs/handoffs/handoff-no-activity.json")
+
+if [[ "$sha_with" == "$sha_without" && -n "$sha_with" ]]; then
+  echo "  PASS: F1 — activity-differing files produce same normalized hash"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F1 — expected same hash, got '$sha_with' vs '$sha_without'" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# F2. After appending to activity, manifest_verify does NOT report drift.
+#     Simulate: write manifest from baseline (empty activity), then append
+#     to activity, then verify.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- F2: manifest_verify clean after activity append --"
+
+# Build a minimal fake upstream git repo (manifest_write requires one for
+# manifest_ship_files, but we bypass ship_files and write the manifest
+# directly using the normalized hash instead).
+# We write the manifest by hand using manifest_file_sha_normalized so the
+# test does not require a full upstream clone.
+
+manifest_path="$tmp/TEMPLATE_MANIFEST.lock"
+{
+  echo "# TEMPLATE_MANIFEST.lock — per FW-ADR-0002"
+  echo "# Generated by test-manifest-handoff-activity-issue-276.sh"
+  echo "# Format: <sha256>  <project-relative path>"
+  echo "#"
+  printf '%s  %s\n' \
+    "$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")" \
+    "$HANDOFF_RELPATH"
+} > "$manifest_path"
+
+# Now simulate the hook appending an activity entry (in-place JSON edit).
+python3 - "$tmp/$HANDOFF_RELPATH" << 'PYEOF'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    doc = json.load(f)
+doc.setdefault("activity", []).append({
+    "name": "Bash: git status",
+    "result": "passed",
+    "actor_role": "hook",
+    "timestamp": "2026-06-02T15:00:00Z"
+})
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(doc, f, indent=2)
+    f.write("\n")
+PYEOF
+
+# manifest_verify should return 0 (no drift) even though the file changed.
+verify_output=$(manifest_verify "$tmp" "$manifest_path" 2>&1)
+verify_rc=$?
+
+if [[ $verify_rc -eq 0 ]]; then
+  echo "  PASS: F2 — manifest_verify rc=0 after activity append (no drift)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F2 — manifest_verify rc=$verify_rc after activity append" >&2
+  echo "        output: $verify_output" >&2
+  fail=$((fail + 1))
+fi
+
+if echo "$verify_output" | grep -qiF "drift"; then
+  echo "  FAIL: F2 — 'drift' appeared in verify output after activity-only change" >&2
+  fail=$((fail + 1))
+else
+  echo "  PASS: F2 — 'drift' absent from verify output (activity correctly ignored)"
+  pass=$((pass + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# F3. A change to the durable "status" field IS detected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- F3: manifest_verify detects durable contract change (status field) --"
+
+# Write a fresh manifest from the current state (with activity appended).
+{
+  echo "# TEMPLATE_MANIFEST.lock — per FW-ADR-0002"
+  echo "# Generated by test-manifest-handoff-activity-issue-276.sh"
+  echo "# Format: <sha256>  <project-relative path>"
+  echo "#"
+  printf '%s  %s\n' \
+    "$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")" \
+    "$HANDOFF_RELPATH"
+} > "$manifest_path"
+
+# Now mutate the durable "status" field (not activity).
+python3 - "$tmp/$HANDOFF_RELPATH" << 'PYEOF'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    doc = json.load(f)
+doc["status"] = "completed"  # durable contract change
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(doc, f, indent=2)
+    f.write("\n")
+PYEOF
+
+verify_output_durable=$(manifest_verify "$tmp" "$manifest_path" 2>&1)
+verify_rc_durable=$?
+
+if [[ $verify_rc_durable -ne 0 ]]; then
+  echo "  PASS: F3 — manifest_verify rc=$verify_rc_durable (drift detected for status change)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F3 — manifest_verify rc=0 but expected drift for status field change" >&2
+  echo "        output: $verify_output_durable" >&2
+  fail=$((fail + 1))
+fi
+
+if echo "$verify_output_durable" | grep -qiF "drift"; then
+  echo "  PASS: F3 — 'drift' reported for durable contract change"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F3 — 'drift' not reported; durable change was silently missed" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# F4. A non-handoff file is hashed raw (normalization not applied).
+#     Two files with different content must produce different normalized hashes.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- F4: non-handoff file hashed raw (normalization not applied) --"
+
+cat > "$tmp/not-a-handoff.md" << 'EOF'
+# Some markdown file
+content A
+EOF
+cat > "$tmp/not-a-handoff-changed.md" << 'EOF'
+# Some markdown file
+content B
+EOF
+
+sha_md_a=$(manifest_file_sha_normalized "$tmp/not-a-handoff.md" "docs/not-a-handoff.md")
+sha_md_b=$(manifest_file_sha_normalized "$tmp/not-a-handoff-changed.md" "docs/not-a-handoff-changed.md")
+sha_raw_a=$(manifest_file_sha "$tmp/not-a-handoff.md")
+
+if [[ "$sha_md_a" == "$sha_raw_a" ]]; then
+  echo "  PASS: F4 — non-handoff file: normalized hash == raw hash"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F4 — non-handoff file: normalized hash '$sha_md_a' != raw '$sha_raw_a'" >&2
+  fail=$((fail + 1))
+fi
+
+if [[ "$sha_md_a" != "$sha_md_b" ]]; then
+  echo "  PASS: F4 — non-handoff files with different content produce different hashes"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F4 — non-handoff files with different content produced same hash" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# F5. manifest_file_sha_normalized is applied for handoff files even when
+#     the relpath argument is detected from the absolute path (fallback).
+#     Ensures the regex matches when relpath is omitted.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- F5: normalized hash via absolute-path detection (no relpath arg) --"
+
+# Reset handoff to baseline (empty activity).
+cat > "$tmp/$HANDOFF_RELPATH" << 'EOF'
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "test-276",
+  "status": "active",
+  "activity": [],
+  "verification": {
+    "tests": []
+  }
+}
+EOF
+
+sha_empty_activity_relpath=$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")
+sha_empty_activity_abspath=$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH")
+
+if [[ "$sha_empty_activity_relpath" == "$sha_empty_activity_abspath" && -n "$sha_empty_activity_relpath" ]]; then
+  echo "  PASS: F5 — relpath and absolute-path detection agree on normalized hash"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: F5 — hash mismatch: relpath='$sha_empty_activity_relpath' abs='$sha_empty_activity_abspath'" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "PASS: $pass"
+echo "FAIL: $fail"
+if [[ $fail -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Re-lands four vetted fixes that were committed to the wrong repo last session, reverted, and ported onto v1.1.1 here. All four were originally reviewed by code-reviewer + security-engineer; both re-reviewed this branch.

## Fixes
- **#222** `scripts/upgrade.sh` — parser fail-**open** on malformed `.template-conflicts.json` → marker-gated hard `exit 1` (3-condition gate keeps legit all-`accepted_local` files passing) + atomic tmp+rename write. New `tests/upgrade/test-conflicts-parser-sanity-issue-222.sh` (14/14).
- **#276** `scripts/lib/manifest.sh` — `manifest_file_sha_normalized` strips the runtime `activity` array from `docs/handoffs/*.json` before sha256, symmetric in write+verify, fail-closed on bad JSON. New `tests/upgrade/test-manifest-handoff-activity-issue-276.sh` (8/8). (No lock file committed — `TEMPLATE_MANIFEST.lock` is a per-project artifact, FW-ADR-0002.)
- **#288** `scripts/lib/gate-tags.sh` — `gate_subgate_upgrade-matrix-fresh` early pre-flight: fast-fail with actionable message when `snapshots/<VERSION>/clean/` is absent (no-op if VERSION absent/empty). Manual regen step + tests. (Doc/code split into single-class commits.)
- **#254** move marker-write to `migrations/v1.0.0-rc13.sh` so it fires on v0.16.0→candidate; remove `v0.16.0` from `upgrade-paths-allowlist.txt`.

## Review
- code-reviewer: **APPROVED** (3 non-blocking observations).
- security-engineer: **SIGN-OFF #276; conditional SIGN-OFF #222** — two LOW residuals, neither introduced here, neither blocking. Condition (file mktemp-hardening follow-up) tracked in a separate issue.

Closes #222
Closes #276
Closes #288
Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced upgrade safety with malformed conflict file detection and atomic file writes
  * Added pre-flight validation checks for release snapshots

* **Documentation**
  * Updated release procedures with new fixture snapshot regeneration step

* **Tests**
  * Added comprehensive test coverage for upgrade scenarios, conflict parsing, and manifest verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->