### PR TITLE
Session follow-ups: reconcile reader-prohibition list (#326) + ADR index catch-up

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -125,7 +125,9 @@ Hard Rule #12). When operating in reader mode:
 - Use the `scaffold_worktree` path from the dispatch brief as the root
   for all scaffold reads. Do not read from the canonical checkout path.
 - Do not run any git command that modifies shared state: no `git reset`,
-  no `git switch`, no `git stash`, no `git commit`, no `git push`.
+  `git checkout`, `git switch`, `git stash`, `git clean`, `git commit`,
+  `git merge`, `git rebase`, or `git push`; and no index, branch, or
+  tag mutations (`git add`/`rm`/`mv`, branch/tag create or delete).
 - **Non-hermetic test scripts are forbidden in reader mode.** If the
   brief asks you to run `test-gate-fail-each.sh` or any script not
   listed in `docs/tests/hermetic-verified.txt`, STOP immediately and

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -200,8 +200,10 @@ Reclassified **Reader** only when both of the following hold:
 
 When operating as Reader, use the `scaffold_worktree` path as the root
 for all scaffold operations and observe the full reader prohibition: no
-`git reset`, no `git switch`, no `git stash`, no `git commit`, no
-`git push`. If any required test script is not in
+`git reset`, `git checkout`, `git switch`, `git stash`, `git clean`,
+`git commit`, `git merge`, `git rebase`, or `git push`; and no index,
+branch, or tag mutations (`git add`/`rm`/`mv`, branch/tag create or
+delete). If any required test script is not in
 `docs/tests/hermetic-verified.txt`, return a reclassification request
 to `tech-lead` immediately.
 

--- a/.gemini/agents/code-reviewer.md
+++ b/.gemini/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: Code Reviewer and Auditor. Use PROACTIVELY before every commit and after significant changes. Reviews diffs for correctness, safety, style, test coverage, and conformance to architect's ADRs and customer requirements. Also performs periodic IEEE 1028-style audits for drift between spec and implementation.
 model: gemini-pro
 canonical_source: .claude/agents/code-reviewer.md
-canonical_sha: ba374a3051571e4368975b59eb70d6488fe962c8
+canonical_sha: 60906e1083416d4b0862bbe5b22afcbdd9565259
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -3,7 +3,7 @@ name: qa-engineer
 description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
 model: gemini-pro
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 7c736e966d7fd6415e745d8bffb7f79622313ae5
+canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 model: claude-sonnet
 canonical_source: .claude/agents/code-reviewer.md
-canonical_sha: ba374a3051571e4368975b59eb70d6488fe962c8
+canonical_sha: 60906e1083416d4b0862bbe5b22afcbdd9565259
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -2,7 +2,7 @@
 name: qa-engineer
 model: claude-sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 7c736e966d7fd6415e745d8bffb7f79622313ae5
+canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,8 +373,10 @@ like "first session of the calendar week" in preference to
     are serialized on the canonical scaffold checkout — at most one
     writer holds the writer-lane token at a time. Readers run in
     throwaway `/tmp/` worktrees (`scaffold_worktree` field in the
-    brief) and must not mutate shared git state (`git reset`, `git
-    switch`, `git stash`, `git commit`, `git push`). `tech-lead`
+    brief) and must not mutate shared git state (no `git reset`,
+    `git checkout`, `git switch`, `git stash`, `git clean`,
+    `git commit`, `git merge`, `git rebase`, or `git push`; and no
+    index, branch, or tag mutations). `tech-lead`
     classifies every dispatch before sending it; default is writer.
     Full protocol and classification table:
     `docs/agents/manual/tech-lead-manual.md` § "Working-tree

--- a/docs/INDEX-FRAMEWORK.md
+++ b/docs/INDEX-FRAMEWORK.md
@@ -72,13 +72,30 @@ FW-ADR-0006). Numbering is sequential within each namespace.
 
 | File | Decision |
 |---|---|
-| `docs/adr/fw-adr-0001-context-memory-strategy.md` | Adopt `claude-mem`; orchestration frameworks require a superseding ADR per project. |
+| `docs/adr/fw-adr-0001-context-memory-strategy.md` | Adopt `claude-mem` as the prior-session memory layer; orchestration frameworks require a superseding ADR per project. |
 | `docs/adr/fw-adr-0002-upgrade-content-verification.md` | `TEMPLATE_MANIFEST.lock` per-file SHA256 manifest as primary trust anchor for `upgrade.sh --verify`; on-demand re-fetch as fallback. (v0.14.0.) |
-| `docs/adr/fw-adr-0003-bare-template-variants.md` | Ship guided + bare template pair for `architecture-template` and `requirements-template`; bare ~50% smaller for fluent authors. (v0.14.0.) |
-| `docs/adr/fw-adr-0004-per-item-file-breakout.md` | Per-FR / per-NFR / per-view files indexed from a thin top-level template; agents load only what's in scope. (v0.14.0.) |
-| `docs/adr/fw-adr-0005-standards-paraphrase-cards.md` | Single `docs/standards/paraphrase-cards.md` file as the source for IEEE/ISO standards paraphrase content cited from agent contracts. (v0.14.0.) |
-| `docs/adr/fw-adr-0006-madr-required-optional-split.md` | Adopt MADR's required / recommended / optional split in `adr-template.md`; small ADRs ~40 lines, full ADRs ~200+. (v0.14.0.) |
-| `docs/adr/fw-adr-0007-external-reference-adoption.md` | Add LIB-0015..0018 (URL-only inventory rows for system-design-primer / jam01 templates / MADR); land "Inspire, don't paste" rule in glossary. **Note**: ADR-numbering split between framework (`FW-ADR-NNNN`, `fw-adr-NNNN-*.md`) and project (`ADR-NNNN`, plain `NNNN-*.md`) shipped in v0.15.0. |
+| `docs/adr/fw-adr-0003-bare-template-variants.md` | Ship guided + bare template pair per template family so fluent authors can use the structure-only form. (v0.14.0.) |
+| `docs/adr/fw-adr-0004-per-item-file-breakout.md` | Break requirements and architecture views into per-item files with a thin index; agents load only what's in scope. (v0.14.0.) |
+| `docs/adr/fw-adr-0005-standards-paraphrase-cards.md` | Extract IEEE/ISO paraphrases into a single `docs/standards/paraphrase-cards.md` as the source for standards citations cited from agent contracts. (v0.14.0.) |
+| `docs/adr/fw-adr-0006-madr-required-optional-split.md` | Split `adr-template.md` sections into MADR required, project required, and optional; small ADRs ~40 lines, full ADRs ~200+. (v0.14.0.) |
+| `docs/adr/fw-adr-0007-external-reference-adoption.md` | Adopt LIB-0015..0018 (URL-only inventory rows); land "Inspire, don't paste" rule in glossary. **Note**: ADR-numbering split between framework (`FW-ADR-NNNN`) and project (`ADR-NNNN`) shipped in v0.15.0. |
+| `docs/adr/fw-adr-0008-tech-lead-orchestration-boundary.md` | Tech-lead orchestrates; production artifacts and customer-truth records route to owning specialists (Hard Rule #8). |
+| `docs/adr/fw-adr-0009-opencode-harness-adapter.md` | Classify OpenCode as a harness/provider adapter; it must not redefine roles, escalation, source-of-truth, or customer interface. |
+| `docs/adr/fw-adr-0010-pre-bootstrap-local-edit-safety.md` | Pre-bootstrap uses a 3-SHA decision matrix with refuse-on-uncertain semantics and an explicit override env var. (Superseded by FW-ADR-0015/0019.) |
+| `docs/adr/fw-adr-0011-routed-through-trailer.md` | `Routed-Through:` commit-trailer plus lint/hook/tool-bridge carve-out enforces Hard Rule #8; primary-enforcement framing superseded by FW-ADR-0012. |
+| `docs/adr/fw-adr-0012-tech-lead-authoring-guard.md` | PreToolUse allow-list hook is the primary preventive enforcement for Hard Rule #8; supersedes FW-ADR-0011's primary-enforcement framing. |
+| `docs/adr/fw-adr-0013-rc-to-rc-pre-bootstrap.md` | Add a versioned pre-bootstrap migration (`v1.0.0-rc13.sh`) cloned from `v0.14.0.sh` so rc-to-rc upgrades on pre-v0.15.0 drivers self-bootstrap safely. (Superseded by FW-ADR-0015/0019.) |
+| `docs/adr/fw-adr-0014-preservation-vs-manifest.md` | Preservation honoured only on divergence-AND-non-manifest-fresh-write paths; upgrade tail emits a two-phase exit replacing single-line "Done." |
+| `docs/adr/fw-adr-0015-upgrade-orchestrator-stub-model.md` | `scripts/upgrade.sh` becomes a stable sub-100-line stub; the real upgrade orchestrator is fetched fresh per invocation from upstream. Foundational ADR for the upgrade-flow rearchitecture; supersedes FW-ADR-0010 and FW-ADR-0013. |
+| `docs/adr/fw-adr-0016-template-state-json-schema.md` | Defines `TEMPLATE_STATE.json` — the single project-owned state artefact consolidating version, manifest, customizations, and runner checksum into one declarative file. |
+| `docs/adr/fw-adr-0017-file-keyed-migration-discovery.md` | Replaces tag-keyed migration enumeration with file-presence discovery in the runner's `migrations/` tree, semver-ordered against `TEMPLATE_STATE.json`. |
+| `docs/adr/fw-adr-0018-transitional-rc-bridging.md` | One transitional in-tree rc bridges currently-deployed downstreams onto the FW-ADR-0015 stub model; consolidates legacy three-file project state into `TEMPLATE_STATE.json`. |
+| `docs/adr/fw-adr-0019-pre-bootstrap-retirement.md` | Formally retires the pre-bootstrap class; marks FW-ADR-0010 and FW-ADR-0013 superseded; deprecates `SWDT_PREBOOTSTRAP_FORCE` env var and `.template-prebootstrap-blocked.json`. (Status: proposed.) |
+| `docs/adr/fw-adr-0020-issues-based-coordination-model.md` | Replace GitHub Projects board with plain GitHub Issues (labels + milestones + optimistic-claim convention) as the v1.1.0 Half-B multi-machine coordination layer. |
+| `docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md` | Single leaf T### task as the harness-agnostic dispatch unit; delegated-specialist mode added to `AGENTS.md`; machine-checked enforcement gate. Implemented: issue #293. |
+| `docs/adr/fw-adr-0022-gemini-harness-adapter.md` | Classify gemini-cli as a co-equal harness adapter; `GEMINI.md` root adapter, `.gemini/agents/` generated roster, description-driven dispatch, three-surface drift control. Implemented: issue #300. |
+| `docs/adr/fw-adr-0023-handoff-activity-array-growth.md` | Two coupled decisions on handoff JSON integrity: (1) deliberate hash-exclusion of the runtime-mutable `activity` array from manifest verification, and (2) disposition of unbounded growth via sidecar migration. |
+| `docs/adr/fw-adr-0024-parallel-agent-working-tree-isolation.md` | Working-tree isolation strategy for parallel specialist agents: strict serialization (current interim), per-agent git worktrees, or read-only worktree for readers with a single canonical writer. |
 
 ## `docs/glossary/`
 

--- a/docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md
+++ b/docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md
@@ -1,0 +1,442 @@
+---
+name: fw-adr-0021-harness-agnostic-leaf-task-dispatch
+description: >
+  Decision on dispatch-unit granularity (single leaf T### task,
+  harness-agnostic), delegated-specialist role-binding in AGENTS.md,
+  and machine-checked enforcement of those constraints.
+status: accepted
+date: 2026-06-02
+---
+
+
+# FW-ADR-0021 — Harness-agnostic single-task dispatch and delegated-specialist
+role mode
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Scaffold placement note](#scaffold-placement-note)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+  - [Option M — Minimalist](#option-m--minimalist)
+  - [Option S — Scalable](#option-s--scalable)
+  - [Option C — Creative (experimental)](#option-c--creative-experimental)
+- [Decision outcome](#decision-outcome)
+- [Design: harness-agnostic leaf-task dispatch](#design-harness-agnostic-leaf-task-dispatch)
+  - [1. Dispatch unit — leaf T### task, harness-agnostic](#1-dispatch-unit--leaf-t-task-harness-agnostic)
+  - [2. Delegated-specialist mode in AGENTS.md](#2-delegated-specialist-mode-in-agentsmd)
+  - [3. Enforcement gate sketch](#3-enforcement-gate-sketch)
+  - [4. Relationship to spec 016 and issue #292](#4-relationship-to-spec-016-and-issue-292)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up ADRs](#follow-up-adrs)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+---
+
+## Status
+
+- **Accepted** — customer ratified both open rulings 2026-06-02
+  (see `CUSTOMER_NOTES.md` entry recorded this turn)
+- **Date:** 2026-06-02
+- **Deciders:** `architect` (proposed); `tech-lead` + customer (accepted 2026-06-02)
+- **Consulted:** `docs/v1.1-handoff-contracts.md`; `schemas/handoff.schema.json`
+  (`bounded_codex_exception` shape); `AGENTS.md` (Codex adapter); `CLAUDE.md`
+  Hard Rules #8, #11; `docs/agents/manual/tech-lead-manual.md` § "Dispatch
+  discipline"; `docs/pm/findings-2026-06-02-customer-notes-drift.md` (issue
+  #292 enforcement-vs-folklore root); `docs/templates/task-template.md` (JIT
+  file list and token-budget fields); `docs/workflow-pipeline.md`
+
+## Scaffold placement note
+
+This ADR was drafted in the meta-project (`docs/adr/`) per the PLAN/DO
+convention (CLAUDE.md § "Project Identity / Working Tree"). It migrated
+into the scaffold's `docs/adr/` as part of the implementation work for
+issue #293 (delegated-specialist schema, gate, and provider parity) so the
+rationale travels with the code, matching the pattern established by
+FW-ADR-0001 through FW-ADR-0020. The meta-project draft copy is retained
+as the team's working reference; this scaffold copy is the canonical version
+from the implementation PR forward.
+
+---
+
+## Context and problem statement
+
+The v1.1 handoff-contract spine (`docs/v1.1-handoff-contracts.md`,
+`schemas/handoff.schema.json`) established machine-readable task contracts and
+bounded-Codex mode. Three gaps surfaced when that infrastructure was used in
+practice across both the Claude Code (`Agent` tool) and Codex MCP harnesses.
+
+**P7 — Granularity.** Durable handoffs (`docs/handoffs/<task_id>.json`) are
+scoped at feature altitude — an objective spanning a dozen T### leaf tasks, with
+`allowed_paths` covering whole directories, and a `bounded_codex_exception`
+block granting authority over all of them at once. The per-leaf decomposition
+already exists one level down in `tasks.md`, and `docs/templates/task-template.md`
+carries the right primitives (a JIT file list and a `tiny|small|medium|large|xl`
+token budget hint). However, no binding prose or schema constraint makes a single
+leaf task the unit of dispatch — a caller can still hand off a multi-task batch
+in one contract and no gate rejects it.
+
+**P8 — Role-binding for delegated-specialist mode.** `AGENTS.md` defines only
+one invocation context for Codex: the main session acts as `tech-lead`,
+orchestrates, and dispatches specialists. There is no "invoked as a delegated
+specialist" mode. When Codex is invoked via the `codex` MCP from a Claude
+orchestrator session with an active handoff, it defaults to orchestrator
+behavior, reads `AGENTS.md`'s "ask to spawn" rule, and may attempt to spawn
+sub-specialists rather than executing the assigned task directly. The
+`bounded_codex_exception` schema fields (`codex_permission_flag`,
+`permitted_role_owned_action`) exist but the role-binding prose — the instruction
+that tells a delegated Codex to adopt the handoff's named role and suppress
+orchestrator behavior — is absent from `AGENTS.md`.
+
+**P9 — Enforcement.** Both P7 and P8 are governed by advisory prose, not by any
+hook or linter. This is the same advisory-prose-not-gates pattern identified as
+the root cause of the `CUSTOMER_NOTES.md` entry-drift problem (issue #292,
+`docs/pm/findings-2026-06-02-customer-notes-drift.md`). Dispatch-brief
+granularity is described in spec 016 as "folklore" being promoted to binding
+prose for the Claude path; this ADR makes it harness-agnostic, extends it to the
+Codex path, and pairs it with a machine-checkable gate.
+
+ADR triggers: cross-cutting pattern change (dispatch-unit convention + new
+`AGENTS.md` mode); public boundary change (new required field shape on the
+handoff contract that hooks validate); enforcement-mechanism choice (same root
+as #292).
+
+## Decision drivers
+
+- The repo IS the brief. Both Claude subagents and Codex self-orient from the
+  repo via `AGENTS.md` / `CLAUDE.md`; no orientation blob needs to be packed
+  into a dispatch contract. Handoff contracts carry task scope only.
+- "One T### task per dispatch, never bundled" is already applied to Claude
+  subagents by convention; it must be promoted to a machine-checked rule and
+  extended to the Codex path.
+- Delegated Codex defaults to orchestrator mode. Without an explicit mode signal
+  in `AGENTS.md`, a bounded-Codex invocation will attempt to spawn rather than
+  execute, defeating the handoff's `permitted_role_owned_action` field.
+- The token-budget and JIT file list fields in `docs/templates/task-template.md`
+  exist; the rule that makes them load-bearing belongs in the handoff contract
+  and in `AGENTS.md`, not only in a template.
+- Enforcement-via-prose has repeatedly failed (issue #292). A gate that rejects
+  non-conforming contracts at commit time is the only durable fix.
+- Changes to `AGENTS.md` affect both harnesses; prose must be unambiguous about
+  which mode is active and who controls it.
+
+## Considered options (Three-Path Rule, binding)
+
+### Option M — Minimalist
+
+Add a short binding paragraph to `AGENTS.md` and to `tech-lead-manual.md`'s
+"Dispatch discipline" section stating (a) one leaf task per dispatch, (b) if a
+handoff's `bounded_codex_exception.codex_permission_flag` is true and a
+`permitted_role_owned_action` is set, adopt that role and do not spawn. No schema
+change. No hook. The rule is advisory prose, promoted from folklore to a named
+binding rule in two docs.
+
+- **Sketch:** Two paragraph additions and an `AGENTS.md` mode table. No new
+  schema fields. No gate script. Implementation cost: one PR touching
+  `AGENTS.md` and `docs/agents/manual/tech-lead-manual.md`.
+- **Pros:** Zero schema migration; lowest implementation cost; immediately
+  deployable; no new failure mode from a flawed gate.
+- **Cons:** Preserves the advisory-prose-not-gates pattern that produced issue
+  #292 and is explicitly called out as the root gap by spec 016 and the
+  findings doc. A delegated Codex that mis-reads mode signals (or runs a stale
+  `AGENTS.md` snapshot) has no hook to catch it. Per-leaf granularity remains
+  unenforced; a caller can still dispatch a multi-task batch without rejection.
+- **When M wins:** the team accepts that operator discipline is the dominant
+  control; automation cost is prohibitive; the enforcement gap is tolerable
+  under the current project scale.
+
+### Option S — Scalable
+
+Promote the leaf-task dispatch unit to a **required schema field** on the
+handoff contract (`dispatch_scope: "single_task"` + a `task_ref` field
+pointing into `tasks.md`) alongside a `delegated_role` field used when the
+harness is invoked as a specialist. A pre-commit hook (extending the existing
+handoff-gate pattern in `scripts/hooks/`) validates: (a) when
+`bounded_codex_exception.codex_permission_flag` is true, `delegated_role` must
+be present and must not be `tech-lead`; (b) when `dispatch_scope` is
+`single_task`, `task_ref` must be non-null and point to a recognized task ID.
+`AGENTS.md` gains a "Delegated-specialist mode" section: "if the active handoff
+declares `delegated_role`, adopt that role, execute the single named task, and
+do not spawn specialists." Feature-scoped handoffs (the existing feature-altitude
+contracts like `fw-012`) are grandfathered as `dispatch_scope: "feature"` and
+are not dispatched directly to bounded Codex — they are orchestrator artifacts
+only.
+
+- **Sketch:** Schema adds two optional fields (`dispatch_scope` and
+  `task_ref`; required only when `codex_permission_flag: true`). `AGENTS.md`
+  gains a mode-selection table (one page). Hook adds one validation path (~30
+  lines). Downstream handoffs continue to work without change unless they use
+  bounded-Codex mode. Implementation cost: one PR touching schema, one hook
+  extension, one `AGENTS.md` section, one `tech-lead-manual.md` paragraph.
+- **Pros:** Machine-checked; closes the enforcement gap for both P7 and P8;
+  gradual adoption (existing feature-scoped handoffs are unaffected); maps
+  cleanly to the existing `bounded_codex_exception` structure; `delegated_role`
+  also serves as the self-orientation signal for any future harness (not Codex-
+  specific); eliminates the "defaulting to orchestrator" behavior by making
+  role adoption the contract, not a per-call override.
+- **Cons:** Schema version bump required; existing bounded-Codex test fixtures
+  must be extended; slightly more author friction per leaf-task handoff
+  (two new fields); gate adds a new failure mode if misimplemented.
+- **When S wins:** enforcement is a named requirement (post-issue-#292); the
+  team will author multiple bounded-Codex handoffs; the hook infrastructure
+  already exists and extending it is low marginal cost.
+
+### Option C — Creative (experimental)
+
+Replace the JSON handoff contract with an executable dispatch manifest: a
+YAML or TOML file that is simultaneously the task spec, the dispatch brief,
+and a self-contained role-binding script. A thin harness shim reads the
+manifest, sets `DELEGATED_ROLE` as an env var, and injects a preamble into
+the agent's system prompt before the agent reads any repo file. The manifest
+contains a `tasks:` array; each item is exactly one leaf task. The harness
+shim rejects arrays with more than one item in the current active slot.
+Schema validation collapses into shim validation; no separate hook.
+
+- **Sketch:** Replace `docs/handoffs/*.json` + `schemas/handoff.schema.json`
+  with a new manifest format. Write a small Python shim (`scripts/dispatch-
+  shim.py`) that validates the manifest, injects the role preamble, and
+  invokes the agent. All existing handoff JSON files are migrated or wrapped.
+- **Pros:** Role injection is guaranteed by construction (the shim controls the
+  prompt); single-task constraint is structurally enforced (array length 1);
+  no separate hook needed; the manifest is self-documenting.
+- **Cons:** Requires migrating all existing `docs/handoffs/*.json` files and
+  retiring the current schema; adds a new runtime dependency (the shim) on every
+  harness invocation path; breaks downstream projects that have adopted the v1.1
+  JSON format; diverges from the repo-is-the-brief model by making the shim a
+  mandatory intermediary; high implementation risk from shim bugs that silently
+  corrupt the agent's role context. The migration cost alone rejects this given
+  the current scale.
+- **When C wins:** the team controls both sides of the harness boundary (i.e.,
+  operates its own MCP server); the shim can be tested exhaustively; and the
+  role-injection guarantee is a hard safety requirement that advisory prose
+  cannot satisfy. None of these hold here.
+
+## Decision outcome
+
+**Chosen option: S — Scalable**
+
+Option M preserves the advisory-prose pattern that produced issue #292 and is
+explicitly insufficient per the findings doc and spec 016's own framing
+("folklore"). Option C requires a migration that breaks downstream v1.1 adopters
+and introduces a new runtime dependency with no benefit over a well-written hook.
+Option S closes both gaps with minimal surface area: two new schema fields,
+one `AGENTS.md` mode section, and one hook extension, all within the existing
+handoff-gate pattern. The schema change is additive and conditional (fields are
+required only when `codex_permission_flag: true`), so all existing feature-
+scoped handoffs continue to pass validation without modification.
+
+---
+
+## Design: harness-agnostic leaf-task dispatch
+
+### 1. Dispatch unit — leaf T### task, harness-agnostic
+
+**The unit of dispatch is a single leaf T### task.** This applies to both Claude
+(`Agent` tool) and Codex (MCP invocation) paths. A durable handoff at
+feature altitude (`dispatch_scope: "feature"`) is an orchestrator artifact only;
+it is never the direct input to a bounded-Codex or Agent-tool invocation.
+
+A leaf-task handoff (`dispatch_scope: "single_task"`) carries:
+
+| Field | Meaning |
+|---|---|
+| `dispatch_scope` | `"single_task"` — the gate rejects anything else for bounded-Codex |
+| `task_ref` | Task ID pointer into `tasks.md` (e.g. `"T041"`) |
+| `delegated_role` | Canonical role name the agent must adopt (e.g. `"software-engineer"`) |
+| `allowed_paths` | JIT file list — only files needed for this task |
+| `token_budget_hint` | `"tiny"` \| `"small"` \| `"medium"` \| `"large"` \| `"xl"` |
+| `acceptance_criteria` | Copied or summarized from `tasks.md` T### entry |
+| `verification.tests[].command` | Test command that must pass before done |
+
+The `task_ref`, `delegated_role`, and `dispatch_scope` fields are added to
+`schemas/handoff.schema.json` under `bounded_codex_exception` (when
+`codex_permission_flag: true`, `delegated_role` and `dispatch_scope` become
+required). The `token_budget_hint` is a top-level optional field (useful for
+both harnesses, not only Codex).
+
+The repo supplies orientation. The dispatch contract carries scope. No
+orientation prose is repeated in the contract.
+
+**Feature-altitude handoffs are grandfathered.** Existing contracts (e.g.
+`docs/handoffs/fw-012-v1-1-handoff-contracts.json`) carry `dispatch_scope:
+"feature"` (default when the field is absent) and are not affected by the new
+gate. They remain valid orchestration artifacts for planning and audit; they
+are not dispatch inputs.
+
+### 2. Delegated-specialist mode in AGENTS.md
+
+`AGENTS.md` gains a "Delegated-specialist mode" section immediately after "Role
+Binding," with the following binding prose:
+
+> If the active handoff (`docs/handoffs/<task_id>.json` pointed to by
+> `.devteam/active-handoff.json`) declares `delegated_role`, this Codex session
+> is operating as a delegated specialist, not as `tech-lead`.
+>
+> In delegated-specialist mode:
+>
+> - Adopt the role named in `delegated_role` for the duration of this session.
+>   Read the corresponding `.claude/agents/<role>.md` as your role contract.
+> - Execute the single task named in `task_ref`. Do not treat the feature-level
+>   objective as your scope.
+> - Do **not** spawn specialists. Do **not** act as `tech-lead`. Do **not**
+>   contact the customer. Return completed artifacts and any blockers to the
+>   orchestrating `tech-lead` session.
+> - The `permitted_role_owned_action` field on `bounded_codex_exception` names
+>   the specific action you are authorized to perform at the top level. Stay
+>   within that action and the declared `allowed_paths`.
+>
+> Presence check: if `delegated_role` is set but is `"tech-lead"`, halt and
+> report a malformed handoff — the gate should have rejected this, but if it
+> reached you, do not proceed.
+
+This makes role adoption the contract, not a per-call manual override. The
+section is harness-agnostic prose; it also applies to any future harness that
+reads `AGENTS.md`.
+
+### 3. Enforcement gate sketch
+
+The existing `scripts/hooks/handoff-pre-tool-gate.py` validates handoff
+contracts on PreToolUse events. A new validation path is added — invocable
+standalone as `scripts/validate-handoff.py --mode bounded-codex` and also
+wired as a pre-commit check:
+
+**Assertion A — delegated_role vs. dispatch_scope coherence.**
+When `bounded_codex_exception.codex_permission_flag` is true:
+- `delegated_role` must be present and must not equal `"tech-lead"`.
+- `dispatch_scope` must equal `"single_task"`.
+- `task_ref` must be non-null and non-empty.
+
+**Assertion B — single-task scope.**
+When `dispatch_scope` is `"single_task"`:
+- `allowed_paths` must not overlap with more than one T### task's known
+  file set (this check is advisory if `tasks.md` is absent; binding if present).
+
+**Assertion C — feature-scope is not a dispatch input.**
+When `dispatch_scope` is `"feature"` (or absent) and
+`bounded_codex_exception.codex_permission_flag` is true — this is a
+misconfiguration. The gate rejects and explains: feature-altitude handoffs
+are orchestrator artifacts; create a leaf-task handoff for direct dispatch.
+
+The gate follows the `lint-questions.sh` / handoff-gate pattern: warn mode
+by default, enforce mode via `HANDOFF_GATE_MODE=enforce`. Pre-commit hooks
+in `.claude/settings.json` run in enforce mode on bounded-Codex handoffs.
+
+### 4. Relationship to spec 016 and issue #292
+
+Spec 016 ("token economy design") is adding dispatch-granularity discipline as
+binding prose in `tech-lead.md` for the Claude Code path. This ADR extends
+that ruling to be harness-agnostic (covering Codex via `AGENTS.md`), adds
+machine enforcement (the gate sketch above), and frames the `delegated_role`
+/ `dispatch_scope` schema fields that make the prose checkable.
+
+Issue #292 (`docs/pm/findings-2026-06-02-customer-notes-drift.md`) identified
+that the `CUSTOMER_NOTES.md` entry-drift problem is rooted in advisory prose
+with no machine check. This ADR applies the same diagnosis to dispatch
+granularity and role-binding, and adopts the same remedy: a hook gate rather
+than a prose rule alone. The two problems share a root; the fix pattern is
+intentionally the same.
+
+## Consequences
+
+### Positive
+
+- The dispatch unit is unambiguous and harness-agnostic. A reader of any
+  handoff contract can determine in one field lookup whether it is an
+  orchestrator artifact or a direct dispatch input.
+- Delegated Codex no longer defaults to orchestrator behavior. Role adoption
+  is the contract; `AGENTS.md` makes the mode explicit rather than relying on
+  the caller to pass a manual override per invocation.
+- The gate closes the same advisory-prose-not-gates gap identified in issue
+  #292, applied to the dispatch path.
+- Feature-altitude handoffs are explicitly classified and grandfathered;
+  downstream projects already using them need no migration.
+- `token_budget_hint` is available to both harnesses; orchestrators can use it
+  to select model tier or set reasoning-effort per task.
+
+### Customer rulings ratified 2026-06-02
+
+Both open decision points from the proposed ADR were ratified by the customer
+this turn. The backing customer-truth entry is recorded in `CUSTOMER_NOTES.md`
+(librarian-stewarded, same turn).
+
+**Ruling 1 — Schema version bump strategy (ratified: MINOR semver bump).**
+The new `delegated_role`, `dispatch_scope`, and `task_ref` fields ship as a
+MINOR semver bump to the handoff schema (`schemas/handoff.schema.json`). This
+is not a v1.2 milestone marker; the bump is self-contained within the current
+release line. Schema consumers that do not set `codex_permission_flag: true`
+are unaffected (fields are conditionally required).
+
+**Ruling 2 — Gate default mode (ratified: WARN default, ENFORCE opt-in).**
+The new validation gate defaults to warn mode. Enforce mode is opt-in via
+`HANDOFF_GATE_MODE=enforce`. Because warn is the default, migration of existing
+`tests/hooks/fixtures/handoff/bounded-codex-*.json` fixtures is NOT a
+prerequisite for shipping the gate — it is a prerequisite only for flipping
+enforce on. Downstream projects adopting enforce mode must update their
+bounded-Codex fixtures before enabling it.
+
+### Negative / trade-offs accepted
+
+- Schema receives a MINOR semver bump (ratified). Authors of leaf-task
+  handoffs using bounded-Codex mode have two additional required fields
+  (`delegated_role`, `dispatch_scope`). The overhead is small (~2 lines per
+  handoff) but real.
+- The gate ships in warn mode by default (ratified). Existing
+  `bounded-codex-*.json` fixtures that lack the new fields will produce
+  warnings, not failures, until `HANDOFF_GATE_MODE=enforce` is set. Teams
+  that want hard enforcement must update those fixtures first — this is
+  explicitly a prerequisite for enabling enforce, not for shipping the gate.
+- The gate's Assertion B (single-task scope via `allowed_paths` overlap check)
+  is advisory when `tasks.md` is absent. Projects that do not maintain a
+  `tasks.md` get weaker enforcement.
+- `AGENTS.md` prose changes affect both harnesses simultaneously. A Codex
+  session running against a stale `AGENTS.md` snapshot will not see the
+  delegated-specialist mode section until it re-reads the file.
+
+### Follow-up ADRs
+
+- A future ADR may address `token_budget_hint` → model-routing integration:
+  mapping `tiny|small|...|xl` to specific model tiers in
+  `docs/model-routing-guidelines.md`.
+- If the Assertion B overlap check proves too expensive to maintain against
+  `tasks.md`, a follow-up may relax it to a format check only.
+
+## Verification
+
+- **Success signal:** A bounded-Codex invocation against a leaf-task handoff
+  with `delegated_role: "software-engineer"` adopts the software-engineer role,
+  executes the single named task, and does not attempt to spawn specialists or
+  contact the customer. The gate passes in enforce mode on that handoff. A
+  feature-altitude handoff with `codex_permission_flag: true` (misconfiguration)
+  is rejected by the gate before commit.
+- **Failure signal:** A delegated Codex session with a correctly formed handoff
+  still defaults to orchestrator behavior (asks to spawn), indicating `AGENTS.md`
+  is not being read or the `delegated_role` field is being ignored — triggering
+  a superseding ADR on runtime prompt injection (closer to Option C territory).
+- **Review cadence:** Re-examine at v1.2.0 scoping or after three documented
+  bounded-Codex invocations in downstream projects, whichever comes first.
+
+## Links
+
+- `docs/v1.1-handoff-contracts.md` § "Bounded Codex Mode"
+- `schemas/handoff.schema.json` (`bounded_codex_exception` shape)
+- `AGENTS.md` (Codex adapter — the file this ADR amends)
+- `docs/agents/manual/tech-lead-manual.md` § "Dispatch discipline"
+- `docs/pm/findings-2026-06-02-customer-notes-drift.md` (issue #292 root)
+- `docs/templates/task-template.md` (JIT file list and token-budget fields)
+- `docs/workflow-pipeline.md` § "Three-path design options"
+- FW-ADR-0008 (`docs/adr/fw-adr-0008-tech-lead-orchestration-boundary.md`) —
+  role-stealing / orchestration-boundary rules this ADR extends to Codex
+- FW-ADR-0009 (`docs/adr/fw-adr-0009-opencode-harness-adapter.md`) —
+  harness-adapter precedent
+- FW-ADR-0020 (`docs/adr/fw-adr-0020-issues-based-coordination-model.md`) —
+  handoff-contract authority model this ADR builds on
+
+## Change log
+
+- 2026-06-03 — customer-truth steward role researcher→librarian per Q-0023; decision principle unchanged.

--- a/docs/adr/fw-adr-0022-gemini-harness-adapter.md
+++ b/docs/adr/fw-adr-0022-gemini-harness-adapter.md
@@ -1,0 +1,633 @@
+---
+name: fw-adr-0022-gemini-harness-adapter
+description: >
+  Classify gemini-cli as a co-equal harness adapter; define GEMINI.md
+  root adapter, .gemini/agents/ roster, routing model for
+  description-driven dispatch, and drift-control strategy across the
+  three-harness roster (Claude / OpenCode / Gemini).
+status: accepted
+date: 2026-06-02
+---
+
+
+# FW-ADR-0022 — Gemini harness adapter
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Scaffold placement note](#scaffold-placement-note)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+  - [Option M — Minimalist](#option-m--minimalist)
+  - [Option S — Scalable](#option-s--scalable)
+  - [Option C — Creative (experimental)](#option-c--creative-experimental)
+- [Decision outcome](#decision-outcome)
+- [Design: Gemini harness adapter](#design-gemini-harness-adapter)
+  - [1. GEMINI.md root adapter](#1-geminimd-root-adapter)
+  - [2. .gemini/agents/ roster](#2-geminiagents-roster)
+  - [3. Routing model under description-driven selection](#3-routing-model-under-description-driven-selection)
+  - [4. Parity and drift control](#4-parity-and-drift-control)
+  - [5. Version floor](#5-version-floor)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up ADRs](#follow-up-adrs)
+- [Customer rulings ratified 2026-06-02](#customer-rulings-ratified-2026-06-02)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+---
+
+## Status
+
+- **Accepted** — customer ratified both open rulings 2026-06-02
+  (see `CUSTOMER_NOTES.md` entry recorded this turn)
+- **Date:** 2026-06-02
+- **Deciders:** `architect` (proposed); `tech-lead` + customer (accepted
+  2026-06-02)
+- **Consulted:** FW-ADR-0008, FW-ADR-0009, FW-ADR-0021;
+  `.opencode/agents/` thin-adapter precedent;
+  `docs/model-routing-guidelines.md` binding table;
+  gemini-cli v0.38.1–v0.44.0 release notes (researcher-verified,
+  Tier-1 source)
+
+## Scaffold placement note
+
+This ADR was drafted in the meta-project (`docs/adr/`) per the PLAN/DO
+convention (CLAUDE.md § "Project Identity / Working Tree"). It migrated
+into the scaffold's `docs/adr/` as part of the implementation work for
+issue #300 (Gemini harness: GEMINI.md, .gemini/agents/ roster,
+compile-runtime-agents.sh extension) so the rationale travels with the
+code, matching the pattern established by FW-ADR-0001 through FW-ADR-0021.
+The meta-project draft copy is retained as the team's working reference;
+this scaffold copy is the canonical version from the implementation PR
+forward.
+
+---
+
+## Context and problem statement
+
+The framework runs across three harness surfaces: Claude Code (native,
+`.claude/agents/`), Codex (`AGENTS.md` adapter), and OpenCode
+(`.opencode/agents/` thin adapters, FW-ADR-0009). gemini-cli v0.38.1
+introduced native named subagents with independent context and parallel
+spawn; v0.44.0 stabilised the surface. gemini-cli selects subagents by
+matching task context against each agent's `description` field
+(autonomous) or by explicit `@name` invocation — a structurally
+different dispatch model from Claude Code's imperative `Agent` tool.
+
+The framework currently has no Gemini adapter. The only `.gemini/`
+artifact is the slash-command TOML set under `.gemini/commands/`. There
+is no `GEMINI.md` (the auto-loaded context file), no `.gemini/agents/`
+roster, and no specification of which session plays `tech-lead`, how
+the "sole human interface" rule is enforced, or how the delegated-
+specialist mode from FW-ADR-0021 maps onto gemini-cli's dispatch model.
+This gap (P12 in the problem register) means a Gemini operator reaches
+the canonical role contracts via nothing but repo exploration — the
+same advisory-prose-only gap identified as the root of issue #292.
+
+The ADR trigger is a new harness surface (cross-cutting pattern change:
+orchestration model, dispatch model, escalation-protocol encoding) and
+a new external dependency (gemini-cli). FW-ADR-0009 established the
+binding classification: new harnesses are adapters, not peer
+orchestrators. This ADR applies that classification to Gemini and
+resolves the three structural gaps specific to gemini-cli's dispatch
+model: (1) `GEMINI.md` auto-load, (2) description-quality as
+load-bearing for autonomous selection, and (3) roster parity / drift
+across three adapter surfaces.
+
+## Decision drivers
+
+- gemini-cli's dispatch model uses description-matching for autonomous
+  agent selection. Description quality is load-bearing: a weak
+  description silently selects the wrong agent. This is structurally
+  different from Claude Code's imperative spawn and from Codex's
+  subagent facility, and must be accounted for in the adapter design.
+- The "sole human interface" and "do not spawn tech-lead as a subagent"
+  rules (FW-ADR-0008, CLAUDE.md Hard Rule #1) must be encoded in
+  `GEMINI.md` so a Gemini session self-orients correctly without
+  operator intervention.
+- FW-ADR-0021's delegated-specialist mode (P8: when invoked as a
+  bounded specialist, adopt the handoff role, suppress orchestrator
+  behavior) must be reachable from Gemini. The `delegated_role` field
+  on the handoff contract is harness-agnostic; `GEMINI.md` must carry
+  the same delegated-specialist prose `AGENTS.md` now carries.
+- Three roster copies (`.claude/agents/`, `.opencode/agents/`,
+  `.gemini/agents/`) plus two root adapters (`AGENTS.md`, `GEMINI.md`)
+  create a drift surface. The existing `compile-runtime-agents.sh`
+  + `canonical_sha` pattern (FW-ADR-0009) already solves the OpenCode
+  case; Gemini must be added to the same generation path rather than
+  maintained by hand.
+- gemini-cli `model` frontmatter in `.gemini/agents/` maps to the
+  binding per-agent default-class table in
+  `docs/model-routing-guidelines.md`. The adapter must not introduce
+  a parallel routing policy.
+- Version floor required: gemini-cli < v0.38.1 has no named subagent
+  surface; the adapter is meaningless below that version.
+
+## Considered options (Three-Path Rule, binding)
+
+### Option M — Minimalist
+
+Ship a single `GEMINI.md` root file (the auto-loaded context file) that
+instructs Gemini to read `CLAUDE.md` and `.claude/agents/tech-lead.md`,
+plus a short note on each role available and how to call them via
+`@name`. Do not create `.gemini/agents/` files. Roles are described in
+prose inside `GEMINI.md` rather than as discrete agent definitions.
+
+- **Sketch:** One new file, `GEMINI.md`, approximately 100 lines.
+  Prose maps each role by name and notes the `@name` invocation syntax.
+  Autonomous description-driven selection is not supported (no agent
+  files to match against); all dispatch must be explicit `@name`. The
+  delegated-specialist mode prose is copied from `AGENTS.md`. No
+  changes to `compile-runtime-agents.sh` or `scripts/lint-agent-
+  contracts.sh`.
+- **Pros:** Lowest implementation cost; one file; no new schema fields;
+  no generation script changes; works on any gemini-cli version that
+  supports `GEMINI.md` auto-load.
+- **Cons:** Autonomous agent selection — the feature that makes
+  gemini-cli's subagent surface useful — is unavailable. Operators
+  must explicitly `@name` every dispatch, which is functionally
+  equivalent to Codex with none of the ergonomic benefit. Description
+  text in `GEMINI.md` prose duplicates and will drift from canonical
+  role descriptions. No `canonical_sha` protection; drift is
+  undetected. Does not satisfy the "co-equal full-team harness" design
+  requirement.
+- **When M wins:** the team needs only light Gemini support as a
+  fallback harness with manual dispatch; ergonomic feature parity is
+  not required.
+
+### Option S — Scalable
+
+Ship `GEMINI.md` as the full root adapter (parallel to `AGENTS.md`)
+plus 13 `.gemini/agents/<role>.md` thin-adapter files modelled on
+`.opencode/agents/`. Each agent file carries a `name` slug, a
+`description` strong enough to drive autonomous selection, a `model`
+field resolved from the binding routing table, and a body pointing to
+`.claude/agents/<role>.md`. Extend `scripts/compile-runtime-agents.sh`
+to emit `.gemini/agents/` in the same generation pass that emits
+`.opencode/agents/`. The generated files carry `canonical_sha`
+frontmatter; lint rejects manual edits. `GEMINI.md` encodes the
+two-mode contract (orchestrator as `tech-lead`; delegated-specialist
+suppression), the `@name` override for deterministic dispatch, and the
+version floor. The `description` field in each agent file is authored
+once in the generation template, treated as load-bearing, and reviewed
+alongside the canonical role contract when it changes.
+
+- **Sketch:** `GEMINI.md` (~150 lines, parallel to `AGENTS.md`); 13
+  `.gemini/agents/<role>.md` files (~15 lines each, generated);
+  `compile-runtime-agents.sh` extended (~30 lines); lint extended to
+  cover Gemini adapters. Total new surface: one root file, 13 generated
+  adapters, one script extension. No new schema fields beyond what
+  FW-ADR-0021 already added.
+- **Pros:** Autonomous selection works and is reliable because
+  descriptions are strong and lint-protected. Drift is machine-
+  detected via `canonical_sha`. `GEMINI.md` is the single readable
+  entry point for a Gemini operator — same ergonomic position as
+  `AGENTS.md` for Codex. Delegated-specialist mode is available.
+  Model routing stays in the binding table; no parallel policy.
+  Implementation cost is low because the generation infrastructure
+  already exists.
+- **Cons:** The `description` field in each `.gemini/agents/` file is
+  load-bearing and requires careful authoring at generation time; a
+  weak description silently degrades autonomous selection. Generation
+  adds a step to the release process. Requires gemini-cli >= v0.38.1.
+- **When S wins:** Gemini is a peer harness with full specialist
+  dispatch; autonomous selection is an expected workflow; drift
+  control matters because the roster grows.
+
+### Option C — Creative (experimental)
+
+Replace the per-harness static adapter files with a single dynamic
+`GEMINI.md` that is generated at session-start by a bootstrapper
+script reading `.claude/agents/*.md`, extracting frontmatter, and
+writing a fresh `GEMINI.md` with embedded agent stubs. gemini-cli's
+`@path` import syntax is used to inline the canonical agent contracts
+directly rather than pointing at file paths. No `.gemini/agents/`
+directory is needed; `GEMINI.md` itself becomes the full session
+context.
+
+- **Sketch:** A `scripts/build-gemini-context.sh` runs before each
+  Gemini session, reads all canonical agent files, extracts `name`
+  and `description` fields, and writes `GEMINI.md` with `@path`
+  imports resolved inline. The file is ephemeral (gitignored or
+  regenerated each session). The bootstrapper itself is the single
+  authoritative artifact.
+- **Pros:** Zero drift by construction — every session reads current
+  canonical files. No static adapter files to lint. `@path` import
+  reuse avoids prose duplication. Removes the three-roster problem
+  entirely for the Gemini surface.
+- **Cons:** Requires a bootstrapper script that runs reliably before
+  every Gemini session — a new runtime dependency the framework does
+  not currently impose. If the script is not run (CI environment,
+  new contributor), `GEMINI.md` is absent or stale and the session
+  self-orients from nothing. gemini-cli's `@path` import behavior at
+  session start is not verified to inline arbitrary agent system prompts
+  at the depth needed for the full role contract; this is an
+  untested assumption about a v0.44.0 feature surface. The ephemeral-
+  file pattern conflicts with the repo-is-the-brief model. High risk
+  from an unverified gemini-cli capability assumption.
+- **When C wins:** the team controls the full bootstrapper invocation
+  path (e.g., via a wrapper script checked into the repo that all
+  operators are trained to run); the `@path` inline behavior is
+  verified against a real gemini-cli session; and the framework is
+  willing to add a mandatory pre-session step. None of these hold
+  currently.
+
+## Decision outcome
+
+**Chosen option: S — Scalable**
+
+Option M forfeits the autonomous selection feature that distinguishes
+gemini-cli's subagent surface, forces all dispatch to be explicit, and
+provides no drift protection — failing the "co-equal harness" design
+requirement. Option C rests on an unverified `@path` inline behavior
+assumption and introduces a mandatory pre-session bootstrapper that
+creates a new failure mode (missing or stale `GEMINI.md`) with no
+machine safeguard. Option S maps directly onto the OpenCode pattern
+already proven in production (FW-ADR-0009): generated thin adapters,
+`canonical_sha` protection, and a root adapter file. The only structural
+addition over the OpenCode pattern is the load-bearing `description`
+field and the explicit `@name`-override guidance in `GEMINI.md` to give
+operators a deterministic dispatch path when autonomous selection would
+be ambiguous.
+
+---
+
+## Design: Gemini harness adapter
+
+### 1. GEMINI.md root adapter
+
+`GEMINI.md` is placed at the repository root. gemini-cli auto-loads it
+as the session context file (configurable via `settings.json`
+`context.fileName`; `GEMINI.md` is the default). It is a root
+canonical binding and follows SCREAMING\_SNAKE file-naming per
+`docs/markdown-style.md`.
+
+`GEMINI.md` encodes the following, in order:
+
+**Role binding — two modes.**
+
+*Mode A: main session as `tech-lead`.* When a Gemini session is opened
+on this repository without an active handoff that declares
+`delegated_role`, the session plays `tech-lead` directly. It is the
+sole human interface, owns orchestration, and dispatches specialists.
+Do not invoke the `tech-lead` agent file as a subagent (`@tech-lead`);
+the main session IS `tech-lead`. This rule is identical to the
+Claude Code and Codex constraints (CLAUDE.md § "Tech-lead is the main-
+session persona"; FW-ADR-0008).
+
+*Mode B: delegated-specialist mode.* If the active handoff
+(`docs/handoffs/<task_id>.json` pointed to by `.devteam/active-
+handoff.json`) declares `delegated_role`, adopt that role for the
+duration of the session. Read `.claude/agents/<role>.md` as the role
+contract. Execute the single task named in `task_ref`. Do not spawn
+specialists, do not act as `tech-lead`, do not contact the customer.
+Return completed artifacts and blockers to the orchestrating session.
+This is the same delegated-specialist clause from `AGENTS.md`
+(FW-ADR-0021); the prose is substantively identical, not copied
+verbatim (IP / paraphrase rule, CLAUDE.md Hard Rule #5).
+
+**Grounding reads.** Before substantive work in Mode A, read:
+
+1. `CLAUDE.md`
+2. `.claude/agents/tech-lead.md`
+3. Any `docs/agents/manual/tech-lead-manual.md`, if present
+
+Situational reads follow the same list as `AGENTS.md`: `docs/FIRST_
+ACTIONS.md`, `docs/MEMORY_POLICY.md`, `docs/TEMPLATE_UPGRADE.md`,
+`docs/IP_POLICY.md`, `docs/sme/CONTRACT.md`,
+`docs/framework-project-boundary.md`.
+
+**Dispatch guidance — `@name` override.**
+
+gemini-cli selects subagents autonomously by matching task context
+against each agent's `description` field. For routine work the
+description-matching selection is expected to be correct. When
+deterministic dispatch is required — specialist chaining, security-
+critical work, customer-flagged critical paths, any Hard Rule #4 / #7
+path — use explicit `@<role-slug>` invocation rather than relying on
+autonomous selection. The 13 available role slugs are listed in
+`GEMINI.md`'s agent roster table.
+
+**Binding references.** `GEMINI.md` carries inline citations to:
+`CLAUDE.md` (Hard Rules, escalation protocol, time-based cadences),
+`SW_DEV_ROLE_TAXONOMY.md`, `docs/glossary/ENGINEERING.md`,
+`docs/glossary/PROJECT.md`, and `docs/model-routing-guidelines.md`
+(binding routing table). These are the same binding references that
+`AGENTS.md` carries.
+
+**Paraphrase / IP rule.** Standards text (SWEBOK, IEEE, ISO) must be
+paraphrased, not quoted verbatim. This applies inside Gemini sessions
+as it does on all other harnesses (CLAUDE.md Hard Rule #5).
+
+**Version floor.** gemini-cli >= v0.38.1 required for named subagent
+support. Sessions running on older versions will see no `.gemini/agents/`
+files and should fall back to explicit `@path`-style guidance, with a
+note that full specialist dispatch is unavailable.
+
+### 2. .gemini/agents/ roster
+
+Thirteen `.gemini/agents/<role>.md` files, one per canonical role.
+Generated by `scripts/compile-runtime-agents.sh` in the same pass as
+`.opencode/agents/`. Each file follows the OpenCode thin-adapter shape:
+
+```yaml
+---
+name: <role-slug>
+model: <gemini-equivalent class from routing table>
+canonical_source: .claude/agents/<role>.md
+canonical_sha: <sha of canonical file at generation time>
+generator: scripts/compile-runtime-agents.sh
+generator_version: <script version>
+classification: generated
+---
+```
+
+Body (two lines):
+
+```text
+Read `.claude/agents/<role>.md` (canonical role contract).
+If `local_supplement` resolves to an existing file, read it after
+the canonical file. Act only as that role. Return output in the
+role's required format.
+```
+
+**`description` field — load-bearing, single source.**
+
+Unlike OpenCode (where description quality is cosmetic because operators
+dispatch imperatively), gemini-cli uses `description` for autonomous
+agent selection. The canonical `.claude/agents/<role>.md` `description:`
+frontmatter field is the single source of truth for this value.
+`compile-runtime-agents.sh` reads that field and copies it verbatim into
+the generated `.gemini/agents/<role>.md` frontmatter. No separate
+Gemini-specific description template exists. If a description needs
+sharpening to improve autonomous selection quality, sharpen the canonical
+field — this benefits all harnesses and avoids a forked value. A
+description that is too generic (e.g., "Software development agent")
+will cause silent misrouting and is a `code-reviewer` finding.
+
+Per-role `description` guidance (representative subset):
+
+| Role | Description design intent |
+|---|---|
+| `tech-lead` | Orchestration, routing, customer interface, escalation — NOT selected autonomously; Mode A only |
+| `architect` | ADR authoring, module-boundary decisions, cross-cutting design choices, technology selection |
+| `software-engineer` | Implementation, construction, code authoring — single leaf task at a time |
+| `code-reviewer` | IEEE 1028 audit, drift detection, pre-commit review |
+| `security-engineer` | Auth, secrets, PII, network-exposed endpoints, Hard Rule #7 paths |
+| `researcher` | Tier-1 source lookup, standards citations, prior-art scans |
+| `qa-engineer` | Test design, acceptance criteria, ISTQB-aligned validation |
+| `release-engineer` | Build pipeline, IaC, deployment, rollback, release gating |
+| `sre` | Operations planning, capacity, DR, incident posture, post-incident review |
+| `project-manager` | PMBOK schedule/cost/risk/stakeholder/lessons artifacts |
+| `tech-writer` | Documentation, user-facing prose, style-guide compliance |
+| `onboarding-auditor` | Zero-context documentation audit — one-shot, milestone-close only |
+| `process-auditor` | Cultural-disruptor process audit — one-shot, every 2–3 milestones |
+
+**`model` field mapping.** Each adapter's `model` is set from the
+`gemini_equivalent` column of the binding per-agent default-class table
+in `docs/model-routing-guidelines.md`:
+
+| Agent | `model` in adapter |
+|---|---|
+| `tech-lead`, `architect`, `code-reviewer`, `software-engineer`, `release-engineer`, `qa-engineer`, `tech-writer`, `security-engineer`, `sre`, `researcher`, `onboarding-auditor`, `process-auditor`, `sme-template` | `gemini-pro` |
+| `project-manager` | `gemini-flash` |
+
+Frontier escalation conditions in the routing table remain the
+per-task override trigger; the adapter `model` field is the default.
+
+### 3. Routing model under description-driven selection
+
+gemini-cli's autonomous selection and imperative `@name` invocation are
+both valid dispatch paths. The framework's "one role = one agent" and
+WIP=1 constraints apply to both paths.
+
+**Autonomous selection (routine work).** When `tech-lead` (the main
+session) determines a task belongs to a specialist, it can describe the
+task naturally; gemini-cli matches the description against the 13 agent
+`description` fields and selects the appropriate specialist. This is the
+ergonomic primary path.
+
+**`@name` override (deterministic dispatch).** `tech-lead` MUST use
+explicit `@<role-slug>` invocation for:
+
+- Security-critical work (Hard Rule #7 path: `@security-engineer`).
+- Customer-flagged critical paths (Hard Rule #4: `@security-engineer`,
+  `@architect`, or the named specialist as required).
+- Specialist chaining where the next specialist is determined by a
+  routing table entry, not by task description alone (e.g., chaining
+  `@architect` → `@code-reviewer` → `@release-engineer`).
+- Any case where the task description is generic enough that
+  description-matching might produce ambiguous or wrong selection.
+
+**No implicit `tech-lead` spawn.** gemini-cli's autonomous selection
+must never select the `tech-lead` agent file, because the main session
+IS `tech-lead`. The `tech-lead` agent file body must include a guard:
+if invoked as a subagent, halt and report a harness misconfiguration.
+This mirrors the Codex `AGENTS.md` "do not spawn tech-lead as a
+subagent" constraint.
+
+**Hard Rule #1 and #8 encoding.** `GEMINI.md` carries binding prose
+making explicit that the main Gemini session is `tech-lead`, not a
+general-purpose orchestrator, and that production artifacts route to
+owning specialists. The escalation protocol (check `CUSTOMER_NOTES.md`,
+route through `tech-lead`, one question per turn) applies unchanged.
+
+### 4. Parity and drift control
+
+The roster now exists in three generated surfaces:
+
+| Surface | Generator | Drift detection |
+|---|---|---|
+| `.claude/agents/` | Canonical (not generated) | `schemas/agent-contract.schema.json` + lint |
+| `.opencode/agents/` | `compile-runtime-agents.sh` | `canonical_sha` mismatch |
+| `.gemini/agents/` | `compile-runtime-agents.sh` (extended) | `canonical_sha` mismatch |
+
+Root adapters (`AGENTS.md`, `GEMINI.md`) are hand-authored, not
+generated, because they carry harness-specific orchestration prose
+that cannot be mechanically derived from the canonical agent contracts.
+They are treated as binding framework files; changes require
+`tech-lead` + `code-reviewer` review and a CHANGELOG entry.
+
+**Generation extension.** `scripts/compile-runtime-agents.sh` gains a
+`--target gemini` path (or runs all targets by default) that:
+
+1. Reads each `.claude/agents/<role>.md`.
+2. Computes the `canonical_sha` (SHA-1 of the canonical file).
+3. Resolves the `model` from `docs/model-routing-guidelines.md`'s
+   Gemini-equivalent column.
+4. Copies the `description:` frontmatter field verbatim from the
+   canonical agent file into the generated adapter's frontmatter.
+5. Emits `.gemini/agents/<role>.md` with the standard thin-adapter
+   body.
+
+The `description` field has one home: the canonical
+`.claude/agents/<role>.md` frontmatter. No separate Gemini description
+template is maintained. This is the same single-source pattern as the
+OpenCode generation path.
+
+**Lint extension.** The existing `scripts/lint-agent-contracts.sh`
+(the same script that covers `.opencode/agents/`) is extended to cover
+`.gemini/agents/`. No separate Gemini-only lint script is added. The
+extended script checks:
+
+- Each `.gemini/agents/<role>.md` `canonical_sha` matches the current
+  SHA of the referenced `.claude/agents/<role>.md`. Mismatch is an
+  error (regenerate required).
+- `description` field is present and non-empty.
+- `model` field is a valid class name from
+  `schemas/model-routing.schema.json`.
+
+**Three-surface sync procedure.** When a canonical agent contract
+changes, the releasing agent runs `compile-runtime-agents.sh` (all
+targets) before commit. CI runs lint on all three surfaces. A PR that
+modifies `.claude/agents/<role>.md` without regenerating
+`.opencode/agents/<role>.md` and `.gemini/agents/<role>.md` fails lint.
+
+### 5. Version floor
+
+gemini-cli >= v0.38.1 is required for named subagent support (stable
+from v0.44.0). `GEMINI.md` carries a visible version-floor note at the
+top of the file. The framework scaffold script (`scripts/scaffold.sh`
+or equivalent) adds a gemini-cli version check at setup time.
+
+The `TEMPLATE_UPGRADE.md` migration section for the release that ships
+this ADR notes: "if using gemini-cli, upgrade to >= v0.38.1 before
+running `compile-runtime-agents.sh` with `--target gemini`."
+
+## Consequences
+
+### Positive
+
+- gemini-cli becomes a co-equal harness: full 13-role roster, autonomous
+  dispatch, delegated-specialist mode, model routing, and Hard Rule
+  enforcement, all consistent with Claude Code and Codex.
+- Description-driven selection is reliable because descriptions are
+  sourced from the canonical agent contracts (single source, no fork),
+  copied verbatim by the generator, and lint-protected via
+  `canonical_sha`.
+- Drift across all three adapter surfaces is machine-detected via
+  `canonical_sha`. A single `compile-runtime-agents.sh` run keeps all
+  three surfaces in sync.
+- `GEMINI.md` gives a Gemini operator a single readable entry point
+  with the same ergonomic position as `AGENTS.md` for Codex operators.
+- The delegated-specialist mode (FW-ADR-0021) is available on the
+  Gemini path without any new schema changes.
+- `project-manager` gets `gemini-flash` as its default, matching
+  the routing table and avoiding frontier spend on PM artifact updates.
+
+### Negative / trade-offs accepted
+
+- `description` quality is load-bearing and must be maintained. A
+  description that is too generic silently causes autonomous misrouting;
+  this is a new failure mode with no equivalent in Claude Code or Codex.
+  Mitigated by: the single-source rule (descriptions are in canonical
+  files, not forked), lint checking for non-empty descriptions, and
+  the fact that any improvement to a canonical `description:` field
+  benefits all harnesses simultaneously.
+- `compile-runtime-agents.sh` gains a third output target, which adds
+  a step to the release process and a new CI lint surface. Marginal
+  cost is low because the infrastructure already exists for OpenCode.
+- `GEMINI.md` and `AGENTS.md` are hand-authored and not machine-
+  generated; they can drift from each other in harness-specific
+  sections. Mitigated by: code-reviewer review on all changes, CHANGELOG
+  entry requirement, and cross-reference links in both files.
+- gemini-cli's autonomous selection model means the "WIP=1 /
+  one role = one agent" constraint is advisory on the autonomous path:
+  nothing prevents a Gemini session from invoking two agents in parallel
+  if the task description is ambiguous. `tech-lead` (main session) is
+  responsible for preventing this via explicit `@name` discipline on
+  ordered chains.
+- Requires gemini-cli >= v0.38.1. Projects on older versions get no
+  subagent support from this adapter.
+
+### Follow-up ADRs
+
+- A future ADR may address `token_budget_hint` → Gemini model tier
+  mapping (parallel to the Codex follow-up noted in FW-ADR-0021).
+- If gemini-cli exposes a `max_turns` or `timeout_mins` frontmatter
+  field that maps to the framework's WIP=1 / slot-queue model, a
+  follow-up ADR should pin the binding defaults.
+- If description-matching quality proves insufficient for reliable
+  autonomous selection across all 13 roles, a follow-up may mandate
+  `@name` for all dispatch (reducing gemini-cli to the Codex ergonomic
+  model while retaining the adapter shape).
+
+## Customer rulings ratified 2026-06-02
+
+Both open decision points were ratified by the customer 2026-06-02
+with the directive "make it all match" (how Codex/OpenCode do it).
+The backing customer-truth entry is recorded in `CUSTOMER_NOTES.md`
+(librarian-stewarded, same turn).
+
+**Ruling 1 — `description` source (ratified: canonical field, no fork).**
+The canonical `.claude/agents/<role>.md` `description:` frontmatter
+field is the single source. `compile-runtime-agents.sh` copies it
+verbatim into the generated Gemini adapter. Option A (separate
+`gemini-agent-descriptions.yaml`) and Option B (new `gemini_description`
+frontmatter key on canonical files) are both rejected. If a description
+needs sharpening for Gemini autonomous selection quality, sharpen the
+canonical field — this benefits all harnesses. No Gemini-specific
+description artifact is maintained.
+
+**Ruling 2 — Lint placement (ratified: extend existing script, no new script).**
+The existing `scripts/lint-agent-contracts.sh` — the same script that
+covers `.opencode/agents/` — is extended to cover `.gemini/agents/`.
+No dedicated `scripts/lint-gemini-adapters.sh` is added. The
+downstream-toggle-ability argument for a separate script is set aside
+per the customer's consistency directive.
+
+## Verification
+
+- **Success signal:** A Gemini session on a repo scaffolded from this
+  template reads `GEMINI.md`, self-orients as `tech-lead`, dispatches a
+  specialist via autonomous description-matching, and that specialist
+  reads its canonical `.claude/agents/<role>.md` contract without
+  operator intervention. A handoff with `delegated_role:
+  "software-engineer"` causes a Gemini session to adopt
+  `software-engineer` mode and suppress orchestrator behavior.
+  `compile-runtime-agents.sh --target gemini` regenerates all 13
+  adapter files with correct `canonical_sha` values. CI lint passes on
+  all three adapter surfaces.
+- **Failure signal:** A Gemini session with a correctly formed
+  `GEMINI.md` and `.gemini/agents/` roster autonomously selects the
+  wrong specialist on two or more documented test tasks, indicating that
+  `description` quality is insufficient and the mandatory-`@name` path
+  must be enforced for all dispatch (follow-up ADR). Alternatively, if
+  gemini-cli changes the agent-definition file format or the context-
+  file name in a future release, the adapter shape breaks — triggering
+  a superseding ADR.
+- **Review cadence:** Re-examine at the first MINOR-boundary release
+  after Gemini harness support ships, or after three documented Gemini
+  operator sessions in downstream projects, whichever comes first
+  (session-anchored per CLAUDE.md § "Time-based cadences").
+
+## Links
+
+- FW-ADR-0008 — tech-lead orchestration boundary (orchestrator /
+  specialist split this ADR extends to Gemini):
+  `docs/adr/fw-adr-0008-tech-lead-orchestration-boundary.md`
+- FW-ADR-0009 — OpenCode harness adapter (thin-adapter precedent and
+  four prohibitions this ADR inherits):
+  `docs/adr/fw-adr-0009-opencode-harness-adapter.md`
+- FW-ADR-0021 — harness-agnostic leaf-task dispatch (delegated-
+  specialist mode and `delegated_role` field this ADR adopts):
+  `docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md`
+- Upstream issue #293 — P8 delegated-specialist mode for Codex
+  (the parallel P8 concern this ADR extends to Gemini)
+- Upstream issue #300 — Gemini harness implementation
+- `.opencode/agents/` — thin-adapter precedent files
+- `scripts/compile-runtime-agents.sh` — generation script to extend
+- `docs/model-routing-guidelines.md` — binding per-agent routing table
+  (Gemini-equivalent column)
+- `AGENTS.md` — Codex root adapter (structural parallel to `GEMINI.md`)
+- gemini-cli release notes v0.38.1 and v0.44.0 (Tier-1 source;
+  verified by `researcher`)
+
+## Change log
+
+- 2026-06-03 — customer-truth steward role researcher→librarian per Q-0023; decision principle unchanged.

--- a/docs/adr/fw-adr-0024-parallel-agent-working-tree-isolation.md
+++ b/docs/adr/fw-adr-0024-parallel-agent-working-tree-isolation.md
@@ -335,8 +335,10 @@ binding instruction:
 
 > You are operating in a throwaway worktree at `<path>`. All scaffold
 > file operations must use this path as the root. Do NOT run any git
-> command that modifies shared state: no `git reset`, no `git switch`,
-> no `git stash`, no `git commit`, no `git push`. If your task
+> command that modifies shared state: no `git reset`, `git checkout`,
+> `git switch`, `git stash`, `git clean`, `git commit`, `git merge`,
+> `git rebase`, or `git push`; and no index, branch, or tag mutations
+> (`git add`/`rm`/`mv`, branch/tag create or delete). If your task
 > requires any of those operations, STOP and return to tech-lead with
 > a reclassification request (you are a writer, not a reader, and
 > must use the writer lane).
@@ -467,3 +469,7 @@ Turn N+1:
 - `scripts/worktree-teardown.sh` — reader worktree removal helper
 - `scripts/worktree-health-check.sh` — stale-worktree detection at session start
 - `docs/tests/hermetic-verified.txt` — canonical list of hermetically safe test scripts
+
+## Change log
+
+- 2026-06-03 — §3 reader-prohibition brief expanded from 5 commands to the canonical 9-command set (+ index/branch/tag clause) per issue #326, to match §4 hermetic criteria.

--- a/docs/agents/manual/tech-lead-manual.md
+++ b/docs/agents/manual/tech-lead-manual.md
@@ -411,8 +411,10 @@ reader-lane instruction to include verbatim in every reader brief:
 
 > You are operating in a throwaway worktree at `<path>`. All scaffold
 > file operations must use this path as the root. Do NOT run any git
-> command that modifies shared state: no `git reset`, no `git switch`,
-> no `git stash`, no `git commit`, no `git push`. If your task
+> command that modifies shared state: no `git reset`, `git checkout`,
+> `git switch`, `git stash`, `git clean`, `git commit`, `git merge`,
+> `git rebase`, or `git push`; and no index, branch, or tag mutations
+> (`git add`/`rm`/`mv`, branch/tag create or delete). If your task
 > requires any of those operations, STOP and return a reclassification
 > request — you need the writer lane.
 

--- a/docs/runtime/agents/code-reviewer.md
+++ b/docs/runtime/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: code-reviewer
 description: Code Reviewer and Auditor. Use PROACTIVELY before every commit and after significant changes. Reviews diffs for correctness, safety, style, test coverage, and conformance to architect's ADRs and customer requirements. Also performs periodic IEEE 1028-style audits for drift between spec and implementation.
 model: sonnet
 canonical_source: .claude/agents/code-reviewer.md
-canonical_sha: ba374a3051571e4368975b59eb70d6488fe962c8
+canonical_sha: 60906e1083416d4b0862bbe5b22afcbdd9565259
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/qa-engineer.md
+++ b/docs/runtime/agents/qa-engineer.md
@@ -3,7 +3,7 @@ name: qa-engineer
 description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
 model: sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 7c736e966d7fd6415e745d8bffb7f79622313ae5
+canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/tests/hermetic-verified.txt
+++ b/docs/tests/hermetic-verified.txt
@@ -10,7 +10,7 @@
 # ALL of the following criteria (fw-adr-0024 §4):
 #
 #   1. It does not call: git reset, git clean, git stash, git switch,
-#      git checkout, git commit, git merge, or git rebase.
+#      git checkout, git commit, git merge, git rebase, or git push.
 #   2. It does not write to the git index (git add, git rm, git mv).
 #   3. It does not create or delete branches or tags.
 #   4. All temporary files it creates are in $TMPDIR or within the


### PR DESCRIPTION
Two follow-up cleanups from this session's worktree-isolation + ADR-migration work.

## A) #326 — reconcile reader-lane git-prohibition list
The reader prohibition was 5 commands in the brief/prose but 8 in the §4 hermetic criteria. Now one canonical **9-command** list everywhere: `git reset, checkout, switch, stash, clean, commit, merge, rebase, push` + "no index/branch/tag mutations." Applied to fw-adr-0024 §3, CLAUDE.md HR-12, tech-lead-manual reader-protocol, and the **code-reviewer + qa-engineer** contracts (the two roles that name the list; software-engineer/release-engineer are Writers and correctly don't). `hermetic-verified.txt` §4 gains `git push`. Mirrors regenerated for the 2 contracts. fw-adr-0024 gains a §3-expansion change-log entry. Closes #326.

## B) ADR index catch-up
fw-adr-0021 (leaf-task dispatch; implemented #293) and fw-adr-0022 (Gemini harness; implemented #300) were implemented this session but never migrated into the scaffold's `docs/adr/`. Now migrated — with placement notes, status reflecting implementation, a `researcher→librarian` custody corrigendum + change logs (matching the fw-adr-0008/0023/0024 pattern), investigation refs preserved. `docs/INDEX-FRAMEWORK.md`'s ADR table rebuilt from 0001-0007 → the full **0001-0024** (contiguous, 24 rows ↔ 24 files).

## Verification
- agent-contract (`lint-agent-contracts`) 0/0 · compile `--verify` 16/16 · lint-routing 0/0
- 9-command list verified word-identical across all 5 homes; 24 ADRs ↔ 24 index rows
- code-reviewer: **APPROVED** (2 nits raised & fixed: git push in §4, fw-adr-0024 change-log)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded ADR index from 7 to 24 entries with updated descriptions.
  * Added three new Architecture Decision Records: harness-agnostic task dispatch (FW-ADR-0021), Gemini harness adapter integration (FW-ADR-0022), and parallel agent working-tree isolation (FW-ADR-0024).
  * Strengthened reader-mode git operation restrictions with broader prohibited command list across all agent configurations.
  * Updated hermeticity verification criteria and tech-lead manual with clarified working-tree mutation rules.

* **Chores**
  * Updated configuration metadata references across agent adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->