### PR TITLE
Small backlog fixes: PID-temp hardening (#319), taxonomy session-load (#273), agent-panel redirect (#264)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,24 @@ IDs or nicknames, those are internal handles; use the mapped teammate
 name, or the canonical role when unmapped, in customer-facing text and
 durable records.
 
+**Agent-panel direct-contact rules (issue #264).**
+
+- **Subagents must not act on agent-panel user input.** The panel is a
+  status surface, not a customer-input channel. If the user addresses a
+  subagent directly in the panel, the subagent replies: "Please send all
+  input to the main Claude Code session (tech-lead), not the agent panel."
+  It then waits; it does not perform work based on that input. This
+  preserves the sole-human-interface rule (Hard Rule #1).
+- **Pasted content arrives as unreadable placeholders.** Content pasted
+  directly into the agent panel appears to the subagent as
+  `[Pasted text #N]` — the text is not accessible. The user must relay
+  such content through the main session (e.g., via SendMessage from
+  `tech-lead` to the specialist).
+
+The standing redirect instruction is included verbatim in every dispatch
+brief via `docs/templates/dispatch-template.md` § "Agent-panel contact
+redirect".
+
 ## Tech-lead is the main-session persona (binding)
 
 **The main harness session IS `tech-lead`.** In Claude Code this means

--- a/docs/templates/dispatch-template.md
+++ b/docs/templates/dispatch-template.md
@@ -119,3 +119,14 @@ What the specialist returns to `tech-lead` on completion:
 - [ ] Any discovered framework gaps to queue in `docs/ISSUE_FILING.md`
 - [ ] Any open question that blocked or narrowed scope, for `docs/OPEN_QUESTIONS.md`
 - [ ] Token budget band consumed (for PM ledger if threshold met)
+
+---
+
+## Agent-panel contact redirect (standing instruction — include verbatim in every dispatch)
+
+If the user addresses you directly in the agent panel, reply with:
+"Please send all input to the main Claude Code session (tech-lead), not
+the agent panel." Then wait; do not act on agent-panel user input. Note
+also: pasted content arriving in the agent panel appears as
+`[Pasted text #N]` placeholders that this context cannot read — the
+user must relay such content through the main session via SendMessage.

--- a/scripts/hooks/post-compact-refresh.sh
+++ b/scripts/hooks/post-compact-refresh.sh
@@ -3,7 +3,7 @@
 # Copyright 2026 occamsshavingkit/sw-dev-team-template contributors
 #
 # scripts/hooks/post-compact-refresh.sh — SessionStart:compact hook that
-# directs Claude to re-read three live working-state files after context
+# directs Claude to re-read four live working-state files after context
 # auto-compaction. The auto-compaction summary may have abstracted away
 # binding rules (CLAUDE.md Hard Rules), recent customer rulings
 # (CUSTOMER_NOTES.md), or queued customer questions
@@ -20,13 +20,14 @@ cat <<EOF
 POST-COMPACTION REFRESH
 
 Context compaction just occurred. Before continuing the session, Read
-the following three files to restore live working state (the
-auto-compaction summary may have abstracted away binding rules,
-recent customer rulings, or queued questions):
+the following files to restore live working state (the auto-compaction
+summary may have abstracted away binding rules, recent customer rulings,
+queued questions, or the canonical role vocabulary):
 
   1. ${CLAUDE_PROJECT_DIR}/CLAUDE.md
   2. ${CLAUDE_PROJECT_DIR}/docs/OPEN_QUESTIONS.md
   3. ${CLAUDE_PROJECT_DIR}/CUSTOMER_NOTES.md
+  4. ${CLAUDE_PROJECT_DIR}/SW_DEV_ROLE_TAXONOMY.md
 
 Skip files that don't exist. Re-read happens at the start of the next
 turn, before answering the user or dispatching agents.

--- a/scripts/hooks/role-routing-reminder.sh
+++ b/scripts/hooks/role-routing-reminder.sh
@@ -26,5 +26,10 @@ entries) and tool-bridge work a specialist cannot perform in its
 sandbox. When unsure, dispatch.
 
 Before authoring: classify the artifact (code / ADR / CHANGELOG / customer-notes / etc.), identify the owning specialist from the roster, dispatch. The `tech-lead-authoring-guard` PreToolUse hook (FW-ADR-0012) will block writes to paths outside the orchestration allow-list. The `Routed-Through:` commit trailer + `scripts/lint-routing.sh` audit (FW-ADR-0011) remain as defense-in-depth — they don't block, they record.
+
+ROLE VOCABULARY — Read SW_DEV_ROLE_TAXONOMY.md before drafting role
+briefs. It is the binding role vocabulary (CLAUDE.md § "Binding
+references"). §3 heatmap and §5 gaps document real overlaps; do not
+claim "industry agrees" on topics it flags as debated.
 ==========================================================================
 EOF

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -128,8 +128,9 @@ ensure_prestaged_required_libs() {
     lib_name="$(basename "$upstream_lib")"
     local_lib="$script_dir/lib/$lib_name"
     if [[ ! -f "$local_lib" && -f "$upstream_lib" ]]; then
-      cp "$upstream_lib" "$local_lib.tmp.$$"
-      mv "$local_lib.tmp.$$" "$local_lib"
+      _lib_tmp="$(mktemp "${local_lib}.tmp.XXXXXX")"
+      cp "$upstream_lib" "$_lib_tmp"
+      mv "$_lib_tmp" "$local_lib"
     fi
   done
 }
@@ -866,8 +867,9 @@ if [[ "${SWDT_BOOTSTRAPPED:-}" != "1" ]]; then
       else
         install_mode=0644
       fi
-      install -m "$install_mode" "$new_file" "$proj_file.tmp.$$"
-      mv "$proj_file.tmp.$$" "$proj_file"
+      _pbs_tmp="$(mktemp "${proj_file}.tmp.XXXXXX")"
+      install -m "$install_mode" "$new_file" "$_pbs_tmp"
+      mv "$_pbs_tmp" "$proj_file"
     done
     # A successful pre-bootstrap clears any stale block artefact (idempotency).
     rm -f "$prebootstrap_block_artefact"
@@ -963,12 +965,13 @@ if [[ "$local_version" == "$new_version" ]]; then
       if [[ -n "$new_sha" && -n "$local_sha" && "$local_sha" != "$new_sha" ]]; then
         echo "WARN: TEMPLATE_VERSION stamp SHA drift detected: local=$local_sha_short upstream=$new_sha_short for version $local_version" >&2
         if [[ $dry_run -eq 0 ]]; then
-          cat > "$tv.tmp.$$" <<EOF
+          _tv_tmp="$(mktemp "${tv}.tmp.XXXXXX")"
+          cat > "$_tv_tmp" <<EOF
 $local_version
 $new_sha
 $(date -u +%Y-%m-%d)
 EOF
-          mv "$tv.tmp.$$" "$tv"
+          mv "$_tv_tmp" "$tv"
           echo "       TEMPLATE_VERSION SHA line refreshed to $new_sha_short (issue #138)." >&2
         else
           echo "       (dry-run: would refresh TEMPLATE_VERSION SHA line to $new_sha_short) (issue #138)" >&2
@@ -1419,7 +1422,8 @@ memory_only_agents_stub() {
 install_agents_adapter_over_memory_stub() {
   local src="$1"
   local dst="$2"
-  local tmp="$dst.tmp.$$"
+  local tmp
+  tmp="$(mktemp "${dst}.tmp.XXXXXX")"
   awk '
     /^<claude-mem-context>$/ { skip=1; next }
     /^<\/claude-mem-context>$/ { skip=0; next }
@@ -1448,8 +1452,10 @@ install_agents_adapter_over_memory_stub() {
 atomic_install() {
   local src="$1"
   local dst="$2"
-  cp "$src" "$dst.tmp.$$"
-  mv "$dst.tmp.$$" "$dst"
+  local _ai_tmp
+  _ai_tmp="$(mktemp "${dst}.tmp.XXXXXX")"
+  cp "$src" "$_ai_tmp"
+  mv "$_ai_tmp" "$dst"
 }
 
 # Issue #262: trivial SPDX-only delta auto-merge helper.
@@ -1988,8 +1994,9 @@ if [[ -f "$intake_template" && ! -f "$intake_target" ]]; then
     mkdir -p "$project_root/docs"
     # Derive a project name for the substitution: basename of project root.
     proj_name="$(basename "$project_root")"
-    sed "s|<project name>|$proj_name|g" "$intake_template" > "$intake_target.tmp.$$"
-    mv "$intake_target.tmp.$$" "$intake_target"
+    _intake_tmp="$(mktemp "${intake_target}.tmp.XXXXXX")"
+    sed "s|<project name>|$proj_name|g" "$intake_template" > "$_intake_tmp"
+    mv "$_intake_tmp" "$intake_target"
   fi
   added+=("docs/intake-log.md")
 fi
@@ -2016,7 +2023,8 @@ roadmap_target="$project_root/ROADMAP.md"
 if [[ ! -f "$roadmap_target" ]]; then
   if [[ $dry_run -eq 0 ]]; then
     proj_name_rm="$(basename "$project_root")"
-    cat > "$roadmap_target.tmp.$$" <<EOF
+    _roadmap_tmp="$(mktemp "${roadmap_target}.tmp.XXXXXX")"
+    cat > "$_roadmap_tmp" <<EOF
 # Roadmap — $proj_name_rm
 
 Project roadmap — owned by \`project-manager\`; entries map to
@@ -2027,7 +2035,7 @@ upstream \`sw-dev-team-template\` roadmap; that one lives in the template
 repo and is intentionally not shipped to downstream scaffolds (FR-015 /
 M4.2).
 EOF
-    mv "$roadmap_target.tmp.$$" "$roadmap_target"
+    mv "$_roadmap_tmp" "$roadmap_target"
   fi
   added+=("ROADMAP.md")
 fi


### PR DESCRIPTION
Three small, independent backlog fixes (triaged from the open-issue list; #275 was already resolved and closed separately).

## #319 — temp-file hardening
The 7 remaining `.tmp.$$` PID-suffix temp writes in `scripts/upgrade.sh` (CWE-377; the #305 sweep missed these) converted to `mktemp "...XXXXXX"`, matching the established pattern — `atomic_install`, prestaged-lib copy, VERSION/SHA refresh, intake-log sed, ROADMAP heredoc, prebootstrap install, adapter-install. No `.$$` patterns remain.

## #273 — taxonomy at session start
`SW_DEV_ROLE_TAXONOMY.md` (binding role vocabulary per CLAUDE.md § "Binding references") was not surfaced at session start, so tech-lead ad-libbed role boundaries. Now: added to the post-compact rehydration list (`post-compact-refresh.sh`) and a ROLE VOCABULARY pointer in the SessionStart banner (`role-routing-reminder.sh`).

## #264 — agent-panel direct-contact redirect
With the agent-teams panel, a user can accidentally talk to a subagent instead of tech-lead (breaking HR-1; pasted content arrives as unreadable `[Pasted text #N]` placeholders). Standing redirect instruction added to `docs/templates/dispatch-template.md` (carried by every dispatch) + a note in `CLAUDE.md` § "Agent-teams panel". Not duplicated into the 16 agent contracts (propagates via the template; avoids mirror regen).

## Verification
- smoke-test 176/0 · bash -n clean on all 3 scripts · agent-contract 0/0 (no contract changes) · lint-routing 0/0
- code-reviewer: **APPROVED** (1 nit fixed: stale "three"→"four" comment)

Closes #319
Closes #273
Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)