### PR TITLE
Leaf-task context-assembly: token_budget + jit_file_list (#296)

### DIFF
--- a/docs/agents/manual/tech-lead-manual.md
+++ b/docs/agents/manual/tech-lead-manual.md
@@ -216,6 +216,44 @@ findings, blockers, and escalations to `tech-lead` instead.
 
 **Rule E — Delegated-specialist briefs carry no orchestrator instructions.** When a handoff carries `delegated_role`, the session that reads it is in delegated-specialist mode on any harness: it executes `task_ref`, suppresses spawning, and returns artifacts to the orchestrator. Do not include spawn-authorization language, team-start instructions, or orchestrator directives in leaf-task handoff briefs — a delegated session has no spawn surface and will not use them.
 
+### Per-task context assembly (FW-ADR-0021, issue #296)
+
+For handoffs with `dispatch_scope: "single_task"`, assemble the brief
+from the **leaf task's context only**. Do not include feature-altitude
+context (overall feature spec, sibling task context, or session
+history beyond what the task file names).
+
+**Procedure:**
+
+1. Read the task entry at `docs/tasks/T-NNNN.md` (or the equivalent
+   task tracker row). Extract:
+   - `Token budget` band (`tiny` | `small` | `medium` | `large` | `xl`)
+     from the task's Token budget section.
+   - `JIT file list` — the explicit list of files named in the task's
+     Token budget section as the files the assignee should load first.
+2. Populate the handoff's `token_budget` field (enum) and
+   `jit_file_list` field (array of paths) from those values. The
+   specialist loads only the listed files; it does not scan the repo
+   for additional context.
+3. The dispatch brief instructs the specialist: "Load the files in
+   `jit_file_list` first; do not read beyond them unless a listed file
+   explicitly references another and that reference is load-bearing for
+   your task."
+
+This bounds the dispatched agent's context and token budget to the
+leaf task — the core FW-ADR-0021 goal. A leaf-task agent that loads
+unrequested feature context is a budget violation equivalent to a
+context-forking brief (Rule B).
+
+**Feature-altitude handoffs (`dispatch_scope: "feature"`) are exempt.**
+They carry their own context scope by design and are grandfathered from
+this rule.
+
+References:
+- `docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md`
+- `docs/templates/task-template.md` § "Token budget" (band definitions
+  and JIT-file-list field)
+
 Closing completed, failed, or no-longer-needed specialists is routine
 slot hygiene; see `docs/agent-health-contract.md`.
 

--- a/schemas/handoff.schema.json
+++ b/schemas/handoff.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
-  "x-schema-version": "1.2.0",
-  "x-schema-changelog": "1.2.0 (issue #293 / fw-adr-0021): added delegated_role, task_ref, dispatch_scope to bounded_codex_exception; when codex_permission_flag is true, delegated_role and dispatch_scope are now required alongside permitted_role_owned_action (task_ref is gate-enforced only via check_delegated_specialist in validate-handoff.py — intentionally absent from then.required so the schema stays lax on task_ref while the gate is strict). token_budget_hint is out of scope for this change (separate fw-adr-0021 concern). | 1.1.0 (fw-adr-0023 D2 Option S): removed 'activity' from required[]; property retained as optional/deprecated for backward-compat with handoff files written before the sidecar migration. Runtime telemetry now written to docs/handoffs/<task_id>.activity.jsonl.",
+  "x-schema-version": "1.3.0",
+  "x-schema-changelog": "1.3.0 (issue #296 / fw-adr-0021 §1): added optional token_budget and jit_file_list to bounded_codex_exception as leaf-task context-assembly inputs for dispatch_scope: single_task. Both fields are optional in the schema; the context-assembly rule and tech-lead manual guide population (gate/manual enforces, schema stays lax on these). | 1.2.0 (issue #293 / fw-adr-0021): added delegated_role, task_ref, dispatch_scope to bounded_codex_exception; when codex_permission_flag is true, delegated_role and dispatch_scope are now required alongside permitted_role_owned_action (task_ref is gate-enforced only via check_delegated_specialist in validate-handoff.py — intentionally absent from then.required so the schema stays lax on task_ref while the gate is strict). token_budget_hint is out of scope for this change (separate fw-adr-0021 concern). | 1.1.0 (fw-adr-0023 D2 Option S): removed 'activity' from required[]; property retained as optional/deprecated for backward-compat with handoff files written before the sidecar migration. Runtime telemetry now written to docs/handoffs/<task_id>.activity.jsonl.",
   "type": "object",
   "required": [
     "schema",
@@ -112,6 +112,16 @@
           "type": "string",
           "enum": ["single_task", "feature"],
           "description": "Scope of this dispatch. 'single_task' is required for bounded-Codex leaf-task dispatch (fw-adr-0021). 'feature' is the default for orchestrator-level planning handoffs and is never a valid input for a delegated-specialist or bounded-Codex invocation."
+        },
+        "token_budget": {
+          "type": "string",
+          "enum": ["tiny", "small", "medium", "large", "xl"],
+          "description": "Leaf-task token-budget band from the T### task entry in tasks.md (docs/templates/task-template.md § 'Token budget'). Guides the delegated session's context loading: tiny/small sessions load minimal files; xl signals a complex task that may require splitting. Optional — feature-altitude handoffs omit this field. Populate for dispatch_scope: single_task dispatches (issue #296 / fw-adr-0021 §1)."
+        },
+        "jit_file_list": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Just-in-time file list for the leaf task: the paths the delegated session should Read first, copied from the T### task entry's JIT file list field (docs/templates/task-template.md § 'Token budget'). Keeps context loading minimal and targeted. Optional — feature-altitude handoffs omit this field. Populate for dispatch_scope: single_task dispatches (issue #296 / fw-adr-0021 §1)."
         }
       },
       "if": {

--- a/scripts/validate-handoff.py
+++ b/scripts/validate-handoff.py
@@ -64,6 +64,41 @@ def check_delegated_specialist(handoff: dict) -> list[str]:
     return errors
 
 
+def _advisory_leaf_context(handoff: dict) -> list[str]:
+    """Return advisory notes (not errors) for optional leaf-task context fields.
+
+    For ``dispatch_scope: "single_task"`` handoffs with ``codex_permission_flag``
+    true, ``token_budget`` and ``jit_file_list`` should be present to guide
+    context assembly (issue #296 / fw-adr-0021 §1). Their absence is schema-valid
+    (optional fields); these notes surface the gap without hard-rejecting.
+
+    Returns advisory strings; callers print them to stderr without incrementing
+    the error count.
+    """
+    exc = handoff.get("bounded_codex_exception")
+    if not isinstance(exc, dict):
+        return []
+    if not exc.get("codex_permission_flag", False):
+        return []
+    if exc.get("dispatch_scope") != "single_task":
+        return []
+
+    notes: list[str] = []
+    if not exc.get("token_budget"):
+        notes.append(
+            "ADVISORY: bounded_codex_exception.token_budget absent on a "
+            "single_task dispatch — populate from the T### task entry's "
+            "token-budget band (issue #296 / fw-adr-0021 §1)"
+        )
+    if not exc.get("jit_file_list"):
+        notes.append(
+            "ADVISORY: bounded_codex_exception.jit_file_list absent on a "
+            "single_task dispatch — populate from the T### task entry's JIT "
+            "file list (issue #296 / fw-adr-0021 §1)"
+        )
+    return notes
+
+
 def check_model_fallback_tier(handoff: dict) -> list[str]:
     """Enforce the data-model rule: model_fallback is acceptable only when
     capability_tier_comparison is 'same' or 'higher'.  A 'lower' value means
@@ -214,6 +249,16 @@ def main() -> int:
                 print(f"FAIL  {path_str}: {msg}", file=sys.stderr)
         else:
             print(f"PASS  {path_str}")
+
+        # Soft advisories: leaf-task context fields (#296). Printed to stderr
+        # as ADVISORY lines; do not affect exit code or PASS/FAIL verdict.
+        try:
+            with path.open(encoding="utf-8") as fh:
+                _h = json.load(fh)
+            for note in _advisory_leaf_context(_h):
+                print(f"ADVISORY  {path_str}: {note}", file=sys.stderr)
+        except (OSError, json.JSONDecodeError):
+            pass
 
     return 1 if any_fail else 0
 

--- a/tests/hooks/fixtures/handoff/delegated-specialist-invalid-token-budget.json
+++ b/tests/hooks/fixtures/handoff/delegated-specialist-invalid-token-budget.json
@@ -1,0 +1,47 @@
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "delegated-specialist-invalid-token-budget-001",
+  "status": "active",
+  "mode": {
+    "execution": "bounded-codex",
+    "codex_allowed": true,
+    "codex_server": "codex"
+  },
+  "owner_role": "software-engineer",
+  "review_roles": [],
+  "security_roles": [],
+  "objective": "Fixture: token_budget with an invalid enum value — schema must reject.",
+  "allowed_paths": ["scripts/**"],
+  "forbidden_paths": [],
+  "framework_scope": "framework-maintenance",
+  "requires": {
+    "tests": [],
+    "review": false,
+    "security_review": false,
+    "human_approval": false
+  },
+  "acceptance_criteria": [],
+  "hard_rule_traces": [],
+  "bounded_codex_exception": {
+    "execution_mode": "bounded-codex",
+    "codex_permission_flag": true,
+    "permitted_role_owned_action": "implement-task-t099",
+    "delegated_role": "software-engineer",
+    "task_ref": "T099",
+    "dispatch_scope": "single_task",
+    "token_budget": "enormous",
+    "allowed_paths": ["scripts/**"],
+    "forbidden_paths": []
+  },
+  "verification": {
+    "tests": [],
+    "reviews": [],
+    "security": [],
+    "human_approval": []
+  },
+  "completion": {
+    "claimed_by": null,
+    "completed_at": null,
+    "evidence": []
+  }
+}

--- a/tests/hooks/fixtures/handoff/delegated-specialist-with-leaf-context.json
+++ b/tests/hooks/fixtures/handoff/delegated-specialist-with-leaf-context.json
@@ -1,0 +1,54 @@
+{
+  "schema": "https://example.invalid/sw-dev-team-template/handoff.schema.json",
+  "task_id": "delegated-specialist-with-leaf-context-001",
+  "status": "active",
+  "mode": {
+    "execution": "bounded-codex",
+    "codex_allowed": true,
+    "codex_server": "codex"
+  },
+  "owner_role": "software-engineer",
+  "review_roles": ["code-reviewer"],
+  "security_roles": [],
+  "objective": "Fixture: valid single_task handoff with token_budget and jit_file_list (issue #296 / fw-adr-0021 §1).",
+  "allowed_paths": ["scripts/**", "tests/**"],
+  "forbidden_paths": [".claude/**", "CUSTOMER_NOTES.md"],
+  "framework_scope": "framework-maintenance",
+  "requires": {
+    "tests": [],
+    "review": false,
+    "security_review": false,
+    "human_approval": false
+  },
+  "acceptance_criteria": [
+    "Schema accepts a single_task handoff carrying token_budget and jit_file_list."
+  ],
+  "hard_rule_traces": [],
+  "bounded_codex_exception": {
+    "execution_mode": "bounded-codex",
+    "codex_permission_flag": true,
+    "permitted_role_owned_action": "implement-task-t041",
+    "delegated_role": "software-engineer",
+    "task_ref": "T041",
+    "dispatch_scope": "single_task",
+    "token_budget": "small",
+    "jit_file_list": [
+      "scripts/validate-handoff.py",
+      "schemas/handoff.schema.json",
+      "tests/hooks/test-handoff-contracts.sh"
+    ],
+    "allowed_paths": ["scripts/**", "tests/**"],
+    "forbidden_paths": [".claude/**"]
+  },
+  "verification": {
+    "tests": [],
+    "reviews": [],
+    "security": [],
+    "human_approval": []
+  },
+  "completion": {
+    "claimed_by": null,
+    "completed_at": null,
+    "evidence": []
+  }
+}

--- a/tests/hooks/test-handoff-contracts.sh
+++ b/tests/hooks/test-handoff-contracts.sh
@@ -285,6 +285,17 @@ run_validator_case "validate-handoff.py rejects codex_permission_flag=true witho
 run_validator_case "validate-handoff.py rejects codex_permission_flag=true without task_ref (gate-only, #293 / fw-adr-0021)" \
     "$FIXTURES/delegated-specialist-missing-taskref.json" invalid
 
+# Leaf-task context fields: token_budget + jit_file_list (issue #296 / fw-adr-0021 §1):
+# Schema must accept a single_task handoff WITH both fields; reject an invalid
+# token_budget enum value; and continue to accept handoffs where both are absent
+# (fields are optional — feature-altitude handoffs are grandfathered).
+run_schema_case "schema accepts single_task handoff with token_budget and jit_file_list (#296 / fw-adr-0021)" \
+    "$FIXTURES/delegated-specialist-with-leaf-context.json" valid
+run_schema_case "schema rejects token_budget with invalid enum value (#296 / fw-adr-0021)" \
+    "$FIXTURES/delegated-specialist-invalid-token-budget.json" invalid
+run_schema_case "schema accepts single_task handoff with token_budget and jit_file_list absent (optional, #296)" \
+    "$FIXTURES/delegated-specialist-valid.json" valid
+
 printf '\nSummary: %s passed, %s failed\n' "$pass" "$fail"
 if [ "$fail" -ne 0 ]; then
     printf 'Failures:\n'


### PR DESCRIPTION
Completes **#296** (P7, fw-adr-0021). #293 added the dispatch-unit fields (dispatch_scope/delegated_role/task_ref); this adds the leaf task's **context-assembly inputs** that the handoff schema was missing.

## What landed
- **schema** — optional `token_budget` (enum `tiny|small|medium|large|xl`, matching the task-template band) + `jit_file_list` (array of paths) in `bounded_codex_exception`. Both **optional** (not in `then.required`) so feature-altitude handoffs stay grandfathered. `x-schema-version` 1.2.0→1.3.0.
- **validate-handoff.py** — `_advisory_leaf_context`: a soft ADVISORY (stderr, exit 0) when a `single_task` dispatch omits these fields. Never hard-rejects (they're optional); never fires for `feature` dispatches.
- **tech-lead-manual § "Per-task context assembly"** — for `single_task`, tech-lead assembles the brief from the leaf T### task's `jit_file_list` + `token_budget` (not feature context), bounding the dispatched agent's context — the fw-adr-0021 goal. Feature handoffs exempt.

## Verification
- handoff contracts 30/30 (with-leaf-context valid / invalid-enum rejected / absent still valid) · schema valid · agent-contract 0/0 · lint-routing 0/0
- code-reviewer: **APPROVED**, no findings

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)