### PR TITLE
fix: backlog batch 3 — #211 #227 #230 #236 #208 (validators/tests/template)

### DIFF
--- a/.github/workflows/improve-template.yml
+++ b/.github/workflows/improve-template.yml
@@ -51,6 +51,16 @@ jobs:
                 echo "improve-template: invalid issue_number '${ISSUE_NUMBER}' (expected positive integer)" >&2
                 exit 2
                 ;;
+              0)
+                # Issue #227: GitHub issue numbers start at 1; zero is not valid.
+                echo "improve-template: invalid issue_number '${ISSUE_NUMBER}' (expected positive integer, got 0)" >&2
+                exit 2
+                ;;
+              0*)
+                # Issue #227: leading zeros not accepted (gh CLI may misparse).
+                echo "improve-template: invalid issue_number '${ISSUE_NUMBER}' (leading zeros not accepted; use '${ISSUE_NUMBER#"${ISSUE_NUMBER%%[!0]*}"}')" >&2
+                exit 2
+                ;;
             esac
             echo "issue=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
           else

--- a/docs/templates/scoping-questions-template.md
+++ b/docs/templates/scoping-questions-template.md
@@ -45,9 +45,9 @@ ask them **one per turn** with all agents idle (see
    yes, which domains?
 5. **External SMEs — availability.** For SME domains you are NOT
    expert in — do you have external SMEs available to consult?
-5a. **External SMEs — substitute criteria.** For SME domains where
-   no external SME is available — what acceptance criteria must a
-   substitute meet?
+5a. **External SMEs — substitute criteria** *(skip if all domains have external SMEs available).*
+   For SME domains where no external SME is available — what acceptance
+   criteria must a substitute meet?
 6. **Step 3 — agent naming category.** Pick a naming category (e.g.,
    Muppets, famous singers, historical scientists), a custom name
    list, or keep canonical role names. `tech-lead` proposes
@@ -60,7 +60,7 @@ ask them **one per turn** with all agents idle (see
 ## Follow-ups to consider (ask only when genuinely thin)
 
 - Is any part of the scope safety-critical or regulated?
-- If yes, which standard(s) govern it?
+- If yes, which standard(s) govern it? *(only when safety-critical answer is yes)*
 - What is the expected delivery cadence (one-off, sprint, continuous)?
 - What is the target deployment environment?
 - Are there environment constraints that shape architecture (air-gapped,

--- a/scripts/lint-questions.sh
+++ b/scripts/lint-questions.sh
@@ -375,7 +375,11 @@ check_pattern2() {
         # At paragraph flush this tells us if the compound ask terminates
         # with a question (fire) or just contains internal rhetorical `?`s
         # (procedural checklist, suppress).
-        last_eff_had_q = (eff ~ /\?[[:space:]]*$/) ? 1 : 0
+        # Issue #230: also catch `?` followed by inline annotations before EOL
+        # (HTML comment close `-->`, markdown emphasis `**...**`/`*`/`_`, or
+        # parentheticals `(...)`) so compound asks with trailing context tokens
+        # are not silently suppressed.
+        last_eff_had_q = (eff ~ /\?([[:space:]]*(-->|\*\*[^*]*\*\*|\*[^*]*\*|_[^_]*_|\([^)]*\)))*[[:space:]]*$/) ? 1 : 0
         if (eff ~ /\?/) {
             if (numbered_count > 1 && !saw_question && !pending_fire) {
                 pending_fire = 1; fire_line = first_num_line; fire_snippet = line

--- a/tests/hooks/test-tech-lead-authoring-guard.sh
+++ b/tests/hooks/test-tech-lead-authoring-guard.sh
@@ -782,6 +782,60 @@ run_case "issue#206 regression: /dev/null + off-list write denies (off-list flag
     deny
 
 # ---------------------------------------------------------------------------
+# Issue #208: CLAUDE_PROJECT_DIR-unset fallback path.
+#
+# When CLAUDE_PROJECT_DIR is unset (or empty), _normalise() and
+# _is_outside_project() fall back to os.getcwd().  The guard must remain
+# fail-closed: project-path writes must still be denied, harness paths
+# (/tmp/, /dev/) must still proceed, and the fallback must not produce a
+# fail-open when cwd resolves to a location that makes all paths look
+# "inside the project".
+#
+# Strategy: set CLAUDE_PROJECT_DIR= (empty string) which is falsy in
+# Python, triggering the os.getcwd() branch identically to the unset case.
+# The test process's cwd is the repo root (REPO_ROOT), so:
+#   - relative project paths remain project-scoped → deny
+#   - /tmp/ absolute paths are harness-allow-listed → proceed
+#   - an absolute path under /tmp/ is outside the project tree → proceed
+# ---------------------------------------------------------------------------
+
+# Cases A–D use an env_line that both empties CLAUDE_PROJECT_DIR (triggering
+# the os.getcwd() fallback) AND unsets SWDT_AGENT_PUSH (to prevent override
+# leaking from the outer test environment).
+_UNSET_ENV="CLAUDE_PROJECT_DIR= SWDT_AGENT_PUSH="
+
+# Case A: empty CLAUDE_PROJECT_DIR + project-relative write to an off-allow-list
+# path (scripts/upgrade.sh is a production file, not on the tech-lead allow-list)
+# → still denied even when CLAUDE_PROJECT_DIR is absent.
+run_case "issue#208: CLAUDE_PROJECT_DIR unset — off-allow-list project write denied" \
+    "$_UNSET_ENV" \
+    '{"tool_input":{"file_path":"scripts/upgrade.sh","contents":"x"}}' \
+    deny
+
+# Case B: empty CLAUDE_PROJECT_DIR + /tmp/ absolute path → proceeds (harness path).
+run_case "issue#208: CLAUDE_PROJECT_DIR unset — /tmp/ write proceeds (harness path)" \
+    "$_UNSET_ENV" \
+    '{"tool_input":{"file_path":"/tmp/some-temp-output.txt","contents":"x"}}' \
+    proceed
+
+# Case C: empty CLAUDE_PROJECT_DIR + /dev/null → proceeds (harness path).
+run_case "issue#208: CLAUDE_PROJECT_DIR unset — /dev/null proceeds (harness path)" \
+    "$_UNSET_ENV" \
+    '{"tool_input":{"command":"echo hi > /dev/null"}}' \
+    proceed
+
+# Case D: empty CLAUDE_PROJECT_DIR + absolute path outside the project tree
+# (e.g. /var/log/app.log) → proceeds. This is by design (issue #205): HR-8
+# is project-scoped; the guard does not control writes to locations that are
+# already outside the project tree. The fallback to os.getcwd() must NOT
+# accidentally treat out-of-project absolute paths as project-relative —
+# this asserts the fallback doesn't break that boundary.
+run_case "issue#208: CLAUDE_PROJECT_DIR unset — out-of-project absolute proceeds (by design #205)" \
+    "$_UNSET_ENV" \
+    '{"tool_input":{"file_path":"/var/log/app.log","contents":"x"}}' \
+    proceed
+
+# ---------------------------------------------------------------------------
 # Summary.
 # ---------------------------------------------------------------------------
 

--- a/tests/lint/test-lint-questions.sh
+++ b/tests/lint/test-lint-questions.sh
@@ -128,6 +128,55 @@ run_case "p2-compound-ask-fires: terminal-? paragraph fires (#148 true-positive)
     1 "$COMPOUND_FIXTURE"
 
 # ===========================================================================
+# Cases 4a–4c: Issue #230 — last_eff_had_q regex must catch `?` followed by
+# inline annotations (comment-close, emphasis, parenthetical) before EOL.
+# Each fixture is a multi-numbered compound ask whose terminal line ends with
+# `?` plus a trailing annotation; the linter must still fire.
+# ===========================================================================
+
+# 4a: `?` followed by HTML/markdown comment close `-->`
+COMPOUND_COMMENT_FIXTURE="$TMPDIR_BASE/compound_ask_comment.md"
+cat > "$COMPOUND_COMMENT_FIXTURE" << 'EOF'
+# Compound ask with trailing comment close
+
+We need to decide:
+
+1. Choose an OAuth provider.
+2. Decide on session-storage mechanism.
+3. Should we ship all three together? -->
+EOF
+run_case "p2-compound-ask-comment-close: terminal-?--> fires (#230)" \
+    1 "$COMPOUND_COMMENT_FIXTURE"
+
+# 4b: `?` followed by markdown bold `**note**`
+COMPOUND_BOLD_FIXTURE="$TMPDIR_BASE/compound_ask_bold.md"
+cat > "$COMPOUND_BOLD_FIXTURE" << 'EOF'
+# Compound ask with trailing bold annotation
+
+We need to decide:
+
+1. Choose an OAuth provider.
+2. Decide on session-storage mechanism.
+3. Should we ship all three together? **decide by Friday**
+EOF
+run_case "p2-compound-ask-bold-annotation: terminal-?-**note** fires (#230)" \
+    1 "$COMPOUND_BOLD_FIXTURE"
+
+# 4c: `?` followed by parenthetical `(see also ...)`
+COMPOUND_PAREN_FIXTURE="$TMPDIR_BASE/compound_ask_paren.md"
+cat > "$COMPOUND_PAREN_FIXTURE" << 'EOF'
+# Compound ask with trailing parenthetical
+
+We need to decide:
+
+1. Choose an OAuth provider.
+2. Decide on session-storage mechanism.
+3. Should we ship all three together? (see also milestone doc)
+EOF
+run_case "p2-compound-ask-parenthetical: terminal-?-(paren) fires (#230)" \
+    1 "$COMPOUND_PAREN_FIXTURE"
+
+# ===========================================================================
 # Case 5: Nested sub-bullets under checkbox are suppressed (issue #185 regression)
 # The outer `- [ ]` starts the checkbox; indented `- ` sub-bullets carry `?`s
 # that are UI prompts, not customer-facing questions.

--- a/tests/release-gate/test-gate-pass.sh
+++ b/tests/release-gate/test-gate-pass.sh
@@ -8,20 +8,45 @@
 #
 # Also captures wall-clock duration for SC-002 audit. Soft-warn if > 5 min;
 # hard-fail at > 10 min.
+#
+# Flags:
+#   --skip-untracked-check   Bypass the clean-worktree precondition check.
+#                            Use during PR authoring when untracked in-flight
+#                            files are present but the committed state is what
+#                            you want to validate (issue #211). The gate itself
+#                            still checks for a clean worktree (worktree-clean
+#                            sub-gate); this flag only skips the test's own
+#                            pre-flight guard, not the gate's check. Running
+#                            with --skip-untracked-check while the worktree
+#                            has modified tracked files will cause the gate's
+#                            worktree-clean sub-gate to FAIL as expected.
 
 set -u
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 gate="$repo_root/scripts/pre-release-gate.sh"
 
+# Parse flags.
+skip_untracked_check=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-untracked-check) skip_untracked_check=1 ;;
+        *) echo "test-gate-pass: unknown flag '$arg'" >&2; exit 2 ;;
+    esac
+done
+
 # Verify worktree is clean (otherwise this test isn't meaningful).
-dirty=$(git -C "$repo_root" status --porcelain \
-    | grep -vE '^\?\? tests/prompt-regression/results-' \
-    || true)
-if [ -n "$dirty" ]; then
-    echo "  SKIP: test-gate-pass requires a clean worktree (excluding known untracked clutter)"
-    printf '%s\n' "$dirty"
-    exit 0
+# Skippable with --skip-untracked-check for PR-authoring use (issue #211).
+if [ "$skip_untracked_check" -eq 0 ]; then
+    dirty=$(git -C "$repo_root" status --porcelain \
+        | grep -vE '^\?\? tests/prompt-regression/results-' \
+        || true)
+    if [ -n "$dirty" ]; then
+        echo "  SKIP: test-gate-pass requires a clean worktree (excluding known untracked clutter)"
+        echo "        Pass --skip-untracked-check to bypass this guard during PR authoring (issue #211)."
+        printf '%s\n' "$dirty"
+        exit 0
+    fi
 fi
 
 start_s=$(date +%s)

--- a/tests/workflows/test-improve-template-logic.sh
+++ b/tests/workflows/test-improve-template-logic.sh
@@ -87,13 +87,22 @@ protected_check() {
 }
 
 # ----- numeric_validator_check ---------------------------------------------
-# Mirrors workflow "Identify target issue" numeric validation (issue #149).
-# Returns 0 = valid (positive integer or empty), 1 = invalid.
+# Mirrors workflow "Identify target issue" numeric validation (issue #149,
+# issue #227). Returns 0 = valid (positive integer or empty), 1 = invalid.
 numeric_validator_check() {
     issue_number=$1
     if [ -n "${issue_number}" ]; then
         case "${issue_number}" in
             *[!0-9]*)
+                # Contains a non-digit character.
+                return 1
+                ;;
+            0)
+                # Issue #227: 0 is not a valid GitHub issue number.
+                return 1
+                ;;
+            0*)
+                # Issue #227: leading zeros rejected (gh CLI sensitive).
                 return 1
                 ;;
         esac
@@ -173,14 +182,17 @@ run_one "hard-rule-content-with-proposal" PASS PASS
 # W2 fix: file already has HR text in unchanged lines; diff adds non-HR content -> PASS
 run_one "hard-rule-unchanged-no-proposal" PASS PASS
 
-# Numeric validator tests (issue #149)
+# Numeric validator tests (issue #149, issue #227)
 run_numeric "valid-integer"   "123"          PASS
-run_numeric "zero"            "0"            PASS
+run_numeric "zero"            "0"            FAIL   # #227: 0 is not a valid GH issue number
 run_numeric "empty"           ""             PASS
 run_numeric "alpha"           "abc"          FAIL
 run_numeric "inject-newline"  "12
 extra"        FAIL
 run_numeric "semicolon"       "12;rm -rf /" FAIL
+run_numeric "leading-zero-2"  "07"           FAIL   # #227: leading zero on valid number
+run_numeric "leading-zero-3"  "007"          FAIL   # #227: multiple leading zeros
+run_numeric "leading-zero-lone-0" "01"       FAIL   # #227: 01 is not 1
 
 printf 'test-improve-template-logic: %d pass, %d fail\n' "${pass_count}" "${fail_count}"
 


### PR DESCRIPTION
Five small, independent fixes.

- **#211** `tests/release-gate/test-gate-pass.sh` — `--skip-untracked-check` so the test can self-validate during authoring (does NOT bypass the gate's own worktree-clean sub-gate).
- **#227** `.github/workflows/improve-template.yml` — reject leading-zero `ISSUE_NUMBER` (gh-CLI sensitive). 19/19.
- **#230** `scripts/lint-questions.sh` — `last_eff_had_q` regex now catches `?` before inline-comment-close / markdown emphasis / paren. 10/10.
- **#236** `docs/templates/scoping-questions-template.md` — conditional skip cue for the 5a substitute-criteria seed.
- **#208** `tests/hooks/test-tech-lead-authoring-guard.sh` — cover the `CLAUDE_PROJECT_DIR`-unset fallback branch. 135/135.

Review: code-reviewer APPROVED after correcting two Routed-Through trailers (#227→release-engineer for the ci-class workflow; #236→tech-writer for the docs-class template) per FW-ADR-0011 R3. Logic approved with all tests green; two non-blocking design-spec confirmations (#208 out-of-project paths proceed by design per #205; #230 nested-paren false-negative within the "false-negatives acceptable" spec).

Closes #211
Closes #227
Closes #230
Closes #236
Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)