### PR TITLE
Multi-model audit briefs + divergence-reconciliation rule (#298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,13 @@ The standing redirect instruction is included verbatim in every dispatch
 brief via `docs/templates/dispatch-template.md` § "Agent-panel contact
 redirect".
 
+**Multi-harness audits.** When the same milestone or release audit is
+dispatched to multiple models or harnesses, use
+`docs/templates/audit-brief-template.md` (identical brief to all
+models) and reconcile divergent findings per
+`docs/agents/manual/tech-lead-manual.md` § "Multi-model audit
+reconciliation".
+
 ## Tech-lead is the main-session persona (binding)
 
 **The main harness session IS `tech-lead`.** In Claude Code this means

--- a/docs/INDEX-FRAMEWORK.md
+++ b/docs/INDEX-FRAMEWORK.md
@@ -131,6 +131,7 @@ FW-ADR-0006). Numbering is sequential within each namespace.
 | `docs/templates/retrofit-playbook-template.md` | Migrating an existing codebase into a scaffolded project (v0.13.0+). |
 | `docs/templates/scoping-questions-template.md` | Seed queue of Step-2 scoping questions. |
 | `docs/templates/customer-note-entry-template.md` | Canonical shape for a single `CUSTOMER_NOTES.md` entry; enforced by `customer-notes-guard.py`. |
+| `docs/templates/audit-brief-template.md` | Self-contained context bundle for milestone/release audits run by conversation-blind agents on any harness; ensures equivalent inputs across models for comparable, reconcilable findings. |
 | `docs/templates/dispatch-template.md` | Structural aid for `tech-lead` dispatching a single task to a specialist; makes one-task-per-dispatch the default shape. Non-binding, no CI gate. |
 | `docs/templates/task-template.md` | INVEST + DoR + DoD + workflow-pipeline trigger annotation. |
 

--- a/docs/agents/manual/tech-lead-manual.md
+++ b/docs/agents/manual/tech-lead-manual.md
@@ -317,6 +317,60 @@ customer narration only. Recording dispatches in the Turn Ledger,
 record-keeping rules call for it; those records serve future-self
 and audit, not in-turn customer narration.
 
+## Multi-model audit reconciliation
+
+When a milestone or release audit is run across multiple models or
+harnesses (Claude Code, Codex, Gemini), this section governs how
+tech-lead prepares and reconciles.
+
+### Equivalent briefs (binding)
+
+All models dispatched to the same audit MUST receive identical briefs.
+Use `docs/templates/audit-brief-template.md` and fill it ONCE; send
+the same filled copy to every auditor. Each brief specifies the exact
+artifact list, binding references, and checklist dimensions. A model
+that receives a different input set cannot produce a finding that is
+comparable to another model's finding on the same dimension.
+
+### No auto-merge of divergent findings
+
+Tech-lead does not auto-merge audit results from different models.
+Each finding set is a separate artifact. When findings agree, they
+reinforce each other. When they diverge, tech-lead records both
+positions and applies the arbitration rules below before accepting
+either.
+
+### Arbitration of divergent findings
+
+| Divergence type | Tech-lead action |
+|---|---|
+| Same dimension, different severity | Hold the higher severity pending review; flag both to `code-reviewer` for a third-opinion pass before accepting either |
+| One model finds a violation, the other does not | Treat the violation as open until the finding model's evidence is examined; a "no finding" does not cancel a "Major" from another model |
+| Conflict on a binding decision axis — Hard Rule number, ADR outcome, or acceptance criterion — where models reach different conclusions | Escalate to the customer for a ruling; tech-lead does not pick between conflicting Hard-Rule interpretations |
+| Different recommendations for the same finding | Record both; route to `architect` or the owning specialist to select the approach |
+
+**Customer escalation trigger (binding).** When two models disagree on
+whether a Hard Rule has been violated, whether an ADR decision applies,
+or whether an acceptance criterion is met, tech-lead takes the
+disagreement to the customer as a single atomic question before
+proceeding. This is a Hard Rule #4 / Hard Rule #1 matter — no agent-
+only resolution is permitted on binding-decision-axis conflicts.
+
+### Relationship to mcp-liaison divergence reconciliation
+
+`mcp-liaison` owns divergence reconciliation for delegated external-
+model MCP sessions (briefs it constructs and dispatches via MCP tools).
+See `docs/agents/manual/mcp-liaison-manual.md` § "Divergence report
+format" for the format `mcp-liaison` uses when MCP output contradicts
+repo state or customer-truth.
+
+The present section governs a different scope: tech-lead reconciling
+audit findings returned by multiple named specialist sessions (each
+running a full audit role contract), not MCP tool responses. The two
+mechanisms are consistent — both require routing confirmed conflicts to
+tech-lead before accepting output — but operate at different dispatch
+levels.
+
 ## Routing table
 
 | Work smells like | Route to |

--- a/docs/templates/audit-brief-template.md
+++ b/docs/templates/audit-brief-template.md
@@ -1,0 +1,181 @@
+---
+name: audit-brief-template
+description: Self-contained context bundle for milestone/release audits run by conversation-blind agents (any harness — Claude Code, Codex, Gemini). Ensures equivalent inputs across models so divergent findings are comparable and reconcilable.
+template_class: audit-brief
+---
+
+
+# Audit brief — <audit-id> — <milestone or release ref>
+
+<!-- TOC -->
+
+- [Conversation-blindness note](#conversation-blindness-note)
+- [Audit identification](#audit-identification)
+- [Artifacts to read (canonical input set)](#artifacts-to-read-canonical-input-set)
+- [Binding references](#binding-references)
+- [Audit dimensions / checklist](#audit-dimensions--checklist)
+- [Required finding-report format](#required-finding-report-format)
+- [Return expectations](#return-expectations)
+
+<!-- /TOC -->
+
+<!-- PURPOSE. This template produces a SELF-CONTAINED audit brief. Every
+field is filled before dispatch; the auditor reads ONLY what is listed
+here. When multiple models (Claude/Codex/Gemini) run the same audit, all
+receive the same filled copy of this template — same artifact list, same
+binding references, same checklist, same output format. Divergent findings
+are then comparable and reconcilable by tech-lead.
+
+Multi-model reconciliation protocol:
+  docs/agents/manual/tech-lead-manual.md § "Multi-model audit reconciliation"
+
+Owned by: tech-lead (prepares the brief). Executed by: the named auditor
+role (code-reviewer, onboarding-auditor, security-engineer, or qa-engineer
+per the audit type). -->
+
+Owned by `tech-lead`. One brief per audit run. When the same audit is
+dispatched to multiple models, fill this template ONCE and send
+identical copies — do not paraphrase per model.
+
+---
+
+## Conversation-blindness note
+
+**You are conversation-blind.** You have no access to prior chat history,
+prior session context, or any information not explicitly listed in this
+brief. Everything you need to perform this audit is in this document.
+If a required artifact is missing or unreadable, stop and return a
+structured blocker — do not infer or hallucinate its contents.
+
+---
+
+## Audit identification
+
+- **Audit ID:** A-<NNNN or timestamp>
+- **Milestone / release ref:** <milestone name, sprint close, or `vX.Y.Z-rcN`>
+- **Audit type:** milestone-close | release-candidate | ad-hoc | multi-model
+- **Auditor role:** `code-reviewer` | `onboarding-auditor` | `security-engineer` | `qa-engineer`
+- **Dispatched by:** `tech-lead`
+- **Dispatched at:** YYYY-MM-DDThh:mmZ
+- **Harness:** Claude Code | Codex | Gemini | <other>
+
+---
+
+## Artifacts to read (canonical input set)
+
+List every file the auditor must read. No auditor may draw on artifacts
+not listed here. This is the **identical input set** for all models.
+
+### Required reads (mandatory before any finding)
+
+| # | Path (absolute from repo root) | Purpose in this audit |
+|---|---|---|
+| 1 | `<path>` | <why it is relevant> |
+| 2 | `<path>` | <why it is relevant> |
+
+### Conditional reads (read if the required set triggers a finding in this area)
+
+| Area | Path | Trigger condition |
+|---|---|---|
+| <area> | `<path>` | <condition that makes this read necessary> |
+
+Do not read files outside these lists. If a finding requires evidence
+from an unlisted file, note it in the blocker section of the report —
+do not read it unilaterally.
+
+---
+
+## Binding references
+
+The auditor must apply these references when evaluating findings.
+They are listed here so all harnesses work from the same authority set.
+
+- **`CLAUDE.md` § "Hard rules"** — the 12 project Hard Rules; violations
+  are automatic Major findings.
+- **`SW_DEV_ROLE_TAXONOMY.md`** — binding role vocabulary; use for role-
+  ownership and boundary findings.
+- **`docs/glossary/ENGINEERING.md`** and **`docs/glossary/PROJECT.md`** —
+  binding terminology; flag term drift.
+- **Relevant ADRs:** `<list specific ADR paths if scope-relevant>`
+- **Acceptance criteria for this milestone:**
+  `<path to CHARTER.md milestone section, task DoD, or inline list>`
+
+---
+
+## Audit dimensions / checklist
+
+Check each dimension. A dimension with no finding is explicitly marked
+"No finding." Do not omit dimensions; an omitted dimension is
+indistinguishable from a missed finding in a multi-model reconciliation.
+
+- [ ] **Hard-rule conformance.** Each of the 12 Hard Rules checked
+      against the artifact set. Cite the rule number for any violation.
+- [ ] **Acceptance-criteria coverage.** Every acceptance criterion
+      for this milestone has observable evidence of satisfaction.
+      Flag any criterion with no evidence.
+- [ ] **Traceability.** Each requirement has a corresponding
+      implementation artifact; each implementation artifact traces to
+      a requirement. Flag gaps.
+- [ ] **ADR conformance.** Relevant ADRs are respected in the
+      artifact set. Flag any conflict between artifact and binding ADR.
+- [ ] **Role-ownership conformance.** Artifacts are produced by the
+      correct owning roles per `SW_DEV_ROLE_TAXONOMY.md`. Flag any
+      role-boundary violation.
+- [ ] **Customer-truth stewardship.** `CUSTOMER_NOTES.md` entries
+      are structurally conformant (canonical shape, no inline `tech-lead`
+      writes). `librarian` is the steward; flag violations.
+- [ ] **Working-tree isolation.** No evidence of parallel-write
+      conflicts, wrong-branch commits, or non-hermetic-test contamination
+      in the git log (if log is in the artifact set).
+- [ ] **Framework/product boundary.** No framework-managed files
+      edited by product work without explicit customer authorization.
+- [ ] <Add further project-specific dimensions here>
+
+---
+
+## Required finding-report format
+
+Every finding uses this structure. Output findings as a numbered list.
+
+```
+### Finding <N> — <severity>: <short title>
+
+**Severity:** Critical | Major | Minor | Observation
+**Hard Rule / ADR / criterion:** <cite the binding reference, or "N/A">
+**Location:** <file path + line range, or artifact name>
+**Evidence:** <exact quote or git reference; do not paraphrase>
+**Recommendation:** <one or two sentences — what change resolves it>
+```
+
+**Severity definitions:**
+
+| Level | Meaning |
+|---|---|
+| Critical | Blocks release or milestone close; a Hard Rule violation, a security gate failure, or a missing customer-required approval |
+| Major | Significant conformance gap; must be resolved before merge but does not block immediately |
+| Minor | Should be fixed; does not block |
+| Observation | No action required; noted for awareness or future reference |
+
+If a dimension has no finding, output:
+```
+### <Dimension name> — No finding
+```
+
+---
+
+## Return expectations
+
+Return to `tech-lead` when the audit is complete:
+
+- [ ] One finding per `### Finding N` block, per format above.
+- [ ] All checklist dimensions explicitly covered (finding or "No finding").
+- [ ] Any artifact that was unreadable or missing listed as a structured
+      blocker:
+      ```
+      Blocker: <path> — <reason unreadable / missing>
+      ```
+- [ ] Auditor harness and model version recorded (for reconciliation
+      traceability):
+      ```
+      Auditor: <role>, <harness>, <model version if known>
+      ```


### PR DESCRIPTION
Implements **#298** (P10): conversation-blind multi-model audits (Claude/Codex/Gemini) lacked equivalent briefs and a rule for reconciling divergent findings.

## What landed (doc-only)
- **`docs/templates/audit-brief-template.md`** — a self-contained audit brief: a fixed canonical input set (every harness reads the *same* artifacts), binding references, audit dimensions, and a per-finding report format (severity / binding-citation / file+line / verbatim evidence / recommendation) plus an `Auditor: <role>, <harness>, <model version>` field that makes cross-model divergence comparable and traceable.
- **`docs/agents/manual/tech-lead-manual.md` § "Multi-model audit reconciliation"** — equivalent-briefs requirement (binding); **no auto-merge** of divergent audits; tech-lead arbitrates; **customer ruling required** when models conflict on a binding (Hard-Rule/ADR/acceptance) axis; distinguished from mcp-liaison's MCP-level divergence reconciliation.
- **CLAUDE.md** advisory pointer (§ Agent-teams panel) + INDEX-FRAMEWORK template-table row.

## Verification
- agent-contract 0/0 (no contract changes) · question-lint 0/0 · lint-routing 0/0
- code-reviewer: **APPROVED** (its one nit — "Hard rules" casing — was verified already correct; no change needed)

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)