### PR TITLE
Bounded specialist long-ops + Gemini bg-default (#287, #265)

### DIFF
--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -173,6 +173,7 @@ customer sign-off.
 - **HR-6** Enforce adversarial stance, Solution Duel rounds, and the below-threshold-task carve-outs from the manual at review time; unaddressed Duel findings block code start.
 - **HR-7** Security testing is co-owned with `security-engineer` and follows `docs/templates/security-template.md` §5, not the `qa/` templates.
 - **HR-8** Production-behavior testing (load, capacity, soak) routes to `sre`; audit-style conformance routes to `code-reviewer`; do not absorb that scope.
+- **HR-9** Long test suites (system, acceptance, soak, regression passes) expected to exceed ~60 s must be structured as bounded stages per `.claude/agents/tech-lead.md` § "Token economy" rule 7. Return a Deferred-wait report immediately when a suite is still running and context budget is near its limit; do not poll in a loop. Tech-lead re-dispatches via SendMessage-warm or ScheduleWakeup. See `docs/agents/manual/tech-lead-manual.md` § "Long-operation worked example" for the format.
 
 ## Hand-offs (escalate through tech-lead; never contact customer)
 

--- a/.claude/agents/release-engineer.md
+++ b/.claude/agents/release-engineer.md
@@ -74,6 +74,20 @@ observation that industry collapses these in most shops.
   `docs/pm/pre-release-gate-overrides.md`; cite the reason in
   `PRE_RELEASE_GATE_REASON` so the audit row is informative.
 
+## Long-running operations
+
+`pre-release-gate.sh`, dogfood harness runs, and soak/smoke pipelines
+routinely exceed 60 s. Per `.claude/agents/tech-lead.md` § "Token economy"
+rule 7: structure
+each long stage as a bounded dispatch. When the gate or pipeline is
+still running as context approaches its budget limit, return immediately
+with a Deferred-wait report (fields: `Deferred-wait:` / `Condition:` /
+`Resume-after:` / `Work done so far:` / `Resumable from:`). Do not
+embed an unbounded poll or sleep loop in a brief. Tech-lead owns the
+re-dispatch decision (SendMessage-warm or ScheduleWakeup). See
+`docs/agents/manual/tech-lead-manual.md` § "Long-operation worked
+example" for the release-cut stage table.
+
 ## Working-tree isolation
 
 `release-engineer` is always a **Writer** (FW-ADR-0024 / `CLAUDE.md`

--- a/.claude/agents/software-engineer.md
+++ b/.claude/agents/software-engineer.md
@@ -77,6 +77,20 @@ On tasks whose trigger annotation fires any clause per
 - Do not start code on a triggered task until the proposal's Duel
   section is closed.
 
+## Long-running operations
+
+Build-and-test chains (compilation + full test suite, CI dry-runs,
+integration harnesses) frequently exceed 60 s. Per Token economy
+rule 7 (`.claude/agents/tech-lead.md` § "Token economy" rule 7):
+structure each long stage as a bounded dispatch. When a build
+or test chain is still running as context approaches its budget limit,
+return immediately with a Deferred-wait report (fields:
+`Deferred-wait:` / `Condition:` / `Resume-after:` / `Work done so
+far:` / `Resumable from:`). Do not embed an unbounded poll or sleep
+loop in a brief. Tech-lead re-dispatches via SendMessage-warm or
+ScheduleWakeup. See `docs/agents/manual/tech-lead-manual.md`
+§ "Long-operation worked example" for the format.
+
 ## Working-tree isolation
 
 `software-engineer` is always a **Writer** (FW-ADR-0024 / `CLAUDE.md`

--- a/.claude/agents/sre.md
+++ b/.claude/agents/sre.md
@@ -65,6 +65,15 @@ model: sonnet
   supplier management for IaaS / PaaS / SaaS, monitoring,
   alerting, SLO reporting, incident posture, and post-incident
   review feeding `docs/pm/LESSONS.md`.
+- **HR-2** Capacity runs, DR rehearsals, and soak tests expected to
+  exceed ~60 s must be structured as bounded stages per Token economy
+  rule 7 (`.claude/agents/tech-lead.md` § "Token economy" rule 7).
+  Return a Deferred-wait report immediately when a long-running
+  operation is still in progress and context budget is near its limit;
+  do not embed an unbounded poll or sleep loop in a brief. Tech-lead
+  re-dispatches via SendMessage-warm or ScheduleWakeup. See
+  `docs/agents/manual/tech-lead-manual.md` § "Long-operation worked
+  example" for the Deferred-wait format.
 
 ## Hand-offs (escalate through tech-lead; never contact customer)
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -148,6 +148,32 @@ non-compliant brief MUST flag the violation before proceeding.
    before dispatching the next task to that slot.
 6. **Atomic commits.** One logical change per commit. MUST NOT bundle
    unrelated edits into a single commit.
+7. **Bounded long-op dispatch.** Briefs for shell operations expected
+   to exceed ~60 s MUST be structured as bounded stages. No stage
+   may contain an unbounded poll or sleep loop. When a stage's
+   completion signal is not yet available, the specialist returns
+   IMMEDIATELY with a structured **Deferred-wait report**:
+
+   ```
+   Deferred-wait: <what is in flight>
+   Condition:     <what signals completion>
+   Resume-after:  <estimated wait>
+   Work done so far: <summary>
+   Resumable from:   <state or file the next dispatch can pick up>
+   ```
+
+   Tech-lead owns re-dispatch using one of two paths:
+   - **SendMessage-warm** — keep the specialist alive; message it
+     when the condition fires. Prefer when the wait is short and
+     context is still warm (soft guidance: roughly ≤15 min, but
+     adjust to the task — this is not a hard constant).
+   - **ScheduleWakeup / re-dispatch** — schedule a wakeup at the
+     deadline and re-dispatch the role with the `Resumable from:`
+     state. Prefer for longer waits or after the specialist closed.
+
+   Full worked example (release-cut stages):
+   `docs/agents/manual/tech-lead-manual.md` § "Long-operation
+   worked example".
 
 **Anti-patterns — Scrum practices that do NOT transfer to multi-agent
 work.**

--- a/.gemini/agents/qa-engineer.md
+++ b/.gemini/agents/qa-engineer.md
@@ -3,7 +3,7 @@ name: qa-engineer
 description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
 model: gemini-pro
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
+canonical_sha: f1383ab993983a2fb534435263611ba41ed36fd8
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.gemini/agents/release-engineer.md
+++ b/.gemini/agents/release-engineer.md
@@ -3,7 +3,7 @@ name: release-engineer
 description: Build and Release Engineer. Use for build-pipeline work, dependency and toolchain management, packaging, tagging, changelog generation, deployment orchestration, and reproducibility of historical builds. Collapses the build-engineer / release-engineer / DevOps-engineer roles per modern practice.
 model: gemini-pro
 canonical_source: .claude/agents/release-engineer.md
-canonical_sha: 05d066a65cf6c7035463a91956c16b44f56b58e2
+canonical_sha: f2ceaeef70e0665a4e115ae974614a2233f68834
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.gemini/agents/software-engineer.md
+++ b/.gemini/agents/software-engineer.md
@@ -3,7 +3,7 @@ name: software-engineer
 description: Software Engineer / implementer. Use for writing production code, unit tests, bug fixes, small refactors, and integration work. Executes on a specification provided by tech-lead or architect; does not decide what to build.
 model: gemini-pro
 canonical_source: .claude/agents/software-engineer.md
-canonical_sha: 2340d72f7e87f653ae657314f31ddbc095a00443
+canonical_sha: f3b59d0390cc3e350f70623c1e63d111aadf3f33
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.gemini/agents/sre.md
+++ b/.gemini/agents/sre.md
@@ -3,7 +3,7 @@ name: sre
 description: Site Reliability Engineer and Performance Engineer. Use for production behavior, reliability, performance, capacity planning, SLO definition, incident response, and performance profiling / tuning. Not for pre-release correctness testing (qa-engineer).
 model: gemini-pro
 canonical_source: .claude/agents/sre.md
-canonical_sha: 82415087c7a9d0d5538ba5d71b85e581514a25a2
+canonical_sha: 5200a012925cd7e74f3095cd5622ee1e1839735f
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.gemini/agents/tech-lead.md
+++ b/.gemini/agents/tech-lead.md
@@ -3,7 +3,7 @@ name: tech-lead
 description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
 model: gemini-pro
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 3953fdb42132443a3d8e6a0e8a3e21e80282de65
+canonical_sha: 50a5dad66420e5556ce40f54c7d87969ed660f4b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/qa-engineer.md
+++ b/.opencode/agents/qa-engineer.md
@@ -2,7 +2,7 @@
 name: qa-engineer
 model: claude-sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
+canonical_sha: f1383ab993983a2fb534435263611ba41ed36fd8
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/release-engineer.md
+++ b/.opencode/agents/release-engineer.md
@@ -2,7 +2,7 @@
 name: release-engineer
 model: openai-coding
 canonical_source: .claude/agents/release-engineer.md
-canonical_sha: 05d066a65cf6c7035463a91956c16b44f56b58e2
+canonical_sha: f2ceaeef70e0665a4e115ae974614a2233f68834
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/software-engineer.md
+++ b/.opencode/agents/software-engineer.md
@@ -2,7 +2,7 @@
 name: software-engineer
 model: openai-coding
 canonical_source: .claude/agents/software-engineer.md
-canonical_sha: 2340d72f7e87f653ae657314f31ddbc095a00443
+canonical_sha: f3b59d0390cc3e350f70623c1e63d111aadf3f33
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/sre.md
+++ b/.opencode/agents/sre.md
@@ -2,7 +2,7 @@
 name: sre
 model: claude-sonnet
 canonical_source: .claude/agents/sre.md
-canonical_sha: 82415087c7a9d0d5538ba5d71b85e581514a25a2
+canonical_sha: 5200a012925cd7e74f3095cd5622ee1e1839735f
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/.opencode/agents/tech-lead.md
+++ b/.opencode/agents/tech-lead.md
@@ -2,7 +2,7 @@
 name: tech-lead
 model: claude-sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 3953fdb42132443a3d8e6a0e8a3e21e80282de65
+canonical_sha: 50a5dad66420e5556ce40f54c7d87969ed660f4b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,6 +93,28 @@ The main session must never autonomously select `@tech-lead`; doing so would
 spawn it as a subagent, which is a harness misconfiguration. `tech-lead` is
 Mode A only — it is the main session, not a dispatchable specialist.
 
+## Background-by-default dispatch (Mode A)
+
+Dispatch subagents asynchronously by default so the customer chat stays
+interactive while specialists work. Foreground (blocking) dispatch is
+allowed only when the specialist's return value is needed before the
+next customer-facing reply — for example, a quick lookup whose answer
+feeds the very next line.
+
+When multiple independent specialists are ready to dispatch, send them
+in one turn as separate async calls rather than serializing them. Two
+specialists whose inputs are already on disk or in the brief need not
+wait for each other.
+
+If the gemini-cli version in use does not expose asynchronous subagent
+dispatch, record "async dispatch unavailable in this gemini-cli version"
+in the Turn Ledger and proceed synchronously — this is a harness
+limitation, not a protocol violation. Upgrade to >= v0.38.1 (stable
+v0.44.0) to restore async capability.
+
+This mirrors the intent of `AGENTS.md` Rule F and `.claude/agents/tech-lead.md`
+§ "Background-by-default (binding)" for the Gemini harness.
+
 ## Agent Roster
 
 All 16 canonical roles are available. Role slugs match `.claude/agents/`

--- a/docs/agents/manual/tech-lead-manual.md
+++ b/docs/agents/manual/tech-lead-manual.md
@@ -219,6 +219,50 @@ findings, blockers, and escalations to `tech-lead` instead.
 Closing completed, failed, or no-longer-needed specialists is routine
 slot hygiene; see `docs/agent-health-contract.md`.
 
+### Long-operation worked example
+
+Release-cut is the canonical long-op case. Four stages; each stage
+that exceeds ~60 s gets its own dispatch. Tech-lead never merges two
+long stages into one brief.
+
+| Stage | Role | Expected duration | Dispatch shape |
+|---|---|---|---|
+| 1. VERSION bump + changelog | `release-engineer` | < 1 min | Bounded: single commit, returns diff |
+| 2. Pre-release gate (`scripts/pre-release-gate.sh`) | `release-engineer` | 10+ min | Deferred-wait on first dispatch; tech-lead re-dispatches with `Resumable from: gate-log path` when PASS/FAIL signal arrives |
+| 3. Dogfood upgrade harness | `release-engineer` | Variable; non-hermetic → writer lane | Deferred-wait if harness outruns context; re-dispatch with `Resumable from: last-passing step` |
+| 4. Tag + push | `release-engineer` | < 1 min | Bounded: returns tag SHA and push confirmation |
+
+**How tech-lead handles Stage 2.**
+
+1. Dispatch `release-engineer` with a bounded brief: "run
+   `scripts/pre-release-gate.sh`; return immediately with a
+   Deferred-wait report if it is still running when your context
+   budget reaches 80%."
+2. Specialist returns:
+   ```
+   Deferred-wait: pre-release-gate.sh still executing
+   Condition:     process exits (PASS or FAIL)
+   Resume-after:  ~8 min
+   Work done so far: sub-gates 1–3 passed; sub-gate 4 running
+   Resumable from: docs/pm/pre-release-gate-overrides.md + gate-log
+   ```
+3. Tech-lead chooses a path:
+   - **SendMessage-warm** (wait ≤ 15 min, specialist still alive):
+     message the specialist when the gate process exits; specialist
+     resumes from the Deferred-wait state.
+   - **ScheduleWakeup / re-dispatch** (wait longer or specialist
+     closed): schedule a wakeup at Resume-after; re-dispatch
+     `release-engineer` with `Resumable from:` as the brief's
+     starting context.
+4. On re-dispatch, specialist reads the gate-log, verifies outcome,
+   and proceeds to Stage 3 or reports failure — no re-running of
+   already-passed sub-gates.
+
+The ~15 min warm/respawn boundary is soft guidance, not a hard
+constant. Adjust to the task: a 5 min wait with a context-heavy
+specialist favors SendMessage-warm; a 20 min wait with a lightweight
+brief favors ScheduleWakeup.
+
 ### Background vs foreground + status-narration ban
 
 Canonical home for the background-by-default dispatch rule and the

--- a/docs/runtime/agents/qa-engineer.md
+++ b/docs/runtime/agents/qa-engineer.md
@@ -3,7 +3,7 @@ name: qa-engineer
 description: QA / Test Engineer. Use for test strategy, test design beyond unit tests (integration, system, acceptance), defect isolation, regression-test maintenance, and quality-metrics definition. Not for unit tests written alongside production code — those belong to software-engineer.
 model: sonnet
 canonical_source: .claude/agents/qa-engineer.md
-canonical_sha: 9340daf14de9803cc1442295cb71b0388820e562
+canonical_sha: f1383ab993983a2fb534435263611ba41ed36fd8
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated
@@ -173,6 +173,7 @@ customer sign-off.
 - **HR-6** Enforce adversarial stance, Solution Duel rounds, and the below-threshold-task carve-outs from the manual at review time; unaddressed Duel findings block code start.
 - **HR-7** Security testing is co-owned with `security-engineer` and follows `docs/templates/security-template.md` §5, not the `qa/` templates.
 - **HR-8** Production-behavior testing (load, capacity, soak) routes to `sre`; audit-style conformance routes to `code-reviewer`; do not absorb that scope.
+- **HR-9** Long test suites (system, acceptance, soak, regression passes) expected to exceed ~60 s must be structured as bounded stages per `.claude/agents/tech-lead.md` § "Token economy" rule 7. Return a Deferred-wait report immediately when a suite is still running and context budget is near its limit; do not poll in a loop. Tech-lead re-dispatches via SendMessage-warm or ScheduleWakeup. See `docs/agents/manual/tech-lead-manual.md` § "Long-operation worked example" for the format.
 
 ## Hand-offs (escalate through tech-lead; never contact customer)
 

--- a/docs/runtime/agents/release-engineer.md
+++ b/docs/runtime/agents/release-engineer.md
@@ -3,7 +3,7 @@ name: release-engineer
 description: Build and Release Engineer. Use for build-pipeline work, dependency and toolchain management, packaging, tagging, changelog generation, deployment orchestration, and reproducibility of historical builds. Collapses the build-engineer / release-engineer / DevOps-engineer roles per modern practice.
 model: sonnet
 canonical_source: .claude/agents/release-engineer.md
-canonical_sha: 05d066a65cf6c7035463a91956c16b44f56b58e2
+canonical_sha: f2ceaeef70e0665a4e115ae974614a2233f68834
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/software-engineer.md
+++ b/docs/runtime/agents/software-engineer.md
@@ -3,7 +3,7 @@ name: software-engineer
 description: Software Engineer / implementer. Use for writing production code, unit tests, bug fixes, small refactors, and integration work. Executes on a specification provided by tech-lead or architect; does not decide what to build.
 model: sonnet
 canonical_source: .claude/agents/software-engineer.md
-canonical_sha: 2340d72f7e87f653ae657314f31ddbc095a00443
+canonical_sha: f3b59d0390cc3e350f70623c1e63d111aadf3f33
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated

--- a/docs/runtime/agents/sre.md
+++ b/docs/runtime/agents/sre.md
@@ -3,7 +3,7 @@ name: sre
 description: Site Reliability Engineer and Performance Engineer. Use for production behavior, reliability, performance, capacity planning, SLO definition, incident response, and performance profiling / tuning. Not for pre-release correctness testing (qa-engineer).
 model: sonnet
 canonical_source: .claude/agents/sre.md
-canonical_sha: 82415087c7a9d0d5538ba5d71b85e581514a25a2
+canonical_sha: 5200a012925cd7e74f3095cd5622ee1e1839735f
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated
@@ -59,6 +59,15 @@ classification: generated
   supplier management for IaaS / PaaS / SaaS, monitoring,
   alerting, SLO reporting, incident posture, and post-incident
   review feeding `docs/pm/LESSONS.md`.
+- **HR-2** Capacity runs, DR rehearsals, and soak tests expected to
+  exceed ~60 s must be structured as bounded stages per Token economy
+  rule 7 (`.claude/agents/tech-lead.md` § "Token economy" rule 7).
+  Return a Deferred-wait report immediately when a long-running
+  operation is still in progress and context budget is near its limit;
+  do not embed an unbounded poll or sleep loop in a brief. Tech-lead
+  re-dispatches via SendMessage-warm or ScheduleWakeup. See
+  `docs/agents/manual/tech-lead-manual.md` § "Long-operation worked
+  example" for the Deferred-wait format.
 
 ## Hand-offs (escalate through tech-lead; never contact customer)
 

--- a/docs/runtime/agents/tech-lead.md
+++ b/docs/runtime/agents/tech-lead.md
@@ -3,7 +3,7 @@ name: tech-lead
 description: Tech Lead, project orchestrator, and the ONLY agent that talks to the human user. Use PROACTIVELY at the start of any multi-step task. Decomposes work, routes subtasks, handles escalations from other subagents, and decides when a question must go to the human. All other agents route their questions back through you.
 model: sonnet
 canonical_source: .claude/agents/tech-lead.md
-canonical_sha: 3953fdb42132443a3d8e6a0e8a3e21e80282de65
+canonical_sha: 50a5dad66420e5556ce40f54c7d87969ed660f4b
 generator: scripts/compile-runtime-agents.sh
 generator_version: 0.2.0
 classification: generated


### PR DESCRIPTION
Implements **#287** (Q-0026 customer ruling — specialists must not run unbounded poll-loops) and **#265** (background-dispatch default), per architect change-set. Doc/contract-only.

## #287 — bounded long-op dispatch
- **tech-lead.md § "Token economy"** — new rule: shell ops expected to exceed ~60s run as **bounded stages**; a specialist returns a structured **Deferred-wait report** (in-flight / condition / resume-after / work-done / resumable-from) instead of an inline poll/sleep loop. Tech-lead owns re-dispatch via **SendMessage-warm** (short wait, context still warm — ~15min as *soft, adjustable* guidance) or **ScheduleWakeup** (longer waits / closed specialist).
- **tech-lead-manual.md** — "Long-operation worked example": the release-cut 4-stage table (pre-release-gate.sh is the long Deferred-wait stage; tech-lead re-dispatches on PASS/FAIL).
- **4 long-op specialist contracts** (release-engineer, qa-engineer, sre, software-engineer) get a Long-running-ops constraint pointing to the tech-lead rule. Reader roles (code-reviewer, security-engineer, etc.) excluded — they don't run long shell ops.

## #265 — background-dispatch default
- Already present in **tech-lead.md** (`Background-by-default (binding)`) and **AGENTS.md** (Rule F) — no change.
- **GEMINI.md** gains the parity "Background-by-default dispatch (Mode A)" section with a gemini-cli async-fallback caveat.

## Verification
- agent-contract 0/0 · compile `--verify` 16/16 (5 contracts × 3 mirrors regenerated) · lint-routing 0/0
- code-reviewer: **APPROVED** after one fix (4 contracts wrongly cited CLAUDE.md for the rule → corrected to tech-lead.md § "Token economy" rule 7)

## Notes
- No CLAUDE.md Hard Rule added (architect: this is a dispatch-discipline rule, not a Hard Rule — avoids rule inflation; CLAUDE.md stays at 12).
- The warm-vs-respawn ~15min threshold is intentionally soft guidance, not a hard constant (tunable per harness cost profile).

Closes #287
Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced procedures for handling long-running operations (test suites, releases, maintenance) with new deferred-wait reporting to support resumable workflows.
  * Added comprehensive worked examples for managing multi-stage operations.

* **Chores**
  * Updated agent contract metadata across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->