### PR TITLE
Handoff activity sidecar (fw-adr-0023 D2, Option S)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ tests/release-gate/snapshots/*
 # declared ephemeral session output and intentionally not tracked.
 docs/pm/token-ledger.md
 tests/prompt-regression/results-*.md
+
+# Handoff activity sidecars (fw-adr-0023 D2 Option S).
+# Runtime telemetry written by handoff-record-activity.py; never committed.
+# Durable handoff contract data lives in docs/handoffs/*.json (git-tracked).
+docs/handoffs/*.activity.jsonl

--- a/docs/TEMPLATE_UPGRADE.md
+++ b/docs/TEMPLATE_UPGRADE.md
@@ -242,6 +242,21 @@ downstream maintainer reading this guide from a project tree may need to
 consult the upstream template repo for `migrations/README.md` and
 `migrations/TEMPLATE.sh`.
 
+**Handoff activity sidecar (FW-ADR-0023).** The release that ships the
+activity-sidecar change moves runtime telemetry out of git-tracked
+handoff JSON files. Existing `docs/handoffs/*.json` files that carry an
+`"activity"` array are migrated by the upgrade: the array is stripped
+from the JSON (which becomes a static durable contract after this point)
+and its entries are written to a gitignored
+`docs/handoffs/<task_id>.activity.jsonl` sidecar. If your project has
+no `docs/handoffs/*.json` files with accumulated `"activity"` entries,
+the migration is a no-op. If you have downstream tooling that reads
+`handoff["activity"]` directly, update it to read the sidecar
+`*.activity.jsonl` file instead. The `manifest_file_sha_normalized`
+normalizer in `scripts/lib/manifest.sh` has been removed in this
+release — it is no longer needed because handoff JSON files are now
+static after creation and are hashed raw.
+
 **Gemini harness adapter (FW-ADR-0022).** The release that ships Gemini
 harness support adds `GEMINI.md` (root adapter) and `.gemini/agents/`
 (generated thin adapters). If you use gemini-cli, upgrade it to

--- a/docs/adr/fw-adr-0023-handoff-activity-array-growth.md
+++ b/docs/adr/fw-adr-0023-handoff-activity-array-growth.md
@@ -1,0 +1,487 @@
+---
+name: fw-adr-0023-handoff-activity-array-growth
+description: >
+  Two coupled decisions on handoff JSON integrity: (1) deliberate hash-exclusion
+  of the runtime-mutable "activity" array from TEMPLATE_MANIFEST.lock verification,
+  and (2) disposition of the unbounded growth that exclusion exposes.
+status: accepted
+date: 2026-06-02
+---
+
+
+# FW-ADR-0023 — Handoff activity-array: hash-exclusion and unbounded growth
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Scaffold placement note](#scaffold-placement-note)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Decision 1 — Hash-exclusion of the activity array](#decision-1--hash-exclusion-of-the-activity-array)
+  - [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+    - [Option M — Minimalist: gitignore handoff files](#option-m--minimalist-gitignore-handoff-files)
+    - [Option S — Scalable: normalize before hashing (shipped as #276 fix)](#option-s--scalable-normalize-before-hashing-shipped-as-276-fix)
+    - [Option C — Creative: separate activity sidecar, handoff files stay static](#option-c--creative-separate-activity-sidecar-handoff-files-stay-static)
+  - [Decision outcome — D1](#decision-outcome--d1)
+  - [Security trade-off (explicit)](#security-trade-off-explicit)
+- [Decision 2 — Unbounded growth of the activity array](#decision-2--unbounded-growth-of-the-activity-array)
+  - [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding-1)
+    - [Option M — Minimalist: leave as-is](#option-m--minimalist-leave-as-is)
+    - [Option S — Scalable: move activity to a sidecar file outside the manifest set](#option-s--scalable-move-activity-to-a-sidecar-file-outside-the-manifest-set)
+    - [Option C — Creative: cap-and-rotate within the handoff file](#option-c--creative-cap-and-rotate-within-the-handoff-file)
+  - [Decision outcome — D2](#decision-outcome--d2)
+- [Consequences](#consequences)
+  - [Positive (D1, already realized)](#positive-d1-already-realized)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up work](#follow-up-work)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+Shape per MADR 3.0 + this template's Three-Path Rule
+(`docs/templates/adr-template.md`). Two coupled decisions (D1
+hash-exclusion, D2 growth disposition) are recorded in one ADR because
+they share the same root: `activity` is runtime telemetry stitched into
+a git-tracked durable contract file.
+
+---
+
+## Status
+
+- **Proposed** — 2026-06-02
+- **Accepted** — 2026-06-03. Option S (Sidecar) adopted per customer ruling 2026-06-03; move `activity` array to gitignored `docs/handoffs/<task>.activity.jsonl`, MINOR schema bump + one-time migration, remove hash-exclusion normalizer.
+- **D1 (hash-exclusion):** implemented in PR #304 / issue #276; this ADR
+  provides post-hoc rationale and security trade-off documentation for
+  the shipped fix. No further implementation work required for D1.
+- **D2 (growth):** Option S (Sidecar) chosen; customer ruling recorded 2026-06-03; implemented in this PR (`feat/activity-sidecar`).
+- **Deciders:** `architect` (proposed); `tech-lead` + customer (accepted 2026-06-03)
+- **Consulted:** `scripts/lib/manifest.sh` (`manifest_file_sha_normalized`,
+  PR #304); `security-engineer` (sign-off on #276, recorded in
+  `CUSTOMER_NOTES.md` 2026-06-02); FW-ADR-0002 (manifest model);
+  FW-ADR-0014 (preservation vs manifest); issue #276
+
+## Scaffold placement note
+
+This ADR was drafted in the meta-project (`docs/adr/`) per the PLAN/DO
+convention (CLAUDE.md § "Project Identity / Working Tree"). It migrated
+into the scaffold's `docs/adr/` as part of the D2 implementation PR
+(`feat/activity-sidecar`) so the rationale travels with the code,
+matching the pattern established by FW-ADR-0001 through FW-ADR-0022.
+The meta-project draft copy is retained as the team's working reference;
+this scaffold copy is the canonical version from the implementation PR
+forward.
+
+---
+
+## Context and problem statement
+
+FW-ADR-0002 introduced `TEMPLATE_MANIFEST.lock`: a git-tracked file
+containing SHA256 hashes of every template-shipped file. `upgrade.sh
+--verify` compares on-disk hashes against the manifest to detect drift
+without network access.
+
+`docs/handoffs/*.json` files are template-shipped (they carry durable
+contract data: `status`, `mode`, `allowed_paths`, `hard_rule_traces`,
+`acceptance_criteria`, `verification`) and therefore appear in the
+manifest.
+
+An activity hook (`handoff-record-activity.py`) appends an entry to the
+top-level `"activity"` array inside each handoff JSON file on every
+PreToolUse and PostToolUse boundary during a session. This is runtime
+telemetry — it is not a durable contract field — but it lives in the
+same file as the durable fields. The result: the file's SHA256 changes
+on every tool call, causing `--verify` to report drift on every session
+even when no contract field changed.
+
+PR #304 (issue #276) shipped a fix: `manifest_file_sha_normalized` in
+`scripts/lib/manifest.sh` strips `"activity"` before hashing, applied
+symmetrically in both `manifest_write` and `manifest_verify`. The fix
+is fail-closed: if `python3` is unavailable it returns an error rather
+than silently falling back to the raw hash.
+
+A reviewer flagged two residual concerns not addressed by the PR:
+1. The `"activity"` content receives no integrity guarantee once
+   excluded from hashing. Is that acceptable?
+2. The `"activity"` array grows without bound on every session; the
+   handoff files are git-tracked. What is the long-term growth
+   disposition?
+
+This ADR records the structural decisions behind the shipped fix (D1)
+and evaluates options for the growth problem (D2).
+
+---
+
+## Decision drivers
+
+- **Manifest integrity must be stable.** `--verify` serving a false
+  "drift" on every session destroys operator trust and CI signal.
+  This was the immediate driver for the #276 fix.
+- **Fail-closed.** An unavailable normalizer must not silently produce
+  a wrong hash. The PR satisfied this with the `python3` guard.
+- **Symmetric write/verify.** The hash used at manifest-write time
+  must be computed identically at verify time. Asymmetry produces
+  either permanent drift (write includes activity, verify strips it)
+  or a false clean (write strips, verify includes).
+- **Security honesty.** A reviewer correctly noted that excluding a
+  field from integrity coverage is a security-relevant choice that
+  must be named and justified, not left implicit.
+- **Git hygiene.** Unbounded growth in a git-tracked file compounds
+  with every session — clone size, diff noise, pre-commit hook
+  runtime — and is a correctness risk for tooling that greps handoff
+  content.
+- **Backward compatibility.** Any growth remediation must not break
+  existing handoff consumers (the gate hook, the bounded-Codex
+  schema, `schemas/handoff.schema.json`).
+
+---
+
+## Decision 1 — Hash-exclusion of the activity array
+
+### Considered options (Three-Path Rule, binding)
+
+#### Option M — Minimalist: gitignore handoff files
+
+Add `docs/handoffs/*.json` to `.gitignore` so the activity-mutated
+files are never tracked, and remove them from the manifest set.
+
+- **Sketch:** One `.gitignore` entry; `manifest_ship_files` exclusion
+  regex gains a `docs/handoffs/` line. Manifest no longer covers
+  handoff files. Implementation cost: one PR, zero Python, no new
+  `manifest.sh` function.
+- **Pros:** Simple; eliminates the drift problem entirely; no integrity
+  surface to reason about for handoff files.
+- **Cons:** Also eliminates verification of the _durable_ fields
+  (`allowed_paths`, `acceptance_criteria`, `verification`, etc.) that
+  the manifest is supposed to protect. A hand-edit to
+  `fw-012-v1-1-handoff-contracts.json`'s `allowed_paths` would go
+  undetected by `--verify`. This is a regression in the framework's
+  tamper-evidence promise, which FW-ADR-0002 makes explicitly for all
+  template-shipped files. Also, untracked runtime-telemetry files have
+  no audit trail of session activity.
+- **When M wins:** if the durable contract fields in handoff files
+  needed no integrity coverage — i.e., if handoffs were treated as
+  fully operator-owned. They are not: the bounded-Codex gate in
+  FW-ADR-0021 depends on `allowed_paths` and `acceptance_criteria`
+  being tamper-evident.
+
+#### Option S — Scalable: normalize before hashing (shipped as #276 fix)
+
+Strip `"activity"` from the JSON before computing the hash, both at
+write time and at verify time, using canonical JSON serialization
+(sorted keys). All other fields remain under integrity coverage.
+
+- **Sketch:** `manifest_file_sha_normalized` in `scripts/lib/manifest.sh`
+  (already implemented). Applies only to `docs/handoffs/*.json` by
+  path pattern. All other files use the raw `manifest_file_sha` path
+  unchanged.
+- **Pros:** Durable contract fields remain covered by the manifest.
+  Session telemetry stops causing spurious drift. Symmetric write/verify
+  produces stable hashes. Fail-closed on missing `python3`. Narrow
+  scope — only handoff files are normalized; all other template files
+  are hashed raw.
+- **Cons:** The `"activity"` key and its contents receive no integrity
+  guarantee. An actor who can write to a handoff file can inject
+  arbitrary content into `"activity"` without detection by `--verify`.
+  This is the security trade-off named explicitly in the section below.
+- **When S wins:** when the durable contract fields must stay covered and
+  the telemetry field's integrity is acceptable to leave unguaranteed.
+  That is the framework's actual posture (see security trade-off below).
+
+#### Option C — Creative: separate activity sidecar, handoff files stay static
+
+Move the `"activity"` array out of the handoff JSON entirely. The hook
+writes to `docs/handoffs/<task_id>.activity.jsonl` (a newline-delimited
+append-only log) instead of mutating the handoff JSON. The handoff JSON
+becomes fully static after creation; `manifest_file_sha_normalized` is
+no longer needed; the raw `manifest_file_sha` path applies to all files.
+
+- **Sketch:** Modify `handoff-record-activity.py` to open a sidecar
+  `*.activity.jsonl` file instead of loading and rewriting the handoff
+  JSON. Add `docs/handoffs/*.activity.jsonl` to `.gitignore` (or track
+  them separately). `schemas/handoff.schema.json` drops `"activity"` or
+  marks it deprecated. `manifest_ship_files` exclusion regex ignores
+  `*.activity.jsonl`.
+- **Pros:** Handoff files are structurally static after creation;
+  hashing is simple and no normalizer is needed. Sidecar files can be
+  gitignored without losing durable contract integrity. Eliminates the
+  growth problem in git history. Clean separation of concerns: durable
+  contract vs. runtime log.
+- **Cons:** Requires a schema change to `schemas/handoff.schema.json`
+  (removing or deprecating `"activity"`); a migration for any existing
+  handoff files that already carry accumulated `"activity"` entries;
+  and a change to `handoff-record-activity.py`. Downstream consumers
+  that read `handoff.activity` must be updated. This is the correct
+  long-term architecture but has non-trivial migration cost.
+- **When C wins:** when the growth problem (D2) is resolved in favor of
+  the sidecar model — the Option C sidecar _is_ the D2 Option S
+  approach (see below). The two decisions are coupled.
+
+### Decision outcome — D1
+
+**Chosen option: S — Normalize before hashing (shipped in PR #304)**
+
+Option M drops durable contract integrity for handoff files; that
+regresses the tamper-evidence property FW-ADR-0002 exists to provide
+and which the bounded-Codex gate (FW-ADR-0021) depends on. Option C
+is the structurally correct long-term design but carries schema
+migration cost that was not in scope for the #276 hotfix; it maps to
+the D2 growth-remediation track below. Option S is the narrowest
+correct fix: it preserves durable-field integrity, is fail-closed, is
+symmetric, and does not require a schema change or migration. The #276
+fix shipped under Option S.
+
+### Security trade-off (explicit)
+
+**The `"activity"` array has no integrity guarantee under this scheme.**
+Content written into `"activity"` by `handoff-record-activity.py` — or
+by any other process with write access to the handoff file — is
+invisible to `--verify`. A compromised or malicious hook could inject
+content into `"activity"` without detection.
+
+Why this is accepted:
+
+1. **`"activity"` is session telemetry, not a trust boundary.** It
+   records tool call events for observability. No framework gate, no
+   bounded-Codex authorization path, and no customer-facing decision
+   reads from `"activity"` as a source of authority. A manipulated
+   `"activity"` log cannot cause the framework to take a privileged
+   action.
+2. **The integrity coverage that matters is on the durable contract
+   fields.** `allowed_paths`, `acceptance_criteria`, `verification`,
+   `status`, `mode`, and `hard_rule_traces` remain covered by the
+   manifest hash. These are the fields the bounded-Codex gate and the
+   operator's security posture depend on.
+3. **Write access to handoff files is equivalent to write access to the
+   repo.** The threat model for `TEMPLATE_MANIFEST.lock` is not
+   adversarial injection by an actor with filesystem access — it is
+   silent drift from tooling bugs, partial upgrades, or hand-edits.
+   FW-ADR-0002 states this explicitly (Option C/tree-hash was rejected
+   because "supply-chain attack threat models" are not in scope).
+4. **`security-engineer` reviewed and signed off on this trade-off**
+   for the #276 fix (recorded in `CUSTOMER_NOTES.md` 2026-06-02,
+   confirmed via the two carry-forward items noted there; neither
+   carry-forward blocks the D1 decision).
+
+If `"activity"` is ever read by a trust-sensitive code path, this
+trade-off must be re-evaluated and this ADR superseded.
+
+---
+
+## Decision 2 — Unbounded growth of the activity array
+
+The `"activity"` array in `docs/handoffs/*.json` grows by at least two
+entries (PreToolUse + PostToolUse) per tool call per session. A session
+with 200 tool calls adds 400 entries. These files are git-tracked; the
+array's growth is recorded in every commit and every clone. On a project
+with several active handoffs and long sessions, the cumulative size can
+reach hundreds of kilobytes of telemetry in git history within weeks.
+
+This is a distinct problem from the hash-exclusion decision. Hash
+exclusion prevents `--verify` noise; it does not stop the files from
+growing.
+
+### Considered options (Three-Path Rule, binding)
+
+#### Option M — Minimalist: leave as-is
+
+Accept unbounded growth. Document it. Rely on periodic `git gc` and
+periodic manual pruning of `"activity"` entries by operators.
+
+- **Sketch:** No code change. Add a note in `docs/handoffs/README.md`
+  (or equivalent) describing the growth behavior and recommending
+  operators truncate `"activity"` to `[]` before committing.
+- **Pros:** Zero implementation cost. No schema change. No migration.
+  No risk of breaking existing consumers.
+- **Cons:** Operator discipline as the only control. In practice,
+  telemetry entries accumulate silently because no agent or gate
+  prompts the operator to prune. Clone size grows monotonically.
+  Grep and diff tooling that reads handoff files becomes noisier.
+  The #276 fix made the growth invisible to `--verify` but did
+  nothing to stop it in git history.
+- **When M wins:** if the volume of tool calls per session were low,
+  handoff lifetimes were short, or the project repo were
+  ephemeral. None hold for the typical multi-week framework project.
+
+#### Option S — Scalable: move activity to a sidecar file outside the manifest set
+
+Move runtime telemetry out of the handoff JSON entirely. The hook
+writes to `docs/handoffs/<task_id>.activity.jsonl` (or
+`.activity.json`), which is gitignored. The handoff JSON drops the
+`"activity"` key. The manifest normalizer in D1 is then a no-op for
+handoff files and can eventually be removed.
+
+- **Sketch:**
+  - `handoff-record-activity.py` writes to
+    `docs/handoffs/<task_id>.activity.jsonl` (append-only, one JSON
+    object per line) instead of mutating the handoff JSON.
+  - `docs/handoffs/*.activity.jsonl` is added to `.gitignore`.
+  - `schemas/handoff.schema.json` removes or deprecates `"activity"`.
+  - A migration strips `"activity"` from existing handoff JSON files
+    and optionally exports accumulated entries to sidecar files.
+  - `manifest_file_sha_normalized` in `manifest.sh` becomes a no-op
+    for handoff files (or is removed in a follow-up, since normalization
+    is no longer needed).
+- **Pros:** Structural fix. Git history no longer accumulates telemetry.
+  Handoff JSON files are static after creation; hash verification is
+  simple and needs no special normalizer. Clean separation of concerns.
+  Gitignored sidecars are not subject to manifest coverage questions.
+  Forward-compatible: consumers that need activity logs read the
+  sidecar; consumers that need the contract read the JSON.
+- **Cons:** Schema change to `schemas/handoff.schema.json`. Migration
+  required for existing handoff files carrying `"activity"`. Change to
+  `handoff-record-activity.py`. Any downstream project or tool that
+  reads `handoff["activity"]` must be updated. This is real work (one
+  sprint), not a hotfix.
+- **When S wins:** when the growth problem is real and git history
+  hygiene matters for the project's lifetime. Recommended (see below).
+
+#### Option C — Creative: cap-and-rotate within the handoff file
+
+Keep `"activity"` in the handoff JSON but impose a hard cap (e.g.,
+the most recent N entries, with older entries replaced by a summary
+count). The hook trims `"activity"` to the last N entries on every
+write.
+
+- **Sketch:** `handoff-record-activity.py` reads the current
+  `"activity"` array, appends the new entry, and discards entries
+  beyond a cap (e.g., 100). The handoff JSON's `"activity"` array
+  never exceeds N entries. Git history still grows (each session
+  produces a modified file), but the per-file size is bounded.
+- **Pros:** No schema change. No migration for durable contract fields.
+  No gitignore change. Simpler than Option S. Activity data stays in
+  one file.
+- **Cons:** Git history still accumulates churn on every session (the
+  file is still modified and committed). The cap is arbitrary; the
+  right value is unclear and potentially project-dependent. Older
+  activity entries are silently discarded — if a debugging or audit
+  scenario needs the full history, it is gone. A summary-count
+  replacement loses individual event fidelity. The normalizer in D1
+  (`manifest_file_sha_normalized`) is still required and still
+  carries the `"activity"`-has-no-integrity-guarantee trade-off.
+  Essentially this option buys bounded file size while keeping all
+  the other costs of D1's accepted trade-off.
+- **When C wins:** when the schema migration cost of Option S is
+  prohibitive and a bounded file size is sufficient — i.e., the team
+  needs a quick bound without a structural fix. It is an acceptable
+  interim step if D2 implementation must be deferred.
+
+### Decision outcome — D2
+
+**Chosen option: S — Sidecar file, gitignored.**
+
+Customer ruling recorded 2026-06-03: Option S adopted. Implemented in
+`feat/activity-sidecar`.
+
+Option M is the prior state and has known long-term hygiene costs
+with no structural bound. Option C bounds file size but keeps git
+churn and the `"activity"`-has-no-integrity-guarantee trade-off alive
+indefinitely. Option S is the structurally correct fix: it eliminates
+git churn for telemetry, removes the normalizer dependency, and
+cleanly separates runtime telemetry from durable contract data. The
+migration cost is real but bounded and follows the existing pattern of
+schema version bumps (FW-ADR-0021 set the precedent for the handoff
+schema with a MINOR bump).
+
+If Option C had been chosen as an interim step pending a later Option S
+migration, a follow-up ADR would record the interim status explicitly.
+
+---
+
+## Consequences
+
+### Positive (D1, already realized)
+
+- `--verify` no longer reports spurious drift on handoff files after
+  every session. Operator trust in the manifest is restored.
+- Durable contract fields (`allowed_paths`, `acceptance_criteria`,
+  `verification`, `status`, `mode`, `hard_rule_traces`) remain under
+  integrity coverage. The bounded-Codex gate (FW-ADR-0021) retains
+  its tamper-evidence foundation.
+- The normalizer is fail-closed: a missing `python3` produces an error
+  rather than a silently wrong hash.
+- The symmetric write/verify design means no manifest entry can be
+  written with one hash function and verified with another.
+
+### Negative / trade-offs accepted
+
+- **`"activity"` has no integrity guarantee (D1, accepted).** Named and
+  bounded above. Acceptable because `"activity"` is not on any trust
+  or authorization path. Must be re-evaluated if that changes.
+- **The normalizer is a new failure mode in the manifest write/verify
+  path (D1).** If the inline Python in `manifest_file_sha_normalized`
+  has a bug, it affects all handoff file hashes symmetrically (write
+  and verify agree on a wrong hash). Mitigation: the normalizer is
+  small (~5 lines of Python), its behavior is unit-testable, and the
+  fail-closed guard prevents a silent wrong answer.
+- **D2 Option S requires schema migration.** Any downstream project or
+  tool that reads `handoff["activity"]` must be updated. The migration
+  strips `"activity"` from existing handoff files; this is a one-way
+  data transformation for the JSON file (the data migrates to the
+  sidecar, not discarded).
+
+### Follow-up work
+
+- Remove or no-op the handoff-file branch of `manifest_file_sha_normalized`
+  in a follow-up PR once the sidecar migration is confirmed stable in
+  downstream projects. The normalizer is still correct to leave in place
+  during the transition; removing it is a cleanup, not a correctness fix.
+- Any downstream project that reads `handoff["activity"]` directly must
+  be updated to read the sidecar `*.activity.jsonl` instead.
+
+---
+
+## Verification
+
+- **D1 success signal (already verified in PR #304):** `upgrade.sh
+  --verify` exits 0 on a project where `handoff-record-activity.py`
+  has appended entries since the last manifest write. The manifest
+  hash for the handoff file matches the post-strip SHA regardless of
+  how many `"activity"` entries are present. `manifest_file_sha_normalized`
+  returns an error (non-zero exit) when `python3` is absent.
+- **D1 failure signal:** `--verify` reports drift on a handoff file
+  whose only change since manifest-write is new `"activity"` entries
+  (indicates the normalizer is not being applied symmetrically); or
+  `--verify` exits 0 on a handoff file whose durable contract fields
+  were modified without a manifest regeneration (indicates the
+  normalizer is stripping too much).
+- **D2 success signal:** `git log --stat` on a multi-session branch
+  shows no modifications to `docs/handoffs/*.json` attributable to
+  telemetry; sidecar files exist locally but do not appear in `git
+  status` (gitignored); existing handoff consumers continue to read
+  durable contract fields correctly.
+- **D2 failure signal:** git history grows at the same rate as before
+  the remediation; or a consumer of `"activity"` breaks silently
+  after the sidecar migration without producing an error.
+- **Review cadence:** Re-examine at the next MINOR release that touches
+  `handoff-record-activity.py`, `schemas/handoff.schema.json`, or
+  `manifest_file_sha_normalized`. Supersede or close if the normalizer
+  is removed and all known consumers have migrated to sidecars.
+
+---
+
+## Links
+
+- Issue #276 (root cause: activity growth breaks `--verify`)
+- PR #304 (D1 fix: `manifest_file_sha_normalized`)
+- FW-ADR-0002 (`docs/adr/fw-adr-0002-upgrade-content-verification.md`) —
+  the manifest model this ADR amends; security threat-model scoping
+  (supply-chain not in scope)
+- FW-ADR-0014 (`docs/adr/fw-adr-0014-preservation-vs-manifest.md`) —
+  preservation vs manifest semantics; `manifest_file_sha_normalized`
+  is called from the same `manifest_write` / `manifest_verify` paths
+  this ADR's D1 fix touches
+- FW-ADR-0021 (`docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md`) —
+  bounded-Codex gate that depends on durable handoff contract fields
+  being tamper-evident
+- `scripts/lib/manifest.sh` — `manifest_file_sha_normalized` (D1
+  implementation), `manifest_write`, `manifest_verify`
+- `scripts/hooks/handoff-record-activity.py` — the hook whose writes
+  trigger the growth problem; modified in D2 implementation
+- `schemas/handoff.schema.json` — the `"activity"` field definition;
+  deprecated/removed by D2 schema change
+- `docs/handoffs/fw-012-v1-1-handoff-contracts.json` — example of an
+  existing handoff file; `"activity"` entries migrated to sidecar by
+  D2 migration
+- `CUSTOMER_NOTES.md` (2026-06-02) — `security-engineer` sign-off on
+  #276; two carry-forward items (neither blocks D1)

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,36 @@
+# docs/handoffs/
+
+Durable handoff contracts for bounded specialist sessions. One JSON file
+per task (`<task_id>.json`), shaped per `schemas/handoff.schema.json` and
+the contract spec in `docs/v1.1-handoff-contracts.md`.
+
+## File types in this directory
+
+| Pattern | Tracked | Purpose |
+|---|---|---|
+| `<task_id>.json` | Yes (git-tracked) | Durable contract — `status`, `mode`, `allowed_paths`, `hard_rule_traces`, `acceptance_criteria`, `verification`. Static after creation. |
+| `<task_id>.activity.jsonl` | No (gitignored) | Runtime telemetry — one JSON object per line, appended by `handoff-record-activity.py` on every PreToolUse/PostToolUse boundary. Ephemeral to the local session. |
+
+## Separation of concerns
+
+The JSON contract file is static after the handoff is created. It holds the
+durable fields that the gate hooks, `upgrade.sh --verify`, and the bounded-
+Codex authorization path all depend on. Do not append telemetry to it.
+
+The `*.activity.jsonl` sidecar holds runtime telemetry for the same task. It
+is gitignored and local-only — it does not appear in `git status`, is not
+covered by `TEMPLATE_MANIFEST.lock`, and is not replicated to other machines.
+It exists for local debugging and observability only. If you need to share
+session telemetry, export the sidecar separately; do not commit it.
+
+This split was introduced by FW-ADR-0023 (D2 Option S: activity sidecar).
+Prior to that release, the `"activity"` array lived inside the handoff JSON
+and was excluded from manifest hashing via `manifest_file_sha_normalized`
+in `scripts/lib/manifest.sh`.
+
+## Active handoff pointer
+
+`.devteam/active-handoff.json` (project root, if present) names the
+`task_id` of the currently active handoff. Hooks read this pointer to
+locate the relevant `docs/handoffs/<task_id>.json` without scanning the
+directory.

--- a/docs/handoffs/fw-012-v1-1-handoff-contracts.json
+++ b/docs/handoffs/fw-012-v1-1-handoff-contracts.json
@@ -9,7 +9,9 @@
     "gate_mode": "warn"
   },
   "owner_role": "software-engineer",
-  "review_roles": ["code-reviewer"],
+  "review_roles": [
+    "code-reviewer"
+  ],
   "security_roles": [],
   "objective": "Implement v1.1 handoff contract infrastructure: schema, validator, hook libraries, durable handoff examples, and active-handoff pointer wiring for the sw-dev-team-template framework.",
   "allowed_paths": [
@@ -29,7 +31,9 @@
   ],
   "framework_scope": "framework-maintenance",
   "requires": {
-    "tests": ["tests/hooks/test-handoff-contracts.sh"],
+    "tests": [
+      "tests/hooks/test-handoff-contracts.sh"
+    ],
     "review": true,
     "security_review": false,
     "human_approval": false
@@ -64,13 +68,14 @@
       "source": "CLAUDE.md ## Hard rules"
     }
   ],
-  "activity": [],
   "verification": {
     "tests": [
       {
         "gate_type": "test",
         "required": true,
-        "accepted_evidence_refs": ["tests/hooks/test-handoff-contracts.sh"],
+        "accepted_evidence_refs": [
+          "tests/hooks/test-handoff-contracts.sh"
+        ],
         "name": "tests/hooks/test-handoff-contracts.sh",
         "actor_role": "qa-engineer",
         "result": "passed",

--- a/migrations/v1.2.0.sh
+++ b/migrations/v1.2.0.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# migrations/v1.2.0.sh — handoff activity-array sidecar migration
+#   (fw-adr-0023 D2 Option S, schema v1.1.0)
+#
+# Walks every docs/handoffs/*.json file in the project:
+#   1. If the file carries a non-empty top-level "activity" array, exports
+#      the entries to a sidecar docs/handoffs/<task_id>.activity.jsonl
+#      (one JSON object per line), then removes the "activity" key from
+#      the JSON file. Data moves; nothing is discarded.
+#   2. If the file carries an empty "activity" array (or no "activity"
+#      key at all), the "activity" key is removed (or left absent) and
+#      the sidecar is not created.
+#
+# The migration is idempotent: re-running it on an already-migrated file
+# (no "activity" key) is a no-op.
+#
+# Requires python3 (already required by the hook layer).
+#
+# Env vars from scripts/upgrade.sh:
+#   PROJECT_ROOT   — absolute path to the downstream project root
+#   OLD_VERSION    — version the project is coming from
+#   NEW_VERSION    — version the project is going to
+#   TARGET_VERSION — this migration's attached version (v1.2.0)
+#   WORKDIR_NEW    — clone of upstream at NEW_VERSION
+#   WORKDIR_OLD    — clone of upstream at OLD_VERSION (optional)
+
+set -euo pipefail
+
+: "${PROJECT_ROOT:?PROJECT_ROOT is required}"
+
+HANDOFFS_DIR="$PROJECT_ROOT/docs/handoffs"
+
+if [[ ! -d "$HANDOFFS_DIR" ]]; then
+  echo "  v1.2.0 activity-sidecar migration: docs/handoffs/ not found — skipping"
+  exit 0
+fi
+
+migrated=0
+skipped=0
+already_done=0
+
+while IFS= read -r -d '' json_file; do
+  rc=0
+  python3 - "$json_file" <<'PYEOF' || rc=$?
+import json, os, sys
+from pathlib import Path
+
+json_file = Path(sys.argv[1])
+
+with json_file.open(encoding="utf-8") as f:
+    doc = json.load(f)
+
+if "activity" not in doc:
+    # Already migrated or never had the key.
+    print(f"  skip (no activity key): {json_file.name}", flush=True)
+    sys.exit(2)
+
+activity = doc.pop("activity")
+
+# Export non-empty arrays to sidecar.
+task_id = doc.get("task_id") or json_file.stem
+sidecar = json_file.parent / f"{task_id}.activity.jsonl"
+
+if isinstance(activity, list) and activity:
+    with sidecar.open("a", encoding="utf-8") as sf:
+        for entry in activity:
+            sf.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    print(f"  migrated {len(activity)} entries -> {sidecar.name}", flush=True)
+    sys.exit(0)
+else:
+    print(f"  removed empty activity array: {json_file.name}", flush=True)
+    sys.exit(3)
+
+PYEOF
+  # rc=0: entries exported to sidecar; rc=3: empty array stripped; rc=2: already done.
+  # Write the stripped JSON back for rc=0 or rc=3 (activity key present and removed).
+  if [[ $rc -eq 0 || $rc -eq 3 ]]; then
+    rc2=0
+    python3 - "$json_file" <<'PYEOF' || rc2=$?
+import json, os, sys
+from pathlib import Path
+
+json_file = Path(sys.argv[1])
+with json_file.open(encoding="utf-8") as f:
+    doc = json.load(f)
+doc.pop("activity", None)
+
+tmp = json_file.with_suffix(".json.migration-tmp")
+with tmp.open("w", encoding="utf-8") as f:
+    json.dump(doc, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+os.replace(tmp, json_file)
+PYEOF
+    if [[ $rc2 -ne 0 ]]; then
+      echo "  ERROR: failed to write stripped JSON for $json_file" >&2
+      exit 1
+    fi
+    if [[ $rc -eq 0 ]]; then
+      migrated=$((migrated + 1))
+    else
+      skipped=$((skipped + 1))
+    fi
+  else
+    already_done=$((already_done + 1))
+  fi
+done < <(find "$HANDOFFS_DIR" -maxdepth 1 -name '*.json' -not -name '*.migration-tmp' -print0 | sort -z)
+
+echo "  v1.2.0 activity-sidecar migration: migrated=$migrated empty-stripped=$skipped already-done=$already_done"

--- a/schemas/handoff.schema.json
+++ b/schemas/handoff.schema.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "x-schema-version": "1.1.0",
+  "x-schema-changelog": "1.1.0 (fw-adr-0023 D2 Option S): removed 'activity' from required[]; property retained as optional/deprecated for backward-compat with handoff files written before the sidecar migration. Runtime telemetry now written to docs/handoffs/<task_id>.activity.jsonl.",
   "type": "object",
   "required": [
     "schema",
@@ -17,7 +19,6 @@
     "requires",
     "acceptance_criteria",
     "hard_rule_traces",
-    "activity",
     "verification",
     "completion"
   ],
@@ -237,7 +238,11 @@
       "items": {"$ref": "#/$defs/external_tool_activity_ref"},
       "description": "Optional INPUT-ONLY list of external-tool activity references (llmdc, Speckit). These are informational inputs to canonical-role work; they are structurally separate from verification.* and completion.evidence and cannot satisfy any evidence gate."
     },
-    "activity": {"type": "array"},
+    "activity": {
+      "type": "array",
+      "deprecated": true,
+      "description": "DEPRECATED (fw-adr-0023 D2 Option S, schema v1.1.0). Runtime telemetry moved to docs/handoffs/<task_id>.activity.jsonl sidecar. This property is retained as optional for backward-compatibility with handoff files written before the migration. New handoff files should omit it."
+    },
     "verification": {
       "type": "object",
       "required": ["tests", "reviews", "security", "human_approval"],

--- a/scripts/hooks/handoff-record-activity.py
+++ b/scripts/hooks/handoff-record-activity.py
@@ -7,45 +7,44 @@ Design notes
 ------------
 **What it does**
     Reads a hook event from stdin (PostToolUse shape or any hook envelope)
-    and appends one evidence entry to the active handoff's
-    ``verification.tests`` list so the TaskCompleted gate can treat the
-    observed activity as ACCEPTED (hook-captured, not worker self-attestation).
+    and appends one evidence entry to the per-task activity sidecar
+    ``docs/handoffs/<task_id>.activity.jsonl`` (one JSON object per line,
+    append-only). The sidecar is gitignored so it never mutates the durable
+    handoff JSON file (fw-adr-0023 D2 Option S).
 
 **Where evidence is written**
-    Directly into the durable handoff file that the active-handoff pointer
-    resolves to (same file ``load_active_handoff`` reads).  The write is
-    *atomic*: the updated JSON is written to a sibling ``.tmp`` file first,
-    then renamed over the original.  This prevents corruption if the process
-    is interrupted between write and close, and preserves schema validity
-    because we (a) append only, never delete or mutate existing fields, and
-    (b) build the new evidence entry to match ``$defs/evidence_gate`` in
-    handoff.schema.json.
+    ``docs/handoffs/<task_id>.activity.jsonl`` — a newline-delimited JSON
+    log that lives beside the durable handoff JSON but is never committed.
+    Derivation of ``<task_id>``: read from the active-handoff pointer, or
+    fall back to extracting it from the resolved handoff file.
 
-    We do NOT write to a separate activity-log file because the gate helpers
-    (``lib/handoff.py``) read ``verification.tests`` (and the other sub-lists)
-    directly; a separate log would require gate changes.  The atomic-append
-    approach keeps the single source of truth.
+    The durable handoff JSON is **never mutated** by this hook. Handoff
+    JSON files are now fully static after creation; ``TEMPLATE_MANIFEST.lock``
+    can hash them raw without a normalizer (fw-adr-0023 §"Follow-up work").
 
-**Schema safety**
-    The appended entry has:
+**Entry shape**
+    Each JSONL line is a JSON object with:
       - ``evidence_kind`` = ``"accepted"``  (not ``"worker_report"``)
       - ``source``        = hook event name (e.g. ``"PostToolUse"``)
       - ``name``          = tool/command summary derived from the event
       - ``result``        = ``"passed"``
       - ``actor_role``    = ``"hook"``  (distinguishes from any human role)
-    All fields are present in ``$defs/evidence_gate``; none are required by
-    the schema so omitting extras is also valid.
+      - ``timestamp``     = ISO 8601 UTC
+    Matches the ``$defs/evidence_gate`` shape in handoff.schema.json.
 
 **Gate mode**
     Mirrors the other hooks: inactive (exit 0 silently) unless
     ``SWDT_HANDOFF_GATES`` is ``"warn"`` or ``"enforce"``.
     On load failure: warn-mode is non-blocking (logs to stderr, exits 0);
-    enforce-mode also exits 0 (recording activity should not block a tool
-    call — only the completion gate blocks).
+    enforce-mode also exits 0 (recording activity must not block a tool call).
 
 **Output**
     No stdout JSON is emitted (this hook does not make a permission
-    decision).  Diagnostic messages go to stderr.
+    decision). Diagnostic messages go to stderr.
+
+**Fail-safe**
+    Any write error appends to stderr and returns 0; recording activity
+    must never gate or block a tool call.
 """
 
 from __future__ import annotations
@@ -53,7 +52,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -62,7 +60,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.hooks.lib.handoff import (  # noqa: E402
-    load_active_handoff,
     resolve_gate_mode,
     _resolve_repo_relative,
 )
@@ -80,7 +77,6 @@ def _extract_tool_summary(event: dict) -> str:
     if isinstance(tool_input, dict):
         command = tool_input.get("command") or ""
         if isinstance(command, str) and command:
-            # Truncate long commands; strip newlines.
             cmd_summary = command.replace("\n", " ").strip()[:80]
             return f"{tool_name}: {cmd_summary}" if tool_name else cmd_summary
     if tool_name:
@@ -88,7 +84,7 @@ def _extract_tool_summary(event: dict) -> str:
     return event.get("hook_event_name") or "unknown"
 
 
-def _build_evidence_entry(event: dict) -> dict:
+def _build_activity_entry(event: dict) -> dict:
     """Return a schema-valid evidence_gate dict for the observed tool event."""
     now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return {
@@ -101,76 +97,43 @@ def _build_evidence_entry(event: dict) -> dict:
     }
 
 
-def _resolve_handoff_path(repo_root: Path) -> Path:
-    """Return the resolved path of the durable handoff file.
+def _resolve_task_id(repo_root: Path) -> str:
+    """Return the task_id from the active-handoff pointer.
 
-    Applies the same containment guards as lib/handoff._resolve_repo_relative:
-    rejects absolute handoff_path values and requires the resolved path to be
-    contained under repo_root.  Raises ValueError on violation so the caller
-    can treat it as a non-blocking load failure.
+    Reads .devteam/active-handoff.json. Raises ValueError when the pointer
+    is absent or carries no usable task_id / handoff_path.
     """
     pointer_path = repo_root / ".devteam" / "active-handoff.json"
     with pointer_path.open(encoding="utf-8") as f:
         pointer = json.load(f)
 
-    handoff_path_str = pointer.get("handoff_path")
+    # Prefer explicit task_id.
     task_id = pointer.get("task_id")
-
-    if isinstance(handoff_path_str, str) and handoff_path_str:
-        # Delegate to the shared guard: raises ValueError if absolute or
-        # if the resolved path escapes the repo root.
-        return _resolve_repo_relative(repo_root, handoff_path_str)
-
     if isinstance(task_id, str) and task_id:
-        handoffs_dir = repo_root / "docs" / "handoffs"
-        for p in sorted(handoffs_dir.glob("*.json")):
-            try:
-                with p.open(encoding="utf-8") as f:
-                    payload = json.load(f)
-                if isinstance(payload, dict) and payload.get("task_id") == task_id:
-                    # task_id branch scans only within docs/handoffs/; verify
-                    # containment for defence-in-depth.
-                    p.relative_to(repo_root.resolve())
-                    return p
-            except (OSError, json.JSONDecodeError):
-                continue
+        return task_id
 
-    raise ValueError("Cannot resolve active handoff path from pointer")
+    # Fall back: derive from handoff_path filename (e.g. "docs/handoffs/foo.json" → "foo").
+    handoff_path_str = pointer.get("handoff_path")
+    if isinstance(handoff_path_str, str) and handoff_path_str:
+        # Containment guard — reject absolute or escaping paths.
+        resolved = _resolve_repo_relative(repo_root, handoff_path_str)
+        return resolved.stem  # filename without extension
+
+    raise ValueError("Cannot resolve task_id from active-handoff pointer")
 
 
-def _atomic_append_evidence(handoff_file: Path, entry: dict) -> None:
-    """Atomically append *entry* to handoff[verification][tests].
+def _append_to_sidecar(sidecar_path: Path, entry: dict) -> None:
+    """Append *entry* as a single JSON line to the sidecar JSONL file.
 
-    Write order: load → mutate → write to .tmp → rename over original.
-    The rename is atomic on POSIX (same filesystem).  The handoff is
-    re-validated by load_active_handoff before we modify it, so the
-    pre-mutation state is already known-valid; we only append a
-    schema-valid evidence entry, keeping the document valid.
+    Opens in append mode so concurrent writes are atomic at the OS level
+    (on POSIX, O_APPEND writes are atomic up to PIPE_BUF; for our small
+    JSON objects this is sufficient). No locking required: this is a
+    single-process hook.
     """
-    with handoff_file.open(encoding="utf-8") as f:
-        handoff = json.load(f)
-
-    tests_list = handoff.get("verification", {}).get("tests")
-    if not isinstance(tests_list, list):
-        raise ValueError("handoff.verification.tests is not a list; cannot append")
-
-    tests_list.append(entry)
-
-    tmp_fd, tmp_path = tempfile.mkstemp(
-        dir=handoff_file.parent,
-        prefix=".tmp-" + handoff_file.name + "-",
-    )
-    try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-            json.dump(handoff, f, indent=2)
-            f.write("\n")
-        os.replace(tmp_path, handoff_file)
-    except Exception:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(entry, ensure_ascii=False) + "\n"
+    with sidecar_path.open("a", encoding="utf-8") as f:
+        f.write(line)
 
 
 # ---------------------------------------------------------------------------
@@ -192,19 +155,25 @@ def main() -> int:
     repo_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
 
     try:
-        handoff = load_active_handoff(repo_root)
+        task_id = _resolve_task_id(repo_root)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
-        # Non-blocking in both modes: recording activity should not gate a tool.
-        print(f"handoff-record-activity: warn: cannot load active handoff: {exc}", file=sys.stderr)
+        # Non-blocking: recording activity must not gate a tool call.
+        print(
+            f"handoff-record-activity: warn: cannot resolve task_id: {exc}",
+            file=sys.stderr,
+        )
         return 0
 
-    entry = _build_evidence_entry(event)
+    entry = _build_activity_entry(event)
+    sidecar_path = repo_root / "docs" / "handoffs" / f"{task_id}.activity.jsonl"
 
     try:
-        handoff_file = _resolve_handoff_path(repo_root)
-        _atomic_append_evidence(handoff_file, entry)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        print(f"handoff-record-activity: warn: cannot record activity evidence: {exc}", file=sys.stderr)
+        _append_to_sidecar(sidecar_path, entry)
+    except OSError as exc:
+        print(
+            f"handoff-record-activity: warn: cannot write sidecar {sidecar_path}: {exc}",
+            file=sys.stderr,
+        )
         return 0
 
     return 0

--- a/scripts/lib/manifest.sh
+++ b/scripts/lib/manifest.sh
@@ -4,19 +4,21 @@
 #
 # scripts/lib/manifest.sh — shared TEMPLATE_MANIFEST.lock helpers.
 #
-# Requires: python3 (for manifest_file_sha_normalized on handoff JSON files)
-#
 # Per FW-ADR-0002 (upgrade content verification, hash-based, manifest-
 # primary). Sourced by scripts/upgrade.sh (write at upgrade-end +
 # verify at --verify) and scripts/scaffold.sh (write at scaffold-end
 # + immediate self-verify).
 #
+# fw-adr-0023 D2 Option S (v1.2.0): handoff JSON files are now fully
+# static after creation — the activity sidecar hook writes runtime
+# telemetry to docs/handoffs/<task_id>.activity.jsonl (gitignored)
+# instead of mutating the handoff JSON. The manifest_file_sha_normalized
+# normalizer (issue #276 / PR #304) is no longer needed; all files are
+# hashed raw by manifest_file_sha. The normalizer function is removed.
+#
 # Exports:
 #   manifest_ship_files <repo>           - list shipped files, sorted
 #   manifest_file_sha   <abs-path>       - sha256 hex of one file (raw)
-#   manifest_file_sha_normalized         - sha256 hex, stripping runtime-
-#     <abs-path> <repo-rel-path>           mutable "activity" from handoff
-#                                          JSON before hashing (issue #276)
 #   manifest_write      <repo> <out>     - write manifest from repo
 #   manifest_verify     <repo> <manifest-path>
 #                                        - verify; rc 0/1/2/3
@@ -79,73 +81,6 @@ manifest_ship_files() {
 # SHA256 of a file (hex hash only, no filename).
 manifest_file_sha() {
   sha256sum "$1" | awk '{print $1}'
-}
-
-# SHA256 of a file after stripping the runtime-mutable "activity" key
-# from handoff JSON files (issue #276).
-#
-# handoff-record-activity.py appends to docs/handoffs/*.json on every
-# PreToolUse/PostToolUse boundary, making the file's content hash
-# change at runtime even though the durable contract portions
-# (status/mode/allowed_paths/hard_rule_traces/acceptance_criteria/
-# verification) are framework-managed and should remain verified.
-#
-# Files matching docs/handoffs/*.json are normalized before hashing:
-# the top-level "activity" key and its entire array value are removed
-# from the JSON, and the result is re-serialised with sorted keys so
-# the hash is stable regardless of field ordering. All other files are
-# hashed from raw bytes (identical to manifest_file_sha).
-#
-# This function is applied symmetrically in manifest_write and
-# manifest_verify so the hash in the manifest and the hash at verify
-# time are computed identically — preserving durable-contract
-# verification while ignoring runtime telemetry.
-manifest_file_sha_normalized() {
-  local path="$1"
-  local relpath="${2:-}"
-  # Normalize only docs/handoffs/*.json files.
-  if [[ "$relpath" =~ ^docs/handoffs/[^/]+\.json$ ]] \
-     || [[ -z "$relpath" && "$path" =~ /docs/handoffs/[^/]+\.json$ ]]; then
-    # Use python3 (required by the hook layer already) to strip
-    # "activity", sort keys, and emit canonical JSON.  Falls back to
-    # raw sha256sum if python3 is unavailable so the function never
-    # silently produces a wrong answer — it fails loudly instead.
-    if command -v python3 >/dev/null 2>&1; then
-      # Capture normalized JSON from python3 separately so a non-zero exit
-      # (malformed JSON, I/O error) is detected before it reaches sha256sum.
-      # Without this intermediate capture, a failing python3 still pipes an
-      # empty stream into sha256sum, which would produce the sha256 of the
-      # empty string — a silently wrong hash that could be persisted to the
-      # manifest lock.  Fail-closed: return 1 on any error.
-      local _normalized_json
-      _normalized_json="$(python3 - "$path" <<'PYEOF'
-import json, sys
-with open(sys.argv[1], encoding="utf-8") as f:
-    doc = json.load(f)
-doc.pop("activity", None)
-print(json.dumps(doc, sort_keys=True, ensure_ascii=False))
-PYEOF
-      )" || {
-        echo "ERROR: manifest_file_sha_normalized: python3 failed normalizing $path" >&2
-        return 1
-      }
-      local _hash
-      _hash="$(printf '%s\n' "$_normalized_json" | sha256sum | awk '{print $1}')"
-      # Sanity-check: a valid sha256 hex is exactly 64 lowercase hex chars.
-      # An empty or malformed hash here means sha256sum itself failed or the
-      # pipeline was silently truncated; refuse to return a bad value.
-      if [[ ! "$_hash" =~ ^[0-9a-f]{64}$ ]]; then
-        echo "ERROR: manifest_file_sha_normalized: hash validation failed for $path (got '${_hash}')" >&2
-        return 1
-      fi
-      printf '%s\n' "$_hash"
-    else
-      echo "ERROR: manifest_file_sha_normalized: python3 not found; cannot normalize $path" >&2
-      return 1
-    fi
-  else
-    sha256sum "$path" | awk '{print $1}'
-  fi
 }
 
 # Decide whether the destination release declares <path> as a fresh-write.
@@ -269,7 +204,7 @@ manifest_write() {
     while IFS= read -r f; do
       [[ -z "$f" ]] && continue
       if [[ -f "$project_repo/$f" ]]; then
-        printf '%s  %s\n' "$(manifest_file_sha_normalized "$project_repo/$f" "$f")" "$f"
+        printf '%s  %s\n' "$(manifest_file_sha "$project_repo/$f")" "$f"
       fi
     done < <(manifest_ship_files "$paths_repo" "$project_repo")
   } > "$out"
@@ -322,7 +257,7 @@ manifest_verify() {
       continue
     fi
     local actual
-    actual="$(manifest_file_sha_normalized "$repo/$path" "$path")"
+    actual="$(manifest_file_sha "$repo/$path")"
     if [[ "$actual" != "${expected[$path]}" ]]; then
       printf 'drift:    %s\n  expected %s\n  actual   %s\n' "$path" "${expected[$path]}" "$actual"
       drift=1

--- a/tests/hooks/test_handoff_record_activity.py
+++ b/tests/hooks/test_handoff_record_activity.py
@@ -3,19 +3,22 @@
 # Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
 #
 # Unit / smoke tests for scripts/hooks/handoff-record-activity.py (T019).
+# Updated for fw-adr-0023 D2 Option S (v1.2.0): hook now writes to sidecar
+# JSONL, not the durable handoff JSON.
+#
 # IEEE 1008-1987 §3.2: features under test —
 #   F1.  No-op when SWDT_HANDOFF_GATES is unset or unrecognised.
 #   F2.  No-op when stdin is not valid JSON.
 #   F3.  Warm-mode non-blocking when active handoff cannot be loaded.
-#   F4.  Evidence entry appended to verification.tests with correct fields.
-#   F5.  evidence_kind is "accepted" (hook-captured, not worker_report).
-#   F6.  Atomic write: original file is replaced, not left as .tmp.
-#   F7.  Existing verification.tests entries are preserved after append.
-#   F8.  Path containment: absolute handoff_path in pointer is rejected (S-1).
+#   F4.  Activity entry appended to sidecar JSONL with correct fields.
+#   F5.  evidence_kind is "accepted".
+#   F6.  Durable handoff JSON is NOT mutated (byte-stable after hook call).
+#   F7.  Sidecar JSONL accumulates entries across multiple calls.
+#   F8.  Path containment: absolute handoff_path in pointer is rejected (S-1);
+#        sidecar is NOT written outside the repo.
 
 from __future__ import annotations
 
-import copy
 import json
 import os
 import subprocess
@@ -67,6 +70,19 @@ def _sample_event(tool_name: str = "Bash", command: str = "pytest tests/") -> di
         "tool_name": tool_name,
         "tool_input": {"command": command},
     }
+
+
+def _sidecar_path(sandbox: Path, fixture_name: str) -> Path:
+    """Return the expected sidecar path for a fixture.
+
+    The hook derives task_id from the active-handoff pointer:
+      1. pointer["task_id"] if present
+      2. else stem of pointer["handoff_path"]
+    The sandbox's pointer only has handoff_path, so the stem of the fixture
+    filename is used — matching the hook's fallback branch.
+    """
+    stem = Path(fixture_name).stem
+    return sandbox / "docs" / "handoffs" / f"{stem}.activity.jsonl"
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +138,6 @@ def test_noop_invalid_stdin_json(tmp_path: Path) -> None:
 def test_nonblocking_no_active_handoff(tmp_path: Path) -> None:
     result = _run_hook(_sample_event(), sandbox=tmp_path, mode="warn")
     assert result.returncode == 0
-    # No stdout JSON (no permission decision emitted)
     assert result.stdout == ""
 
 
@@ -133,26 +148,27 @@ def test_nonblocking_no_active_handoff_enforce(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# F4 — evidence entry appended with correct fields
+# F4 — activity entry appended to sidecar JSONL with correct fields
 # ---------------------------------------------------------------------------
-def test_appends_evidence_entry() -> None:
+def test_appends_to_sidecar() -> None:
     sandbox = _make_sandbox("completion-evidence-satisfied.json")
     try:
         event = _sample_event(tool_name="Bash", command="pytest tests/hooks/")
         result = _run_hook(event, sandbox=sandbox, mode="warn")
         assert result.returncode == 0
 
-        handoff_path = sandbox / "docs" / "handoffs" / "completion-evidence-satisfied.json"
-        updated = json.loads(handoff_path.read_text(encoding="utf-8"))
-        tests = updated["verification"]["tests"]
+        sidecar = _sidecar_path(sandbox, "completion-evidence-satisfied.json")
+        assert sidecar.exists(), f"sidecar not created at {sidecar}"
 
-        # At least one new entry added
-        new_entries = [e for e in tests if e.get("actor_role") == "hook"]
-        assert len(new_entries) == 1, f"expected 1 hook entry, got {new_entries}"
-        entry = new_entries[0]
+        lines = sidecar.read_text(encoding="utf-8").splitlines()
+        assert len(lines) >= 1, "expected at least one JSONL line"
+
+        entry = json.loads(lines[-1])
         assert entry["result"] == "passed"
         assert entry["source"] == "PostToolUse"
         assert "Bash" in entry["name"]
+        assert entry["actor_role"] == "hook"
+        assert "timestamp" in entry
     finally:
         import shutil
         shutil.rmtree(sandbox)
@@ -167,20 +183,39 @@ def test_evidence_kind_is_accepted() -> None:
         result = _run_hook(_sample_event(), sandbox=sandbox, mode="warn")
         assert result.returncode == 0
 
-        handoff_path = sandbox / "docs" / "handoffs" / "completion-evidence-satisfied.json"
-        updated = json.loads(handoff_path.read_text(encoding="utf-8"))
-        hook_entries = [e for e in updated["verification"]["tests"] if e.get("actor_role") == "hook"]
-        assert hook_entries, "no hook entry found"
-        assert hook_entries[0]["evidence_kind"] == "accepted"
+        sidecar = _sidecar_path(sandbox, "completion-evidence-satisfied.json")
+        assert sidecar.exists()
+
+        entry = json.loads(sidecar.read_text(encoding="utf-8").splitlines()[-1])
+        assert entry["evidence_kind"] == "accepted"
     finally:
         import shutil
         shutil.rmtree(sandbox)
 
 
 # ---------------------------------------------------------------------------
-# F6 — atomic write: no .tmp file left behind
+# F6 — durable handoff JSON is NOT mutated (byte-stable)
 # ---------------------------------------------------------------------------
+def test_handoff_json_not_mutated() -> None:
+    sandbox = _make_sandbox("completion-evidence-satisfied.json")
+    try:
+        handoff_path = sandbox / "docs" / "handoffs" / "completion-evidence-satisfied.json"
+        before_bytes = handoff_path.read_bytes()
+
+        result = _run_hook(_sample_event(), sandbox=sandbox, mode="warn")
+        assert result.returncode == 0
+
+        after_bytes = handoff_path.read_bytes()
+        assert before_bytes == after_bytes, (
+            "Durable handoff JSON was mutated by the hook — fw-adr-0023 requires it to be static"
+        )
+    finally:
+        import shutil
+        shutil.rmtree(sandbox)
+
+
 def test_no_tmp_file_left_after_write() -> None:
+    """No stale .tmp files in the handoffs dir (sidecar write is direct append)."""
     sandbox = _make_sandbox("completion-evidence-satisfied.json")
     try:
         result = _run_hook(_sample_event(), sandbox=sandbox, mode="warn")
@@ -195,50 +230,44 @@ def test_no_tmp_file_left_after_write() -> None:
 
 
 # ---------------------------------------------------------------------------
-# F7 — existing tests entries are preserved after append
+# F7 — sidecar JSONL accumulates entries across multiple calls
 # ---------------------------------------------------------------------------
-def test_existing_entries_preserved() -> None:
+def test_sidecar_accumulates_entries() -> None:
     sandbox = _make_sandbox("completion-evidence-satisfied.json")
     try:
-        handoff_path = sandbox / "docs" / "handoffs" / "completion-evidence-satisfied.json"
-        before = json.loads(handoff_path.read_text(encoding="utf-8"))
-        original_tests = copy.deepcopy(before["verification"]["tests"])
-        original_count = len(original_tests)
+        for _ in range(3):
+            result = _run_hook(_sample_event(), sandbox=sandbox, mode="warn")
+            assert result.returncode == 0
 
-        result = _run_hook(_sample_event(), sandbox=sandbox, mode="warn")
-        assert result.returncode == 0
+        sidecar = _sidecar_path(sandbox, "completion-evidence-satisfied.json")
+        assert sidecar.exists()
+        lines = sidecar.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3, f"expected 3 JSONL lines, got {len(lines)}"
 
-        updated = json.loads(handoff_path.read_text(encoding="utf-8"))
-        updated_tests = updated["verification"]["tests"]
-        assert len(updated_tests) == original_count + 1
-
-        # All original entries still present (by identity comparison)
-        for orig in original_tests:
-            assert orig in updated_tests
+        # All lines must be valid JSON.
+        for line in lines:
+            entry = json.loads(line)
+            assert entry["actor_role"] == "hook"
     finally:
         import shutil
         shutil.rmtree(sandbox)
 
 
 # ---------------------------------------------------------------------------
-# F8 — path containment: absolute handoff_path is rejected (S-1)
+# F8 — path containment: absolute handoff_path in pointer is rejected (S-1)
 # ---------------------------------------------------------------------------
 
 
 def test_absolute_handoff_path_rejected_exits_zero(tmp_path: Path) -> None:
-    """S-1: pointer with an absolute handoff_path must not write outside repo and must exit 0."""
-    # Set up a real handoff file at an absolute path OUTSIDE the sandbox.
+    """S-1: pointer with an absolute handoff_path must not write outside repo."""
     outside_dir = Path(tempfile.mkdtemp())
     try:
-        # Copy a valid handoff fixture to the outside location.
         outside_handoff = outside_dir / "outside-handoff.json"
         outside_handoff.write_text(
             (FIXTURE_DIR / "completion-evidence-satisfied.json").read_text(encoding="utf-8"),
             encoding="utf-8",
         )
-        before_text = outside_handoff.read_text(encoding="utf-8")
 
-        # Wire up the sandbox with a pointer referencing the absolute outside path.
         (tmp_path / ".devteam").mkdir(exist_ok=True)
         (tmp_path / ".devteam" / "active-handoff.json").write_text(
             json.dumps({"handoff_path": str(outside_handoff)}),
@@ -247,20 +276,23 @@ def test_absolute_handoff_path_rejected_exits_zero(tmp_path: Path) -> None:
 
         result = _run_hook(_sample_event(), sandbox=tmp_path, mode="warn")
 
-        # Must not block (exit 0) — recording must never gate a tool call.
+        # Must not block (exit 0).
         assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
-        # Must not have written to the outside file.
-        assert outside_handoff.read_text(encoding="utf-8") == before_text, (
-            "absolute handoff_path was written outside the repo — containment guard failed"
-        )
+
+        # No sidecar should appear under tmp_path/docs/handoffs/.
+        sidecars = list((tmp_path / "docs").rglob("*.activity.jsonl")) if (tmp_path / "docs").exists() else []
+        assert sidecars == [], f"unexpected sidecar(s) written: {sidecars}"
+
+        # No sidecar in outside_dir either.
+        outside_sidecars = list(outside_dir.glob("*.activity.jsonl"))
+        assert outside_sidecars == [], f"sidecar written outside repo: {outside_sidecars}"
     finally:
         import shutil
         shutil.rmtree(outside_dir)
 
 
 def test_traversal_handoff_path_rejected_exits_zero(tmp_path: Path) -> None:
-    """S-1: pointer with a repo-relative but escaping handoff_path must not write outside and exits 0."""
-    # Wire sandbox with a pointer that uses ../ to escape the repo root.
+    """S-1: pointer with a repo-relative but escaping handoff_path exits 0."""
     (tmp_path / ".devteam").mkdir(exist_ok=True)
     (tmp_path / ".devteam" / "active-handoff.json").write_text(
         json.dumps({"handoff_path": "../../etc/passwd"}),
@@ -270,5 +302,4 @@ def test_traversal_handoff_path_rejected_exits_zero(tmp_path: Path) -> None:
     result = _run_hook(_sample_event(), sandbox=tmp_path, mode="warn")
 
     assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
-    # stderr should carry a diagnostic warning.
     assert result.stderr != "", "expected a stderr warning on containment violation"

--- a/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
+++ b/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
@@ -4,29 +4,31 @@
 #
 # tests/upgrade/test-manifest-handoff-activity-issue-276.sh
 #
-# Issue #276: TEMPLATE_MANIFEST.lock must not report drift when the
-# runtime-mutable "activity" array in docs/handoffs/*.json changes,
-# but MUST still detect changes to the durable contract portions
-# (status, mode, allowed_paths, hard_rule_traces, acceptance_criteria,
-# verification).
+# fw-adr-0023 D2 Option S (v1.2.0): handoff JSON files are now fully static
+# after creation. The handoff-record-activity.py hook writes runtime telemetry
+# to docs/handoffs/<task_id>.activity.jsonl (gitignored) instead of mutating
+# the handoff JSON. manifest_file_sha_normalized is removed; all files are
+# hashed raw via manifest_file_sha.
 #
-# IEEE 1008-1987 §3.2 — features under test:
-#   F1. manifest_file_sha_normalized strips "activity" before hashing.
-#   F2. A change to the "activity" array produces the same normalized
-#       hash (no drift reported by manifest_verify).
-#   F3. A change to the durable "status" field IS detected (drift
-#       reported) — the normalization does not blind the manifest to
-#       real contract changes.
-#   F4. A file outside docs/handoffs/ is hashed raw (normalization is
-#       not applied to unrelated files).
-#   F5. manifest_write records the normalized hash for handoff JSON
-#       files, so a subsequent manifest_verify passes even after the
-#       activity array has been appended to.
+# This test file is updated from its issue-#276 origin to reflect the new
+# sidecar model. The normalizer tests (F1/F2/F5 from the original) are
+# replaced with verification that:
+#
+#   NEW-F1. manifest_file_sha agrees with sha256sum raw (no normalizer path).
+#   NEW-F2. A handoff JSON file that does NOT change between write and verify
+#           produces no drift (manifest_verify rc=0).
+#   NEW-F3. A change to a durable field (status) IS detected (rc=1, drift).
+#   NEW-F4. A non-handoff file is hashed raw: two different files differ.
+#   NEW-F5. The v1.2.0 migration strips "activity" from handoff JSON files
+#           and exports entries to the sidecar JSONL.
+#
+# IEEE 1008-1987 §3.2 — features under test.
 
 set -u
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 manifest_lib="$repo_root/scripts/lib/manifest.sh"
+migration="$repo_root/migrations/v1.2.0.sh"
 # shellcheck source=scripts/lib/manifest.sh
 source "$manifest_lib"
 
@@ -50,7 +52,6 @@ check() {
 }
 
 check_output() {
-  # check_output <label> <expected-pattern> <cmd...>
   local label="$1"; shift
   local pattern="$1"; shift
   local out
@@ -65,23 +66,8 @@ check_output() {
   fi
 }
 
-check_not_output() {
-  local label="$1"; shift
-  local pattern="$1"; shift
-  local out
-  out=$("$@" 2>&1) || true
-  if ! echo "$out" | grep -qF "$pattern"; then
-    echo "  PASS: $label"
-    pass=$((pass + 1))
-  else
-    echo "  FAIL: $label (unwanted pattern='$pattern' found in output)" >&2
-    echo "        output was: $out" >&2
-    fail=$((fail + 1))
-  fi
-}
-
 # ---------------------------------------------------------------------------
-# Fixture: a minimal handoff JSON with an empty activity array.
+# Fixture: a minimal handoff JSON WITHOUT an activity key (post-migration).
 # ---------------------------------------------------------------------------
 HANDOFF_RELPATH="docs/handoffs/test-276-handoff.json"
 mkdir -p "$tmp/docs/handoffs"
@@ -91,7 +77,6 @@ cat > "$tmp/$HANDOFF_RELPATH" << 'EOF'
   "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
   "task_id": "test-276",
   "status": "active",
-  "activity": [],
   "verification": {
     "tests": []
   }
@@ -99,59 +84,27 @@ cat > "$tmp/$HANDOFF_RELPATH" << 'EOF'
 EOF
 
 # ---------------------------------------------------------------------------
-# F1. manifest_file_sha_normalized strips "activity" before hashing.
-#     Verify that two files differing only in "activity" produce the same hash.
+# NEW-F1. manifest_file_sha produces the same result as sha256sum raw.
 # ---------------------------------------------------------------------------
-echo "-- F1: normalized hash ignores activity array --"
+echo "-- NEW-F1: manifest_file_sha matches raw sha256sum --"
 
-cat > "$tmp/handoff-with-activity.json" << 'EOF'
-{
-  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
-  "task_id": "test-276",
-  "status": "active",
-  "activity": [{"name": "Bash: ls", "result": "passed", "actor_role": "hook"}],
-  "verification": {
-    "tests": []
-  }
-}
-EOF
+sha_lib=$(manifest_file_sha "$tmp/$HANDOFF_RELPATH")
+sha_raw=$(sha256sum "$tmp/$HANDOFF_RELPATH" | awk '{print $1}')
 
-cat > "$tmp/handoff-no-activity.json" << 'EOF'
-{
-  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
-  "task_id": "test-276",
-  "status": "active",
-  "activity": [],
-  "verification": {
-    "tests": []
-  }
-}
-EOF
-
-sha_with=$(manifest_file_sha_normalized "$tmp/handoff-with-activity.json" "docs/handoffs/handoff-with-activity.json")
-sha_without=$(manifest_file_sha_normalized "$tmp/handoff-no-activity.json" "docs/handoffs/handoff-no-activity.json")
-
-if [[ "$sha_with" == "$sha_without" && -n "$sha_with" ]]; then
-  echo "  PASS: F1 — activity-differing files produce same normalized hash"
+if [[ "$sha_lib" == "$sha_raw" && -n "$sha_lib" ]]; then
+  echo "  PASS: NEW-F1 — manifest_file_sha matches sha256sum raw"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F1 — expected same hash, got '$sha_with' vs '$sha_without'" >&2
+  echo "  FAIL: NEW-F1 — lib='$sha_lib' raw='$sha_raw'" >&2
   fail=$((fail + 1))
 fi
 
 # ---------------------------------------------------------------------------
-# F2. After appending to activity, manifest_verify does NOT report drift.
-#     Simulate: write manifest from baseline (empty activity), then append
-#     to activity, then verify.
+# NEW-F2. A handoff JSON file that does NOT change produces no drift.
+# Write manifest from baseline; verify — must be clean.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- F2: manifest_verify clean after activity append --"
-
-# Build a minimal fake upstream git repo (manifest_write requires one for
-# manifest_ship_files, but we bypass ship_files and write the manifest
-# directly using the normalized hash instead).
-# We write the manifest by hand using manifest_file_sha_normalized so the
-# test does not require a full upstream clone.
+echo "-- NEW-F2: static handoff file produces no drift --"
 
 manifest_path="$tmp/TEMPLATE_MANIFEST.lock"
 {
@@ -159,161 +112,166 @@ manifest_path="$tmp/TEMPLATE_MANIFEST.lock"
   echo "# Generated by test-manifest-handoff-activity-issue-276.sh"
   echo "# Format: <sha256>  <project-relative path>"
   echo "#"
-  printf '%s  %s\n' \
-    "$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")" \
-    "$HANDOFF_RELPATH"
+  printf '%s  %s\n' "$(manifest_file_sha "$tmp/$HANDOFF_RELPATH")" "$HANDOFF_RELPATH"
 } > "$manifest_path"
 
-# Now simulate the hook appending an activity entry (in-place JSON edit).
-python3 - "$tmp/$HANDOFF_RELPATH" << 'PYEOF'
-import json, sys
-with open(sys.argv[1], encoding="utf-8") as f:
-    doc = json.load(f)
-doc.setdefault("activity", []).append({
-    "name": "Bash: git status",
-    "result": "passed",
-    "actor_role": "hook",
-    "timestamp": "2026-06-02T15:00:00Z"
-})
-with open(sys.argv[1], "w", encoding="utf-8") as f:
-    json.dump(doc, f, indent=2)
-    f.write("\n")
-PYEOF
-
-# manifest_verify should return 0 (no drift) even though the file changed.
 verify_output=$(manifest_verify "$tmp" "$manifest_path" 2>&1)
 verify_rc=$?
 
 if [[ $verify_rc -eq 0 ]]; then
-  echo "  PASS: F2 — manifest_verify rc=0 after activity append (no drift)"
+  echo "  PASS: NEW-F2 — manifest_verify rc=0 (no drift on static file)"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F2 — manifest_verify rc=$verify_rc after activity append" >&2
+  echo "  FAIL: NEW-F2 — manifest_verify rc=$verify_rc" >&2
   echo "        output: $verify_output" >&2
   fail=$((fail + 1))
 fi
 
 if echo "$verify_output" | grep -qiF "drift"; then
-  echo "  FAIL: F2 — 'drift' appeared in verify output after activity-only change" >&2
+  echo "  FAIL: NEW-F2 — 'drift' appeared in verify output unexpectedly" >&2
   fail=$((fail + 1))
 else
-  echo "  PASS: F2 — 'drift' absent from verify output (activity correctly ignored)"
+  echo "  PASS: NEW-F2 — 'drift' absent from verify output"
   pass=$((pass + 1))
 fi
 
 # ---------------------------------------------------------------------------
-# F3. A change to the durable "status" field IS detected.
+# NEW-F3. A change to the durable "status" field IS detected.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- F3: manifest_verify detects durable contract change (status field) --"
+echo "-- NEW-F3: durable contract change (status field) detected --"
 
-# Write a fresh manifest from the current state (with activity appended).
+# Write manifest from current state.
 {
   echo "# TEMPLATE_MANIFEST.lock — per FW-ADR-0002"
-  echo "# Generated by test-manifest-handoff-activity-issue-276.sh"
   echo "# Format: <sha256>  <project-relative path>"
-  echo "#"
-  printf '%s  %s\n' \
-    "$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")" \
-    "$HANDOFF_RELPATH"
+  printf '%s  %s\n' "$(manifest_file_sha "$tmp/$HANDOFF_RELPATH")" "$HANDOFF_RELPATH"
 } > "$manifest_path"
 
-# Now mutate the durable "status" field (not activity).
+# Mutate the durable "status" field.
 python3 - "$tmp/$HANDOFF_RELPATH" << 'PYEOF'
 import json, sys
-with open(sys.argv[1], encoding="utf-8") as f:
-    doc = json.load(f)
-doc["status"] = "completed"  # durable contract change
-with open(sys.argv[1], "w", encoding="utf-8") as f:
-    json.dump(doc, f, indent=2)
-    f.write("\n")
+from pathlib import Path
+p = Path(sys.argv[1])
+doc = json.loads(p.read_text(encoding="utf-8"))
+doc["status"] = "completed"
+p.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
 PYEOF
 
 verify_output_durable=$(manifest_verify "$tmp" "$manifest_path" 2>&1)
 verify_rc_durable=$?
 
 if [[ $verify_rc_durable -ne 0 ]]; then
-  echo "  PASS: F3 — manifest_verify rc=$verify_rc_durable (drift detected for status change)"
+  echo "  PASS: NEW-F3 — manifest_verify rc=$verify_rc_durable (drift detected)"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F3 — manifest_verify rc=0 but expected drift for status field change" >&2
+  echo "  FAIL: NEW-F3 — manifest_verify rc=0 but status was mutated" >&2
   echo "        output: $verify_output_durable" >&2
   fail=$((fail + 1))
 fi
 
 if echo "$verify_output_durable" | grep -qiF "drift"; then
-  echo "  PASS: F3 — 'drift' reported for durable contract change"
+  echo "  PASS: NEW-F3 — 'drift' reported for durable contract change"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F3 — 'drift' not reported; durable change was silently missed" >&2
+  echo "  FAIL: NEW-F3 — 'drift' not reported; durable change was silently missed" >&2
   fail=$((fail + 1))
 fi
 
 # ---------------------------------------------------------------------------
-# F4. A non-handoff file is hashed raw (normalization not applied).
-#     Two files with different content must produce different normalized hashes.
+# NEW-F4. Two files with different content produce different raw hashes.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- F4: non-handoff file hashed raw (normalization not applied) --"
+echo "-- NEW-F4: different files produce different hashes --"
 
-cat > "$tmp/not-a-handoff.md" << 'EOF'
-# Some markdown file
+cat > "$tmp/file-a.md" << 'EOF'
 content A
 EOF
-cat > "$tmp/not-a-handoff-changed.md" << 'EOF'
-# Some markdown file
+cat > "$tmp/file-b.md" << 'EOF'
 content B
 EOF
 
-sha_md_a=$(manifest_file_sha_normalized "$tmp/not-a-handoff.md" "docs/not-a-handoff.md")
-sha_md_b=$(manifest_file_sha_normalized "$tmp/not-a-handoff-changed.md" "docs/not-a-handoff-changed.md")
-sha_raw_a=$(manifest_file_sha "$tmp/not-a-handoff.md")
+sha_a=$(manifest_file_sha "$tmp/file-a.md")
+sha_b=$(manifest_file_sha "$tmp/file-b.md")
 
-if [[ "$sha_md_a" == "$sha_raw_a" ]]; then
-  echo "  PASS: F4 — non-handoff file: normalized hash == raw hash"
+if [[ "$sha_a" != "$sha_b" && -n "$sha_a" && -n "$sha_b" ]]; then
+  echo "  PASS: NEW-F4 — different files produce different hashes"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F4 — non-handoff file: normalized hash '$sha_md_a' != raw '$sha_raw_a'" >&2
-  fail=$((fail + 1))
-fi
-
-if [[ "$sha_md_a" != "$sha_md_b" ]]; then
-  echo "  PASS: F4 — non-handoff files with different content produce different hashes"
-  pass=$((pass + 1))
-else
-  echo "  FAIL: F4 — non-handoff files with different content produced same hash" >&2
+  echo "  FAIL: NEW-F4 — expected different hashes, got same: '$sha_a'" >&2
   fail=$((fail + 1))
 fi
 
 # ---------------------------------------------------------------------------
-# F5. manifest_file_sha_normalized is applied for handoff files even when
-#     the relpath argument is detected from the absolute path (fallback).
-#     Ensures the regex matches when relpath is omitted.
+# NEW-F5. Migration v1.2.0 strips "activity" from handoff JSON and exports
+#         non-empty entries to the sidecar JSONL.
 # ---------------------------------------------------------------------------
 echo ""
-echo "-- F5: normalized hash via absolute-path detection (no relpath arg) --"
+echo "-- NEW-F5: migration strips activity, exports to sidecar --"
 
-# Reset handoff to baseline (empty activity).
-cat > "$tmp/$HANDOFF_RELPATH" << 'EOF'
+MIGTEST_RELPATH="docs/handoffs/test-mig-handoff.json"
+mkdir -p "$tmp/docs/handoffs"
+
+cat > "$tmp/$MIGTEST_RELPATH" << 'EOF'
 {
-  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
-  "task_id": "test-276",
+  "task_id": "test-mig",
   "status": "active",
-  "activity": [],
-  "verification": {
-    "tests": []
-  }
+  "activity": [
+    {"name": "Bash: ls", "result": "passed", "actor_role": "hook", "timestamp": "2026-06-03T00:00:00Z"}
+  ],
+  "verification": {"tests": []}
 }
 EOF
 
-sha_empty_activity_relpath=$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH" "$HANDOFF_RELPATH")
-sha_empty_activity_abspath=$(manifest_file_sha_normalized "$tmp/$HANDOFF_RELPATH")
+PROJECT_ROOT="$tmp" bash "$migration" >/dev/null
 
-if [[ "$sha_empty_activity_relpath" == "$sha_empty_activity_abspath" && -n "$sha_empty_activity_relpath" ]]; then
-  echo "  PASS: F5 — relpath and absolute-path detection agree on normalized hash"
+# activity key must be gone.
+has_activity=$(python3 -c "
+import json, sys
+doc = json.load(open(sys.argv[1]))
+print('yes' if 'activity' in doc else 'no')
+" "$tmp/$MIGTEST_RELPATH")
+
+if [[ "$has_activity" == "no" ]]; then
+  echo "  PASS: NEW-F5 — activity key removed from handoff JSON"
   pass=$((pass + 1))
 else
-  echo "  FAIL: F5 — hash mismatch: relpath='$sha_empty_activity_relpath' abs='$sha_empty_activity_abspath'" >&2
+  echo "  FAIL: NEW-F5 — activity key still present after migration" >&2
+  fail=$((fail + 1))
+fi
+
+# Sidecar must exist with 1 JSONL line.
+sidecar="$tmp/docs/handoffs/test-mig.activity.jsonl"
+if [[ -f "$sidecar" ]]; then
+  line_count=$(wc -l < "$sidecar")
+  if [[ "$line_count" -eq 1 ]]; then
+    echo "  PASS: NEW-F5 — sidecar has 1 entry"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: NEW-F5 — sidecar has $line_count lines (expected 1)" >&2
+    fail=$((fail + 1))
+  fi
+  # Entry must be valid JSON.
+  if python3 -c "import json; json.loads(open('$sidecar').readline())" 2>/dev/null; then
+    echo "  PASS: NEW-F5 — sidecar entry is valid JSON"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: NEW-F5 — sidecar entry is not valid JSON" >&2
+    fail=$((fail + 1))
+  fi
+else
+  echo "  FAIL: NEW-F5 — sidecar file not created" >&2
+  fail=$((fail + 1))
+fi
+
+# Idempotent re-run: second run should be a no-op (no sidecar duplication).
+PROJECT_ROOT="$tmp" bash "$migration" >/dev/null
+line_count_after=$(wc -l < "$sidecar")
+if [[ "$line_count_after" -eq 1 ]]; then
+  echo "  PASS: NEW-F5 — migration is idempotent (sidecar not doubled)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F5 — sidecar grew on second run ($line_count_after lines)" >&2
   fail=$((fail + 1))
 fi
 


### PR DESCRIPTION
Implements **fw-adr-0023 Decision 2, Option S** (sidecar) — Accepted customer ruling 2026-06-03. Moves runtime telemetry out of the git-tracked handoff JSON so handoff files are static durable contracts again. (D1, the `--verify` hash-exclusion hotfix, shipped earlier in #304/#276 — now closed.)

## What landed
- **`scripts/hooks/handoff-record-activity.py`** — appends activity to a gitignored `docs/handoffs/<task_id>.activity.jsonl` (append-only JSONL) instead of mutating the handoff JSON. Handoff JSON is now byte-stable after creation. Fail-safe (a sidecar write error never crashes the hook); path-contained task_id resolution.
- **`schemas/handoff.schema.json`** — `activity` dropped from `required[]` (property kept `deprecated: true` for back-compat); `x-schema-version` MINOR bump.
- **`scripts/lib/manifest.sh`** — removed the `manifest_file_sha_normalized` activity-stripping normalizer; handoff JSONs are now hashed raw, symmetrically in `manifest_write`/`manifest_verify` (no more spurious `--verify` drift, no python3 dependency).
- **`migrations/v1.2.0.sh`** — one-way, idempotent, data-preserving: exports any accumulated `activity` to the sidecar before stripping the key. Applied to the existing `fw-012-…json` handoff file (now static).
- **`.gitignore`** — `docs/handoffs/*.activity.jsonl`.
- **ADR migrated** into the scaffold's `docs/adr/` (rationale travels with the code, per the ADR's own placement note); upgrade + `docs/handoffs/README.md` notes added.

## Verification
- `test_handoff_record_activity.py` 12/12 · `test-manifest-handoff-activity-issue-276.sh` 10/10 · full handoff suite 82/82 · **smoke-test 176/0** · lint-routing 0/0
- code-reviewer: **APPROVED** after one fix (stale "normalizer retained" note corrected)

## Notes
- Schema keeps `activity` as `deprecated` (per ADR "remove OR deprecate") so handoff files mid-transition stay valid. No live code reads `handoff["activity"]` (consumer scan clean).
- The migration is keyed `v1.2.0`; the template `VERSION` bump itself is left to the release step (Hard Rule #10).
- Pre-existing doc-debt noted: the INDEX-FRAMEWORK ADR table lists only 0001-0007; left as a separate catch-up rather than adding 0023 inconsistently.

Implements fw-adr-0023 D2 (Option S). No open issue to close (#276 covered D1, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architecture decision and upgrade documentation for handoff activity management.

* **Chores**
  * Updated handoff schema to version 1.1.0 with activity field now optional.
  * Added migration script to relocate activity from handoff JSON to separate sidecar files.
  * Updated handoff structure and directory documentation.

* **Tests**
  * Updated test coverage to validate new handoff activity behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/occamsshavingkit/sw-dev-team-template/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->