### PR TITLE
fix: batch 10 — #305 mktemp-harden upgrade.sh + #308 fixture-07 assertion

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -333,14 +333,17 @@ if [[ $resolve_mode -eq 1 ]]; then
     done < "$resolve_customizations"
   fi
 
-  tmp_out="$conflicts_path.tmp.$$"
+  # Issue #305: use mktemp (random suffix) instead of PID suffix to avoid
+  # symlink-race / TOCTOU windows and PID-collision on shared CI runners
+  # (CWE-377 / CWE-59). mktemp pattern mirrors the correct usage at ~line 764.
+  tmp_out="$(mktemp "${conflicts_path}.tmp.XXXXXX")"
   removed=0
   kept_unresolved=0
   # Issue #152: collect "path<TAB>new_sha" lines for every conflict entry
   # cleared by hand-merge so we can refresh TEMPLATE_MANIFEST.lock rows
   # after the JSON rewrite. Without this, --verify fails on the very
   # next run because the manifest still carries pre-resolution SHAs.
-  resolved_paths_log="$conflicts_path.resolved.$$"
+  resolved_paths_log="$(mktemp "${conflicts_path}.resolved.XXXXXX")"
   : > "$resolved_paths_log"
   {
     printf '{\n'
@@ -433,7 +436,7 @@ if [[ $resolve_mode -eq 1 ]]; then
   manifest_for_resolve="$project_root/TEMPLATE_MANIFEST.lock"
   refreshed_manifest_rows=0
   if [[ -s "$resolved_paths_log" && -f "$manifest_for_resolve" ]]; then
-    manifest_tmp="$manifest_for_resolve.tmp.$$"
+    manifest_tmp="$(mktemp "${manifest_for_resolve}.tmp.XXXXXX")"  # Issue #305: mktemp, not PID suffix
     awk -F '\t' '
       NR == FNR { new_sha[$1] = $2; next }
       /^[[:space:]]*#/ || /^[[:space:]]*$/ { print; next }
@@ -2224,6 +2227,16 @@ EOF
   # state, not the desired post-merge state).
   conflicts_path="$project_root/.template-conflicts.json"
   if [[ ${#conflicts[@]} -gt 0 || ${#local_only_kept[@]} -gt 0 || ${#accepted_local[@]} -gt 0 ]]; then
+    # Issue #305: allocate the temp path BEFORE the { } writer block so the
+    # variable is set in the current shell scope (not a subshell). mktemp
+    # random suffix eliminates the CWE-377/CWE-59 symlink-race present with
+    # PID-suffixed names. The EXIT trap (set after conflicts_path is known)
+    # removes any stale tmp if the process is killed between write and mv.
+    _conflicts_tmp="$(mktemp "${conflicts_path}.tmp.XXXXXX")"
+    # Extend the EXIT trap to also remove this tmp (the workdir trap covers
+    # workdir but not project_root artefacts — issue #305 code-reviewer obs).
+    # shellcheck disable=SC2064  # intentional: expand _conflicts_tmp now
+    trap "rm -rf \"\$workdir\"; rm -f '${_conflicts_tmp}'" EXIT
     {
       printf '{\n'
       printf '  "schema": 1,\n'
@@ -2267,11 +2280,11 @@ EOF
         for f in "${accepted_local[@]}"; do emit_entry "$f" "accepted_local"; done
       fi
       printf '\n  ]\n}\n'
-    } > "$conflicts_path.tmp.$$"
+    } > "$_conflicts_tmp"
     # Issue #222: atomic rename so a kill mid-write never leaves a
     # truncated file on disk that the #200 parser would silently
     # misread as "no prior conflicts".
-    mv "$conflicts_path.tmp.$$" "$conflicts_path"
+    mv "$_conflicts_tmp" "$conflicts_path"
   else
     # No tracked entries — remove any stale file from a prior upgrade.
     rm -f "$conflicts_path"

--- a/tests/release-gate/test-gate-fail-each.sh
+++ b/tests/release-gate/test-gate-fail-each.sh
@@ -47,6 +47,7 @@ _cleanup_sandbox() {
     # (left by prior killed runs before hermeticity was enforced).
     rm -f "$repo_root"/migrations/v9.9.9-fixture-*.sh
     rm -f "$repo_root"/scripts/.fixture-04-no-spdx-*.sh
+    rm -f "$repo_root"/scripts/upgrade.sh.bak-*  # #308 nit-a: fixture-03 bak on SIGINT
     rm -f "$repo_root"/.claude/agents/.fixture-01-stray-*
     rm -f "$repo_root"/.claude/agents/fixture-*-no-hard-rules-*.md
 }
@@ -78,13 +79,15 @@ fi
 _assert_in_sandbox() {
     local target_dir="$1"
     local operation="$2"
-    local real_target real_sandbox real_root
+    local real_target real_sandbox
     real_target="$(cd "$target_dir" && pwd -P)"
     real_sandbox="$(cd "$sandbox" && pwd -P)"
-    real_root="$(cd "$repo_root" && pwd -P)"
-    if [ "$real_target" = "$real_root" ]; then
-        echo "FATAL: safety guard fired — '$operation' attempted on live repo_root '$real_root'" >&2
-        echo "       All git-history operations must target the sandbox '$real_sandbox'." >&2
+    # #308 nit-b: assert target IS sandbox (not just ≠ repo_root) so a third
+    # repo that is neither repo_root nor sandbox cannot slip past the guard.
+    if [ "$real_target" != "$real_sandbox" ]; then
+        echo "FATAL: safety guard fired — '$operation' attempted outside sandbox." >&2
+        echo "       target='$real_target' is not sandbox='$real_sandbox'." >&2
+        echo "       All git-history operations must target the sandbox." >&2
         exit 2
     fi
 }
@@ -256,13 +259,15 @@ if git -C "$sandbox" diff --quiet && git -C "$sandbox" diff --cached --quiet; th
     register_revert "git -C '$sandbox' tag -d '$fixture07_tag' >/dev/null 2>&1; git -C '$sandbox' reset --hard '$fixture07_orig_head' >/dev/null 2>&1"
     assert_subgate_fails "07-upgrade-paths-fail" "upgrade-paths" "$sandbox_gate"
     # Check the diagnostic line names the synthetic tag.
+    # Issue #308: gate-tags.sh emits "failing pairs:" (line ~359), not
+    # "failing source tags:" which was never emitted anywhere in scripts/.
     out=$("$sandbox_gate" 2>&1) || true
-    if printf '%s' "$out" | grep -qE "failing source tags:.*${fixture07_tag}"; then
-        echo "  PASS: [07-upgrade-paths-fail] '$fixture07_tag' surfaces in failing-source-tags diagnostic"
+    if printf '%s' "$out" | grep -qE "failing pairs:.*${fixture07_tag}"; then
+        echo "  PASS: [07-upgrade-paths-fail] '$fixture07_tag' surfaces in failing-pairs diagnostic"
         pass=$((pass + 1))
     else
-        echo "  FAIL: [07-upgrade-paths-fail] '$fixture07_tag' not in failing-source-tags diagnostic"
-        echo "       output: $(printf '%s' "$out" | grep 'failing source tags' || echo '<no failing-source-tags line>')"
+        echo "  FAIL: [07-upgrade-paths-fail] '$fixture07_tag' not in failing-pairs diagnostic"
+        echo "       output: $(printf '%s' "$out" | grep 'failing pairs' || echo '<no failing-pairs line>')"
         fail=$((fail + 1))
     fi
     # Revert sandbox.

--- a/tests/upgrade/test-conflicts-parser-sanity-issue-222.sh
+++ b/tests/upgrade/test-conflicts-parser-sanity-issue-222.sh
@@ -76,11 +76,11 @@ echo "-- #222 static checks --"
 check "#222-static-A: ERROR exit-1 guard for issue #222 present in upgrade.sh" \
   grep -q "ERROR: issue #222" "$upgrade"
 
-check "#222-static-B: writer uses atomic tmp file (conflicts_path.tmp.\$\$)" \
-  grep -q 'conflicts_path\.tmp\.\$\$' "$upgrade"
+check "#222-static-B: writer uses atomic tmp file via mktemp (issue #305 hardening)" \
+  grep -q 'mktemp.*conflicts_path.*tmp' "$upgrade"
 
-check "#222-static-C: atomic mv of conflicts_path.tmp.\$\$ into conflicts_path" \
-  grep -qP 'mv "\$conflicts_path\.tmp\.\$\$" "\$conflicts_path"' "$upgrade"
+check "#222-static-C: atomic mv of _conflicts_tmp into conflicts_path" \
+  grep -q 'mv.*_conflicts_tmp.*conflicts_path' "$upgrade"
 
 check "#222-static-D: guard checks prior_conflict_sha count == 0" \
   grep -q 'prior_conflict_sha\[@\]\}' "$upgrade"


### PR DESCRIPTION
- **#305** `scripts/upgrade.sh` — replaces the four PID-suffixed temp writes flagged by the #222 security sign-off with `mktemp "...XXXXXX"` (atomic semantics preserved), and extends the EXIT trap to clean the project_root tmp. **Closes the CWE-377/CWE-59 finding** that the #222 sign-off was made conditional on (code-reviewer confirmed; no security re-pass needed). Tests: test-conflicts-parser-sanity-issue-222 14/14, test-rerun-safety 9/9.
- **#308** `tests/release-gate/test-gate-fail-each.sh` — fixture-07 secondary assertion corrected (`failing source tags:` → `failing pairs:`, matching `gate-tags.sh`); plus two guard nits from the #309 review (INT/TERM trap cleans fixture-03's `upgrade.sh.bak-*`; `_assert_in_sandbox` tightened to `== sandbox`). Verified hermetic in a throwaway clone (9/9, HEAD unchanged).

Review: code-reviewer APPROVED; CWE-377/59 verdict CLOSED for the four sites. Non-blocking follow-up filed for remaining lower-severity collocated PID-temps.

Closes #305
Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)