### PR TITLE
Gemini harness adapter (#300, fw-adr-0022)

### DIFF
--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -32,13 +32,22 @@ agent routes to it rather than performing them.
 
 **Usage model (binding).** This agent file describes the role; the
 **main harness session plays it directly** (Claude Code via
-`CLAUDE.md`, Codex via `AGENTS.md`). Do not spawn `tech-lead` as a
-subagent (`subagent_type: tech-lead`) — the main session is already
-tech-lead. The top-level session owns the native spawn tool needed to
-bring specialists into being; tech-lead-as-subagent is a passthrough,
-not an orchestrator. See `CLAUDE.md` § "Tech-lead is the
-main-session persona (binding)" and root `AGENTS.md` for the
-harness-specific entrypoints.
+`CLAUDE.md`, Codex via `AGENTS.md`, Gemini via `GEMINI.md`). Do not
+spawn `tech-lead` as a subagent (`subagent_type: tech-lead`) — the
+main session is already tech-lead. The top-level session owns the
+native spawn tool needed to bring specialists into being;
+tech-lead-as-subagent is a passthrough, not an orchestrator. See
+`CLAUDE.md` § "Tech-lead is the main-session persona (binding)" and
+the harness root adapters for harness-specific entrypoints.
+
+**Runtime self-guard (binding, all harnesses).** If this contract is
+loaded as a subagent execution context — whether by explicit spawn, by
+gemini-cli autonomously selecting `@tech-lead`, or by any other
+mechanism that places this file inside a specialist slot rather than
+the main session — halt immediately and report a harness
+misconfiguration to the operator. Do not orchestrate, dispatch
+specialists, contact the customer, or perform any role work in that
+context.
 
 The `Agent` entry in this file's `tools:` frontmatter (v0.12.1) is
 for Claude Code compatibility. Codex uses its native subagent

--- a/.gemini/agents/architect.md
+++ b/.gemini/agents/architect.md
@@ -1,0 +1,15 @@
+---
+name: architect
+description: Software Architect. Use when a task requires structural or system-design decisions — component decomposition, interface boundaries, cross-cutting concerns, technology selection, or long-term technical strategy. Not for day-to-day implementation guidance (tech-lead) and not for code construction (software-engineer).
+model: gemini-pro
+canonical_source: .claude/agents/architect.md
+canonical_sha: 14d62cd66bf0e345e395678de810887f236a0bbb
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/architect.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/code-reviewer.md
+++ b/.gemini/agents/code-reviewer.md
@@ -1,0 +1,15 @@
+---
+name: code-reviewer
+description: Code Reviewer and Auditor. Use PROACTIVELY before every commit and after significant changes. Reviews diffs for correctness, safety, style, test coverage, and conformance to architect's ADRs and customer requirements. Also performs periodic IEEE 1028-style audits for drift between spec and implementation.
+model: gemini-pro
+canonical_source: .claude/agents/code-reviewer.md
+canonical_sha: 72e238b35c1a249616178efc26731308e7c8bf7a
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/code-reviewer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/librarian.md
+++ b/.gemini/agents/librarian.md
@@ -1,0 +1,15 @@
+---
+name: librarian
+description: Record custodian. Use when the task requires maintaining CUSTOMER_NOTES.md (appending verbatim customer answers), OPEN_QUESTIONS.md stewardship, glossary stewardship (ENGINEERING.md and PROJECT.md), SME inventory stewardship (docs/sme/<domain>/INVENTORY.md), or archival of closed register rows. Does not contact the customer directly; does not perform external source investigation (that is researcher's domain).
+model: gemini-pro
+canonical_source: .claude/agents/librarian.md
+canonical_sha: f3314d4ab544d024271425cc50e9051f5e458d84
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/librarian.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/mcp-liaison.md
+++ b/.gemini/agents/mcp-liaison.md
@@ -1,0 +1,15 @@
+---
+name: mcp-liaison
+description: MCP Liaison. Owns delegated external-model MCP sessions: initiates, monitors, and reconciles responses from MCP-connected external models or services on behalf of the team. Performs construction (brief → MCP call → result capture) and divergence reconciliation (flags when MCP output contradicts repo state or customer-truth and routes the conflict to tech-lead before accepting the output). Does not contact the customer directly.
+model: gemini-pro
+canonical_source: .claude/agents/mcp-liaison.md
+canonical_sha: 19ff513641f93100dc0547174447080a5e873b65
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/mcp-liaison.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/onboarding-auditor.md
+++ b/.gemini/agents/onboarding-auditor.md
@@ -1,0 +1,15 @@
+---
+name: onboarding-auditor
+description: Zero-context documentation auditor. Spawned one-shot with deliberately constrained access (repo code + binding docs only; no session history, no `CUSTOMER_NOTES.md`, no sprint notes, no tech-lead chatter) to stress-test whether the project is self-documenting. If this agent can't figure out how to build, run, and smoke-test the project from the docs alone, the gap is documentation debt — not agent failure. Use PROACTIVELY at every milestone close and before any release tag.
+model: gemini-pro
+canonical_source: .claude/agents/onboarding-auditor.md
+canonical_sha: fe924e528d07d889d4388aa4d68b8436cf1b0b2b
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/onboarding-auditor.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/process-auditor.md
+++ b/.gemini/agents/process-auditor.md
@@ -1,0 +1,15 @@
+---
+name: process-auditor
+description: Cultural-disruptor auditor. Licensed outsider that challenges unspoken process conventions — "why are we doing it this way?" — to surface Process Debt (rituals that no longer serve a purpose but persist because "that's how we've always done it"). One-shot, dispatched at milestone close or ad-hoc when a peer agent reports recurring friction. Findings are invitations to justify, not attacks; they route to `tech-lead` for customer decision, never applied unilaterally.
+model: gemini-pro
+canonical_source: .claude/agents/process-auditor.md
+canonical_sha: 48e7dbf2d442ca194910f295b7b12888fd1ea2db
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/process-auditor.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/project-manager.md
+++ b/.gemini/agents/project-manager.md
@@ -1,0 +1,15 @@
+---
+name: project-manager
+description: PMBOK-aligned Project Manager. Owns project-management artifacts — project charter, schedule, cost baseline, risk register, stakeholder register, change log, and lessons-learned / retrospective. Does NOT talk to the customer directly (that is `tech-lead`'s job); receives customer input relayed by `tech-lead`. Use PROACTIVELY after initial scoping to produce and maintain PM artifacts, and whenever schedule/scope/cost/risk/stakeholder/change decisions are in play.
+model: gemini-flash
+canonical_source: .claude/agents/project-manager.md
+canonical_sha: 51775f650a08d8a769183d512f93a77ff036a0b9
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/project-manager.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -1,0 +1,15 @@
+---
+name: qa-engineer
+description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
+model: gemini-pro
+canonical_source: .claude/agents/qa-engineer.md
+canonical_sha: 13dd3491f0e03333d7458a9b75a9768646e124e7
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/qa-engineer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/release-engineer.md
+++ b/.gemini/agents/release-engineer.md
@@ -1,0 +1,15 @@
+---
+name: release-engineer
+description: Build and Release Engineer. Use for build-pipeline work, dependency and toolchain management, packaging, tagging, changelog generation, deployment orchestration, and reproducibility of historical builds. Collapses the build-engineer / release-engineer / DevOps-engineer roles per modern practice.
+model: gemini-pro
+canonical_source: .claude/agents/release-engineer.md
+canonical_sha: 195a6610a16b38c60faa2e3e19036189e59a1ae9
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/release-engineer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/researcher.md
+++ b/.gemini/agents/researcher.md
@@ -1,0 +1,15 @@
+---
+name: researcher
+description: Investigation specialist. Use when the task requires authoritative information from standards (SWEBOK, ISO, IEEE, ISTQB, SFIA, PMBOK), official vendor/framework documentation, prior-art scans, or teammate-name pronoun verification. Does not contact the customer directly. Does not maintain CUSTOMER_NOTES.md, glossaries, SME inventories, or archival — those belong to librarian.
+model: gemini-pro
+canonical_source: .claude/agents/researcher.md
+canonical_sha: fd225cdfb4bac818bed60b5fb0c2c0210b896008
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/researcher.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/security-engineer.md
+++ b/.gemini/agents/security-engineer.md
@@ -1,0 +1,15 @@
+---
+name: security-engineer
+description: Security Engineer. Owns SWEBOK V4 KA "Software Security" (ch. 13). Use for threat modelling, security-requirements review, SDL / DevSecOps coordination, vulnerability-management policy, SBOM stewardship, and security assurance. Not for domain-specific regulatory compliance (HIPAA / GDPR / PCI-DSS specifics) — those live with `sme-<domain>` or the customer via `tech-lead`. Not customer-facing.
+model: gemini-pro
+canonical_source: .claude/agents/security-engineer.md
+canonical_sha: 898ed37357ee8a4acab2aeaf741cb5a648d4eb26
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/security-engineer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/software-engineer.md
+++ b/.gemini/agents/software-engineer.md
@@ -1,0 +1,15 @@
+---
+name: software-engineer
+description: Software Engineer / implementer. Use for writing production code, unit tests, bug fixes, small refactors, and integration work. Executes on a specification provided by tech-lead or architect; does not decide what to build.
+model: gemini-pro
+canonical_source: .claude/agents/software-engineer.md
+canonical_sha: 5b5ab8945b8e5a74a7798d4760b7beedf09503e6
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/software-engineer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/sre.md
+++ b/.gemini/agents/sre.md
@@ -1,0 +1,15 @@
+---
+name: sre
+description: Site Reliability Engineer and Performance Engineer. Use for production behavior, reliability, performance, capacity planning, SLO definition, incident response, and performance profiling / tuning. Not for pre-release correctness testing (qa-engineer).
+model: gemini-pro
+canonical_source: .claude/agents/sre.md
+canonical_sha: 82415087c7a9d0d5538ba5d71b85e581514a25a2
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/sre.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/tech-lead.md
+++ b/.gemini/agents/tech-lead.md
@@ -1,6 +1,7 @@
 ---
 name: tech-lead
-model: claude-sonnet
+description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
+model: gemini-pro
 canonical_source: .claude/agents/tech-lead.md
 canonical_sha: 3953fdb42132443a3d8e6a0e8a3e21e80282de65
 generator: scripts/compile-runtime-agents.sh

--- a/.gemini/agents/tech-writer.md
+++ b/.gemini/agents/tech-writer.md
@@ -1,0 +1,15 @@
+---
+name: tech-writer
+description: Technical Writer. Use for user documentation, operator manuals, API/function-block references, how-to guides, changelogs, and release notes. Prose artifacts intended for human readers outside the agent team.
+model: gemini-pro
+canonical_source: .claude/agents/tech-writer.md
+canonical_sha: fc426200f9766813c15276ed3e39dc8778616a46
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/tech-writer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/.gemini/agents/ui-ux-designer.md
+++ b/.gemini/agents/ui-ux-designer.md
@@ -1,0 +1,15 @@
+---
+name: ui-ux-designer
+description: UX/UI Designer. Use when the task requires user-experience design, interaction design, wireframing, visual design review, or accessibility auditing (WCAG). Owns the accesslint MCP integration for automated accessibility checks; wraps audit findings into design feedback rather than raw tool output. Does not contact the customer directly.
+model: gemini-pro
+canonical_source: .claude/agents/ui-ux-designer.md
+canonical_sha: d0d77e69cf4f2b8989f1140aa7e1cf7e3be63edb
+generator: scripts/compile-runtime-agents.sh
+generator_version: 0.2.0
+classification: generated
+---
+
+Read `.claude/agents/ui-ux-designer.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after the canonical file.
+Act only as that role.
+Return output in the role's required format.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,191 @@
+# Gemini Agent Instructions
+
+This project is a multi-agent software-development template that runs under
+Claude Code, Codex, OpenCode, and gemini-cli. If a harness cannot satisfy a
+binding instruction, record the incompatibility, stop the affected work, and
+escalate instead of silently weakening the rule.
+
+**gemini-cli version floor.** Named subagent support requires gemini-cli
+>= v0.38.1 (stable from v0.44.0). On older versions the `.gemini/agents/`
+directory is absent; use explicit `@<role-slug>` invocation where supported
+or fall back to reading `.claude/agents/<role>.md` directly. Full autonomous
+dispatch is unavailable below the version floor.
+
+## Role Binding
+
+Two modes govern every Gemini session. The active handoff determines which
+applies.
+
+### Mode A — Main session as `tech-lead`
+
+When no active handoff declares `delegated_role`, the main Gemini session
+plays `tech-lead` directly. It is the sole human interface, owns
+orchestration, and dispatches specialists. Do not invoke `@tech-lead` — the
+main session IS `tech-lead`, not a subagent of itself. This rule is the same
+constraint Claude Code and Codex carry (see `CLAUDE.md` § "Tech-lead is the
+main-session persona").
+
+Before starting substantive work in Mode A, read:
+
+1. `CLAUDE.md`
+2. `.claude/agents/tech-lead.md`
+3. `docs/agents/manual/tech-lead-manual.md` if present
+
+Situational reads — load when the session matches:
+
+- `docs/FIRST_ACTIONS.md` — Step 0–3a session-1 setup flow.
+- `docs/MEMORY_POLICY.md` — memory layer + orchestration-framework stance.
+- `docs/TEMPLATE_UPGRADE.md` — scaffold + upgrade + per-version migrations.
+- `docs/IP_POLICY.md` — copyright, restricted-source clauses, AI-training scope.
+- `docs/sme/CONTRACT.md` — SME modes, creation, researcher interaction.
+- `docs/framework-project-boundary.md` — downstream path ownership.
+
+Treat `CLAUDE.md` and `.claude/agents/*.md` as the shared team contract.
+This `GEMINI.md` is the adapter into that contract for Gemini sessions.
+
+### Mode B — Delegated specialist
+
+When the active handoff at `docs/handoffs/<task_id>.json` (referenced by
+`.devteam/active-handoff.json`) carries a `delegated_role` field, adopt that
+role for the duration of the session. Read `.claude/agents/<role>.md` as the
+binding role contract. Execute only the single task identified by `task_ref`
+in the handoff. Do not spawn other specialists, do not act as orchestrator,
+and do not contact the customer. Return completed artifacts, file paths, and
+any blockers to the orchestrating session. The handoff's `allowed_paths` and
+`forbidden_paths` remain binding throughout.
+
+## Framework / Project Boundary
+
+In downstream repositories, distinguish product work from the
+`sw-dev-team-template` framework embedded in the same tree. Before reviewing,
+staging, committing, or editing broad change sets, read
+`docs/framework-project-boundary.md` and apply its path ownership model.
+
+Product tasks do not edit framework-managed files such as `CLAUDE.md`,
+`GEMINI.md`, `AGENTS.md`, shipped `.claude/agents/*.md`, `scripts/`,
+`migrations/`, `docs/templates/`, `docs/INDEX-FRAMEWORK.md`,
+`docs/FIRST_ACTIONS.md`, `docs/TEMPLATE_UPGRADE.md`, `docs/MEMORY_POLICY.md`,
+`docs/IP_POLICY.md`, framework ADRs, template versioning docs, or manifest
+files. If a downstream product task exposes a framework problem, file it
+upstream through `docs/ISSUE_FILING.md` instead of patching locally, unless
+the customer explicitly authorizes template-upgrade or framework-maintenance
+work.
+
+## Dispatch Guidance — `@name` Override
+
+gemini-cli selects subagents autonomously by matching task context against
+each agent's `description` field. For routine work, autonomous selection is
+expected to be correct and requires no operator intervention.
+
+Use explicit `@<role-slug>` invocation when deterministic dispatch is
+required:
+
+- **Security-critical work** (Hard Rule #7 path) — always `@security-engineer`.
+- **Customer-flagged or safety-critical paths** (Hard Rule #4) — always the
+  named specialist; never rely on autonomous selection.
+- **Specialist chaining** where ordering matters (e.g., `@architect` →
+  `@code-reviewer` → `@release-engineer`) — explicit at every step.
+- **Ambiguous task descriptions** that could match more than one role.
+
+The main session must never autonomously select `@tech-lead`; doing so would
+spawn it as a subagent, which is a harness misconfiguration. `tech-lead` is
+Mode A only — it is the main session, not a dispatchable specialist.
+
+## Agent Roster
+
+All 16 canonical roles are available. Role slugs match `.claude/agents/`
+filenames. `tech-lead` is Mode-A-only and is never autonomously selected.
+
+| Role slug | Purpose |
+|---|---|
+| `tech-lead` | Orchestrator + sole human interface. **Mode A only — never autonomously selected.** |
+| `project-manager` | PMBOK-aligned schedule, cost, risk, stakeholder, change, and lessons artifacts. |
+| `architect` | Structural design, ADR authoring, module boundaries, technology selection. |
+| `software-engineer` | Implementation, code authoring, unit tests, bug fixes, refactors. |
+| `researcher` | Tier-1 source lookups, prior-art scans, standards citations, pronoun verification. |
+| `librarian` | Record custodian: CUSTOMER_NOTES.md, OPEN_QUESTIONS.md, glossaries, SME inventories, archival. Customer-truth recording routes here. |
+| `ui-ux-designer` | UX/interaction design, wireframes, WCAG accessibility auditing, accesslint integration. |
+| `mcp-liaison` | Delegated MCP session construction and divergence reconciliation. |
+| `qa-engineer` | Test strategy, integration/system/acceptance test design, defect isolation. |
+| `sre` | Operations planning, capacity, DR, incident posture, post-incident review. |
+| `tech-writer` | User docs, API references, operator manuals, how-tos, release notes prose. |
+| `code-reviewer` | IEEE 1028 code review, drift detection, conformance audit, pre-commit gate. |
+| `release-engineer` | Build pipeline, IaC, deployment, rollback, release gating. |
+| `security-engineer` | Auth, secrets, PII, network-exposed endpoints, Hard Rule #7 paths, SDL. |
+| `onboarding-auditor` | Zero-context documentation audit — one-shot, dispatched at milestone close. |
+| `process-auditor` | Cultural-disruptor process audit — one-shot, every 2–3 milestones. |
+
+Per-project `sme-<domain>` agents are also available when the project has
+created them. Dispatch via `@sme-<domain>` or autonomous selection.
+
+## Binding References
+
+The following files are binding for all work done in Gemini sessions. When
+they conflict with any other source, they win:
+
+- **`CLAUDE.md`** — Hard Rules (11 rules), escalation protocol, time-based
+  cadences. Read in Mode A before substantive work.
+- **`SW_DEV_ROLE_TAXONOMY.md`** — binding role vocabulary. Role-ownership
+  disputes resolve here, not by agent opinion.
+- **`docs/glossary/ENGINEERING.md`** — binding generic software-engineering
+  terminology. Amend via `librarian` + `architect` + `tech-lead` consensus.
+- **`docs/glossary/PROJECT.md`** — binding project-specific terminology.
+  Amend via `librarian` + relevant `sme-<domain>` + `tech-lead` consensus.
+- **`docs/model-routing-guidelines.md`** — binding per-agent model tier and
+  effort defaults. The `gemini_equivalent` column governs `.gemini/agents/`
+  `model` fields.
+
+## Paraphrase and IP Rule
+
+Standards text (SWEBOK, IEEE, ISO, and similar) must be paraphrased, not
+quoted verbatim, in any output or committed file (CLAUDE.md Hard Rule #5).
+This applies in Gemini sessions on the same terms as in all other harnesses.
+
+## Escalation and Customer-Truth Custody
+
+The escalation protocol is unchanged from `CLAUDE.md` § "Escalation
+protocol": one question per turn, all agents and tools idle, question as the
+final line, batched internally in `docs/OPEN_QUESTIONS.md` first.
+
+Customer-truth recording routes to `librarian`. When `tech-lead` receives a
+customer answer, it routes the verbatim text to `librarian`; `librarian`
+appends the entry to `CUSTOMER_NOTES.md` using the canonical shape in
+`docs/templates/customer-note-entry-template.md`. No other agent writes
+customer-truth entries directly.
+
+## Codex Pre-Close Checklist Equivalent
+
+Before closing any non-trivial Mode A turn, confirm:
+
+1. Every direct `tech-lead` edit is within the allowed orchestration or
+   tool-bridge scope from Hard Rule #8.
+2. Customer-truth text and authorization records were routed to `librarian`,
+   not written directly by `tech-lead`.
+3. Required specialist work was dispatched, queued, or covered by an explicit
+   customer exception.
+4. The diff contains no accidental edits to framework-managed files (unless
+   customer authorized template-upgrade or framework-maintenance work).
+5. Non-default model tier or reasoning effort has a recorded rationale.
+
+Map canonical roles to agent files and Codex adapter for cross-harness
+reference:
+
+- `tech-lead` → `.claude/agents/tech-lead.md`
+- `project-manager` → `.claude/agents/project-manager.md`
+- `architect` → `.claude/agents/architect.md`
+- `software-engineer` → `.claude/agents/software-engineer.md`
+- `researcher` → `.claude/agents/researcher.md`
+- `librarian` → `.claude/agents/librarian.md`
+- `ui-ux-designer` → `.claude/agents/ui-ux-designer.md`
+- `mcp-liaison` → `.claude/agents/mcp-liaison.md`
+- `qa-engineer` → `.claude/agents/qa-engineer.md`
+- `sre` → `.claude/agents/sre.md`
+- `tech-writer` → `.claude/agents/tech-writer.md`
+- `code-reviewer` → `.claude/agents/code-reviewer.md`
+- `release-engineer` → `.claude/agents/release-engineer.md`
+- `security-engineer` → `.claude/agents/security-engineer.md`
+- `onboarding-auditor` → `.claude/agents/onboarding-auditor.md`
+- `process-auditor` → `.claude/agents/process-auditor.md`
+- `sme-<domain>` → `.claude/agents/sme-<domain>.md`
+
+Codex adapter: `AGENTS.md` (structural parallel to this file).

--- a/docs/TEMPLATE_UPGRADE.md
+++ b/docs/TEMPLATE_UPGRADE.md
@@ -242,6 +242,16 @@ downstream maintainer reading this guide from a project tree may need to
 consult the upstream template repo for `migrations/README.md` and
 `migrations/TEMPLATE.sh`.
 
+**Gemini harness adapter (FW-ADR-0022).** The release that ships Gemini
+harness support adds `GEMINI.md` (root adapter) and `.gemini/agents/`
+(generated thin adapters). If you use gemini-cli, upgrade it to
+>= v0.38.1 before running `scripts/compile-runtime-agents.sh` — older
+versions have no named subagent surface and the `.gemini/agents/` output
+will be unused or unsupported. Run `compile-runtime-agents.sh` (all
+targets) after this template upgrade to emit the new `.gemini/agents/`
+files alongside the existing `.opencode/agents/` output. gemini-cli
+v0.44.0+ is the stable-surface version; v0.38.1 is the minimum floor.
+
 ## Known upgrade cliffs
 
 An upgrade cliff is a specific version hop where the project's existing

--- a/docs/runtime/agents/tech-lead.md
+++ b/docs/runtime/agents/tech-lead.md
@@ -3,7 +3,7 @@ name: tech-lead
 description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
 model: sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 11a38f07e9355c2bab5cd2f097c22f989b450398
+canonical_sha: 3953fdb42132443a3d8e6a0e8a3e21e80282de65
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/scripts/compile-runtime-agents.sh
+++ b/scripts/compile-runtime-agents.sh
@@ -16,10 +16,18 @@
 # claude-sonnet with a stderr WARN. Pass --no-opencode-adapters to
 # skip adapter generation (compact-runtime-only mode for self-tests).
 #
+# fw-adr-0022 scope: also writes a thin Gemini CLI adapter stub to
+# .gemini/agents/<role>.md. The adapter's model class is resolved from
+# the Gemini-equivalent column of the same binding table in
+# docs/model-routing-guidelines.md. The Gemini adapter MUST include the
+# description field (load-bearing for Gemini autonomous role selection).
+# Pass --no-gemini-adapters to skip Gemini adapter generation.
+#
 # Usage:
 #   scripts/compile-runtime-agents.sh [--check] [--verify] [--strict] \
 #                                     [--out-dir <path>] \
-#                                     [--no-opencode-adapters] [role...]
+#                                     [--no-opencode-adapters] \
+#                                     [--no-gemini-adapters] [role...]
 #
 # Inputs:
 #   * Zero positional args -> walk every .claude/agents/*.md (excluding
@@ -55,6 +63,12 @@
 #                   Default behaviour generates both compact-runtime
 #                   contracts and adapter stubs. In --verify mode this
 #                   restricts verification to compact-runtime only.
+#   --no-gemini-adapters
+#                   Skip writing .gemini/agents/<role>.md adapters
+#                   (fw-adr-0022). Default behaviour generates Gemini
+#                   adapters alongside OpenCode adapters. In --verify
+#                   mode this restricts verification to compact-runtime
+#                   and OpenCode only.
 #
 # Section-heading mapping (canonical-slug <- accepted heading patterns,
 # case-insensitive, whitespace-tolerant; punctuation/parentheticals
@@ -90,8 +104,10 @@ DEFAULT_OUT_DIR="docs/runtime/agents"
 GENERATED_SCHEMA="${SCHEMA_DIR}/generated-artifact.schema.json"
 OPENCODE_OUT_DIR=".opencode/agents"
 OPENCODE_LOCAL_DIR=".opencode/agents/local"
+GEMINI_OUT_DIR=".gemini/agents"
 ROUTING_DOC="docs/model-routing-guidelines.md"
 DEFAULT_MODEL_CLASS="claude-sonnet"
+DEFAULT_GEMINI_MODEL_CLASS="gemini-pro"
 
 # ---- arg parsing -----------------------------------------------------
 CHECK_MODE=0
@@ -101,6 +117,7 @@ REPRO_MODE=0
 OUT_DIR="${DEFAULT_OUT_DIR}"
 ROLES=""
 NO_OPENCODE_ADAPTERS=0
+NO_GEMINI_ADAPTERS=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -140,6 +157,10 @@ while [ $# -gt 0 ]; do
       ;;
     --no-opencode-adapters)
       NO_OPENCODE_ADAPTERS=1
+      shift
+      ;;
+    --no-gemini-adapters)
+      NO_GEMINI_ADAPTERS=1
       shift
       ;;
     -h|--help)
@@ -255,6 +276,10 @@ if [ "${REPRO_MODE}" -eq 1 ]; then
   if [ "${NO_OPENCODE_ADAPTERS}" -eq 1 ]; then
     repro_args_a="${repro_args_a} --no-opencode-adapters"
     repro_args_b="${repro_args_b} --no-opencode-adapters"
+  fi
+  if [ "${NO_GEMINI_ADAPTERS}" -eq 1 ]; then
+    repro_args_a="${repro_args_a} --no-gemini-adapters"
+    repro_args_b="${repro_args_b} --no-gemini-adapters"
   fi
 
   # OPENCODE_OUT_DIR is read from the script's own default; we need to
@@ -376,6 +401,22 @@ if [ "${REPRO_MODE}" -eq 1 ]; then
           fi
       fi
 
+      if [ "${NO_GEMINI_ADAPTERS}" -eq 0 ]; then
+          a_gm="${REPRO_A}/root/${GEMINI_OUT_DIR}/${r}.md"
+          b_gm="${REPRO_B}/root/${GEMINI_OUT_DIR}/${r}.md"
+          if [ -f "${a_gm}" ] || [ -f "${b_gm}" ]; then
+              if [ ! -f "${a_gm}" ] || [ ! -f "${b_gm}" ]; then
+                  echo "reproducibility FAIL: ${r} -- diff at ${a_gm} (one side missing)"
+                  role_ok=0
+                  repro_status=1
+              elif ! cmp -s "${a_gm}" "${b_gm}"; then
+                  echo "reproducibility FAIL: ${r} -- diff at ${a_gm}"
+                  role_ok=0
+                  repro_status=1
+              fi
+          fi
+      fi
+
       if [ "${role_ok}" -eq 1 ]; then
           echo "reproducibility OK: ${r}"
       fi
@@ -391,6 +432,7 @@ fi
 VERIFY_SCRATCH=""
 VERIFY_COMMITTED_RUNTIME=""
 VERIFY_COMMITTED_OPENCODE=""
+VERIFY_COMMITTED_GEMINI=""
 if [ "${VERIFY_MODE}" -eq 1 ]; then
   if [ "${CHECK_MODE}" -eq 1 ]; then
     echo "compile-runtime-agents: --verify and --check are mutually exclusive" >&2
@@ -399,9 +441,11 @@ if [ "${VERIFY_MODE}" -eq 1 ]; then
   VERIFY_SCRATCH="$(mktemp -d)"
   VERIFY_COMMITTED_RUNTIME="${OUT_DIR}"
   VERIFY_COMMITTED_OPENCODE="${OPENCODE_OUT_DIR}"
+  VERIFY_COMMITTED_GEMINI="${GEMINI_OUT_DIR}"
   OUT_DIR="${VERIFY_SCRATCH}/runtime"
   OPENCODE_OUT_DIR="${VERIFY_SCRATCH}/opencode"
-  mkdir -p "${OUT_DIR}" "${OPENCODE_OUT_DIR}"
+  GEMINI_OUT_DIR="${VERIFY_SCRATCH}/gemini"
+  mkdir -p "${OUT_DIR}" "${OPENCODE_OUT_DIR}" "${GEMINI_OUT_DIR}"
   # Trap cleanup; preserved across compile_role's own EXIT trap usage
   # by being installed last and re-installing after each compile.
 fi
@@ -616,6 +660,35 @@ resolve_model_class() {
   ' "${ROUTING_DOC}"
 }
 
+# ---- gemini model-class resolver ------------------------------------
+# Like resolve_model_class but reads column 6 (Gemini equivalent) of the
+# binding table instead of column 3 (default_class / Claude equivalent).
+resolve_gemini_model_class() {
+  role_slug="$1"
+  if [ ! -f "${ROUTING_DOC}" ]; then
+    echo ""
+    return 0
+  fi
+  awk -v role="${role_slug}" '
+    BEGIN { FS = "|"; in_table = 0 }
+    /^##[ \t]+Binding per-agent default-class table/ { in_table = 1; next }
+    /^##[ \t]+/ { if (in_table) in_table = 0 }
+    in_table == 0 { next }
+    /^\|[ \t]*`[a-z0-9-]+`[ \t]*\|[ \t]*`[a-z0-9-]+`[ \t]*\|/ {
+      agent = $2
+      gsub(/^[ \t]+|[ \t]+$/, "", agent)
+      gsub(/`/, "", agent)
+      if (agent == role) {
+        cls = $6
+        gsub(/^[ \t]+|[ \t]+$/, "", cls)
+        gsub(/`/, "", cls)
+        print cls
+        exit
+      }
+    }
+  ' "${ROUTING_DOC}"
+}
+
 # ---- opencode adapter writer ----------------------------------------
 # Writes .opencode/agents/<role>.md with frontmatter + the fixed
 # four-line body required by R-7. canonical_sha is the same 40-hex
@@ -645,6 +718,57 @@ write_opencode_adapter() {
     if [ -f "${local_supplement}" ]; then
       printf 'local_supplement: %s\n' "${local_supplement}"
     fi
+    printf 'generator: %s\n' "${GENERATOR_PATH}"
+    printf 'generator_version: %s\n' "${GENERATOR_VERSION}"
+    printf 'classification: generated\n'
+    printf -- '---\n'
+    printf '\n'
+    # shellcheck disable=SC2016  # literal backticks for Markdown output
+    printf 'Read `.claude/agents/%s.md` (canonical role contract).\n' "${role}"
+    # shellcheck disable=SC2016  # literal backticks for Markdown output
+    printf 'If `local_supplement` resolves to an existing file, read it after the canonical file.\n'
+    printf 'Act only as that role.\n'
+    printf "Return output in the role's required format.\n"
+  } > "${tmp_out}"
+
+  mv "${tmp_out}" "${out_path}"
+
+  if ! maybe_validate_output "${out_path}"; then
+    overall_status=1
+  fi
+}
+
+# ---- gemini adapter writer ------------------------------------------
+# Writes .gemini/agents/<role>.md with frontmatter + the fixed
+# four-line body (same thin-adapter shape as opencode). Key differences
+# from the opencode adapter (per fw-adr-0022 §2):
+#   - description field is REQUIRED (load-bearing for Gemini autonomous
+#     role selection); copied verbatim from the canonical frontmatter.
+#   - model comes from the Gemini-equivalent column of the binding table,
+#     not default_class.
+write_gemini_adapter() {
+  role="$1"
+  canonical_src="$2"
+  canonical_sha="$3"
+  canonical_desc="$4"
+
+  gemini_model="$(resolve_gemini_model_class "${role}")"
+  if [ -z "${gemini_model}" ]; then
+    echo "compile-runtime-agents: ${role} not in routing table (Gemini col), defaulting to ${DEFAULT_GEMINI_MODEL_CLASS}" >&2
+    gemini_model="${DEFAULT_GEMINI_MODEL_CLASS}"
+  fi
+
+  mkdir -p "${GEMINI_OUT_DIR}"
+  out_path="${GEMINI_OUT_DIR}/${role}.md"
+  tmp_out="${out_path}.tmp"
+
+  {
+    printf -- '---\n'
+    printf 'name: %s\n' "${role}"
+    printf 'description: %s\n' "${canonical_desc}"
+    printf 'model: %s\n' "${gemini_model}"
+    printf 'canonical_source: %s\n' "${canonical_src}"
+    printf 'canonical_sha: %s\n' "${canonical_sha}"
     printf 'generator: %s\n' "${GENERATOR_PATH}"
     printf 'generator_version: %s\n' "${GENERATOR_VERSION}"
     printf 'classification: generated\n'
@@ -794,6 +918,13 @@ compile_role() {
     write_opencode_adapter "${role}" "${src}" "${canonical_sha}"
   fi
 
+  # Gemini adapter (fw-adr-0022) — same conditions as opencode. The
+  # description is passed explicitly because it is load-bearing for
+  # Gemini autonomous role selection and must be copied verbatim.
+  if [ "${NO_GEMINI_ADAPTERS}" -eq 0 ]; then
+    write_gemini_adapter "${role}" "${src}" "${canonical_sha}" "${fm_desc}"
+  fi
+
   out_path="${OUT_DIR}/${role}.md"
 
   if [ "${role_incomplete}" -eq 1 ] && [ "${STRICT_MODE}" -eq 0 ]; then
@@ -910,6 +1041,23 @@ if [ "${VERIFY_MODE}" -eq 1 ]; then
           verify_status=1
         elif ! cmp -s "${gen_opencode}" "${cmt_opencode}"; then
           echo "verify FAIL: ${cmt_opencode} differs from generator output"
+          role_ok=0
+          verify_status=1
+        fi
+      fi
+    fi
+
+    # Gemini adapter (unless suppressed).
+    if [ "${NO_GEMINI_ADAPTERS}" -eq 0 ]; then
+      gen_gemini="${GEMINI_OUT_DIR}/${role}.md"
+      cmt_gemini="${VERIFY_COMMITTED_GEMINI}/${role}.md"
+      if [ -f "${gen_gemini}" ]; then
+        if [ ! -f "${cmt_gemini}" ]; then
+          echo "verify FAIL: ${cmt_gemini} differs from generator output (committed file missing)"
+          role_ok=0
+          verify_status=1
+        elif ! cmp -s "${gen_gemini}" "${cmt_gemini}"; then
+          echo "verify FAIL: ${cmt_gemini} differs from generator output"
           role_ok=0
           verify_status=1
         fi

--- a/scripts/lint-agent-contracts.sh
+++ b/scripts/lint-agent-contracts.sh
@@ -56,6 +56,7 @@ cd "${REPO_ROOT}"
 AGENTS_DIR=".claude/agents"
 RUNTIME_DIR="docs/runtime/agents"
 OPENCODE_DIR=".opencode/agents"
+GEMINI_DIR=".gemini/agents"
 FIXTURES_DIR="tests/prompt-regression"
 SCHEMA_DIR="schemas"
 CONTRACT_SCHEMA="${SCHEMA_DIR}/agent-contract.schema.json"
@@ -495,8 +496,15 @@ scan_canonical() {
 }
 
 # ---- generated-artifact validation -----------------------------------
+# lint_generated_file <src> [gemini]
+#   Pass the literal string "gemini" as $2 when validating a file under
+#   .gemini/agents/; this enables the Gemini-specific description check
+#   (fw-adr-0022 §4: description must be present and non-empty).
+#   The schema itself does not enforce this for generated artifacts
+#   (doing so would break runtime/opencode adapters which omit the field).
 lint_generated_file() {
     src="$1"
+    is_gemini="${2:-}"
     workdir="$(mktemp -d)"
     tmpjson="${workdir}/fm.json"
     # Extract frontmatter to a JSON object. Same recipe used by the
@@ -534,6 +542,37 @@ lint_generated_file() {
         fi
         err "${src}" "${diag}"
     fi
+
+    # Gemini-specific: description must be present and non-empty
+    # (fw-adr-0022 §4 — load-bearing for autonomous Gemini role selection).
+    # Not enforced via the shared schema to avoid breaking runtime/opencode
+    # adapters that legitimately omit description.
+    if [ "${is_gemini}" = "gemini" ]; then
+        desc_val="$(awk -F'\t' '$1=="description" {print $0; exit}' "${tmpjson}" 2>/dev/null || true)"
+        # Re-extract directly from the raw frontmatter for reliability.
+        desc_val="$(awk '
+            BEGIN { state = "pre" }
+            {
+                if (state == "pre") {
+                    if ($0 == "---") { state = "fm"; next }
+                    exit
+                }
+                if (state == "fm") {
+                    if ($0 == "---") { exit }
+                    if ($0 ~ /^description[ \t]*:/) {
+                        v = $0
+                        sub(/^description[ \t]*:[ \t]*/, "", v)
+                        print v
+                        exit
+                    }
+                }
+            }
+        ' "${src}")"
+        if [ -z "${desc_val}" ]; then
+            err "${src}" "gemini adapter missing required description field (fw-adr-0022 §4)"
+        fi
+    fi
+
     rm -rf "${workdir}"
 }
 
@@ -543,13 +582,19 @@ scan_generated() {
         ERR_COUNT=$((ERR_COUNT + 1))
         return
     fi
-    for dir in "${RUNTIME_DIR}" "${OPENCODE_DIR}"; do
+    for dir in "${RUNTIME_DIR}" "${OPENCODE_DIR}" "${GEMINI_DIR}"; do
         [ -d "${dir}" ] || continue
         # Only validate role-shaped basenames; skip READMEs and any
         # non-role markdown the directories may hold (e.g.,
         # generated-artifacts.manifest.json sits in docs/runtime/agents/
         # at a sibling path but is not .md). The role check mirrors the
         # compiler's role walk (kebab-case slug, no sme-template).
+        #
+        # Pass "gemini" as the second arg when scanning .gemini/agents/ so
+        # lint_generated_file applies the description-required check
+        # (fw-adr-0022 §4) for that surface only.
+        _lint_extra=""
+        [ "${dir}" = "${GEMINI_DIR}" ] && _lint_extra="gemini"
         ls "${dir}" 2>/dev/null \
             | grep '\.md$' \
             | sed 's/\.md$//' \
@@ -559,7 +604,7 @@ scan_generated() {
             | LC_ALL=C sort \
             | sed 's/$/.md/' \
             | while IFS= read -r f; do
-                lint_generated_file "${dir}/${f}"
+                lint_generated_file "${dir}/${f}" "${_lint_extra}"
                 printf 'COUNTERS\t%d\t%d\n' "${ERR_COUNT}" "${WARN_COUNT}"
             done > "${TMP_COUNTERS}"
         last="$(tail -1 "${TMP_COUNTERS}" 2>/dev/null || true)"

--- a/scripts/scaffold.sh
+++ b/scripts/scaffold.sh
@@ -56,6 +56,42 @@ fi
 
 mkdir -p "$target"
 
+# --- Advisory: gemini-cli version check (fw-adr-0022) ------------------------
+# The Gemini harness adapter requires gemini-cli >= v0.38.1. This check is
+# advisory only — scaffold does not hard-fail when gemini-cli is absent or
+# older, because the Gemini harness is optional. Matches the pattern of other
+# optional-tool checks in this script.
+_GEMINI_MIN="0.38.1"
+_gemini_warn() { echo "WARN (scaffold): $*" >&2; }
+if command -v gemini >/dev/null 2>&1; then
+  _gemini_ver="$(gemini --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  if [ -z "${_gemini_ver}" ]; then
+    _gemini_warn "gemini-cli found but version could not be determined; need >= ${_GEMINI_MIN} for the Gemini harness adapter (fw-adr-0022)"
+  else
+    # Compare semver components numerically.
+    _req_major="$(printf '%s' "${_GEMINI_MIN}" | cut -d. -f1)"
+    _req_minor="$(printf '%s' "${_GEMINI_MIN}" | cut -d. -f2)"
+    _req_patch="$(printf '%s' "${_GEMINI_MIN}" | cut -d. -f3)"
+    _got_major="$(printf '%s' "${_gemini_ver}" | cut -d. -f1)"
+    _got_minor="$(printf '%s' "${_gemini_ver}" | cut -d. -f2)"
+    _got_patch="$(printf '%s' "${_gemini_ver}" | cut -d. -f3)"
+    _ver_ok=0
+    if [ "${_got_major}" -gt "${_req_major}" ]; then
+      _ver_ok=1
+    elif [ "${_got_major}" -eq "${_req_major}" ] && [ "${_got_minor}" -gt "${_req_minor}" ]; then
+      _ver_ok=1
+    elif [ "${_got_major}" -eq "${_req_major}" ] && [ "${_got_minor}" -eq "${_req_minor}" ] && [ "${_got_patch}" -ge "${_req_patch}" ]; then
+      _ver_ok=1
+    fi
+    if [ "${_ver_ok}" -eq 0 ]; then
+      _gemini_warn "gemini-cli ${_gemini_ver} is older than ${_GEMINI_MIN}; upgrade for the Gemini harness adapter (fw-adr-0022). Scaffold continues."
+    fi
+  fi
+else
+  _gemini_warn "gemini-cli not found; Gemini harness adapter (fw-adr-0022) will not be usable until installed (>= ${_GEMINI_MIN}). Scaffold continues."
+fi
+unset _GEMINI_MIN _gemini_warn _gemini_ver _req_major _req_minor _req_patch _got_major _got_minor _got_patch _ver_ok
+
 template_version="$(tr -d '[:space:]' < VERSION)"
 template_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 today="$(date -u +%Y-%m-%d)"


### PR DESCRIPTION
Implements the Accepted **fw-adr-0022** (Gemini harness adapter, Option S) — issue **#300**: makes gemini-cli a co-equal harness alongside Claude Code and Codex/OpenCode.

## What landed
- **`GEMINI.md`** (hand-authored root adapter, parallel to `AGENTS.md`): version floor (gemini-cli ≥ v0.38.1), two-mode role binding (Mode A = main session is `tech-lead`; Mode B = delegated-specialist, paraphrased per HR-5), grounding + situational reads, `@name`-override dispatch guidance for deterministic / Hard-Rule-4/7 paths, **16-role roster table**, binding references, paraphrase rule, librarian customer-truth custody.
- **`.gemini/agents/<role>.md`** — 16 generated thin adapters with a **load-bearing `description`** copied verbatim from each canonical contract (gemini-cli selects subagents by description-matching), `model` from the **Gemini-equivalent column** (gemini-pro for 15, gemini-flash for project-manager), and `canonical_sha` drift protection.
- **`compile-runtime-agents.sh`** — emits `.gemini/agents/` in the same pass as opencode (`--no-gemini-adapters` flag; included in `--verify` + reproducibility).
- **`lint-agent-contracts.sh`** — covers `.gemini/agents/` (canonical_sha + valid model + a gemini-specific non-empty-description check), per ADR ruling 2 (extend existing, no new script).
- **`.claude/agents/tech-lead.md`** — ADR §3 **runtime self-guard**: if loaded as a subagent context (incl. gemini-cli autonomously selecting `@tech-lead`) rather than the main-session persona, halt and report harness misconfiguration. Runtime + opencode + gemini mirrors regenerated.
- **`scaffold.sh`** advisory gemini-cli version check; **`TEMPLATE_UPGRADE.md`** migration note.

## Verification
- agent-contract (`lint-agent-contracts`) **0/0** (now covering `.gemini/`) · compile `--verify` **16/16** across runtime + opencode + gemini, no FAILs
- lint-routing **0/0** · gemini description check confirmed firing on empty/absent description
- code-reviewer: **APPROVED** after one fix round (M-1 runtime guard, m-1 gemini description lint)

## Notes
- Roster is **16** (the ADR text predates the roster bundle's 13→16); implementation covers all 16. No routing-table change needed — the Gemini-equivalent column already lists all 16 roles.
- Commits role-matched per FW-ADR-0011 (`Routed-Through:` software-engineer for scripts+generated adapters, tech-writer for the root adapter + guard + mirrors + upgrade note).
- **#293** (delegated-specialist parity across *all* providers) remains the explicit follow-up per ruling Q-0028 — GEMINI.md already carries Mode B for the Gemini surface.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)