### PR TITLE
rc14 backfill: recognize heading synonyms, atomic insert (#261)

### DIFF
--- a/migrations/v1.0.0-rc14.sh
+++ b/migrations/v1.0.0-rc14.sh
@@ -175,11 +175,17 @@ _rc14_map_section() {
   case "${norm}" in
     "role overview"|"job"|"two modes"|"overview")
       echo "role_overview" ;;
-    "hard rules"|"hard block conditions"|"enforcement"|"constraints")
+    # hard_rules synonyms: canonical + common customisation headings.
+    # "rules" and "invariants" are the two most common alternatives
+    # used by customised agents and previously caused false-positive
+    # "missing hard_rules" reports (issue #261).
+    "hard rules"|"hard block conditions"|"enforcement"|"constraints"|"rules"|"invariants")
       echo "hard_rules" ;;
     "escalation"|"escalation protocol"|"escalation format"|"hand offs"|"handoffs")
       echo "escalation" ;;
-    "output"|"output format"|"customer facing output discipline")
+    # output_format synonyms: "return format" is the other common
+    # customisation heading not in the original list.
+    "output"|"output format"|"customer facing output discipline"|"return format")
       echo "output_format" ;;
     *)
       echo "" ;;
@@ -212,9 +218,9 @@ _rc14_extract_section_by_slug() {
     }
     function map_slug(n) {
       if (n == "role overview" || n == "job" || n == "two modes" || n == "overview") return "role_overview"
-      if (n == "hard rules" || n == "hard block conditions" || n == "enforcement" || n == "constraints") return "hard_rules"
+      if (n == "hard rules" || n == "hard block conditions" || n == "enforcement" || n == "constraints" || n == "rules" || n == "invariants") return "hard_rules"
       if (n == "escalation" || n == "escalation protocol" || n == "escalation format" || n == "hand offs" || n == "handoffs") return "escalation"
-      if (n == "output" || n == "output format" || n == "customer facing output discipline") return "output_format"
+      if (n == "output" || n == "output format" || n == "customer facing output discipline" || n == "return format") return "output_format"
       return ""
     }
     /^## / {
@@ -258,7 +264,9 @@ _rc14_insert_after_escalation() {
   local target="$1"
   local body_file="$2"
   local workfile
-  workfile=$(mktemp)
+  # Use mktemp next to the target so the mv is same-filesystem atomic
+  # (issue #319 pattern: avoids truncation on interrupted write).
+  workfile=$(mktemp "${target}.tmp.XXXXXX")
 
   local anchor_line
   anchor_line=$(awk '

--- a/tests/upgrade/test-rc14-pass2-backfill.sh
+++ b/tests/upgrade/test-rc14-pass2-backfill.sh
@@ -359,6 +359,118 @@ check "case5: audit row mentions 'not reachable'" \
 check "case5: lint passes" lint_one_agent "$proj5/.claude/agents/synthetic-agent.md"
 
 # ---------------------------------------------------------------------------
+# Case 6: synonym headings — must NOT be double-backfilled (issue #261 fix)
+# ---------------------------------------------------------------------------
+# A customised agent uses ## Rules instead of ## Hard rules.
+# Before the fix, _rc14_map_section didn't recognise "rules" → hard_rules
+# and treated the section as missing, causing a double-backfill.
+# After the fix, it must be detected as already-present; migration is no-op.
+echo ""
+echo "-- Case 6: synonym headings prevent false-positive backfill (issue #261) --"
+
+proj6a="$tmp/proj6a"
+upstream6a="$tmp/upstream6a"
+mkdir -p "$proj6a/.claude/agents" "$proj6a/docs"
+make_upstream "$upstream6a" "synthetic-agent.md"
+
+# Write an agent with ## Rules (synonym for hard_rules) and ## Output format.
+cat > "$proj6a/.claude/agents/synthetic-agent.md" <<'EOF'
+---
+name: synthetic-agent
+description: A synthetic test agent using non-standard synonym headings for rc14 issue #261 coverage.
+---
+
+## Job
+
+This is the role overview body for synthetic-agent.
+
+## Escalation format
+
+Route all unresolved questions to tech-lead. Do not contact the customer directly.
+
+## Rules
+
+1. Do not contact the customer directly; all customer communication flows through tech-lead.
+2. Do not commit production code without code-reviewer approval.
+
+## Output format
+
+Return diffs with short rationale. No essays. Include file paths when referencing code.
+EOF
+printf '.claude/agents/synthetic-agent.md\n' > "$proj6a/.template-customizations"
+
+before6a="$(cat "$proj6a/.claude/agents/synthetic-agent.md")"
+rc6a=$(run_migration "$proj6a" "$upstream6a" "$tmp/case6a.log")
+after6a="$(cat "$proj6a/.claude/agents/synthetic-agent.md")"
+
+check "case6a (synonym ## Rules): migration exits 0" bash -c "[ '$rc6a' = '0' ]"
+check "case6a (synonym ## Rules): file NOT modified (no double-backfill)" \
+  bash -c "[ '$before6a' = '$after6a' ]"
+check "case6a (synonym ## Rules): exactly one Rules/Hard-rules-family heading" \
+  bash -c "[ \"\$(grep -cE '^## (Rules|Hard rules)' '$proj6a/.claude/agents/synthetic-agent.md')\" = '1' ]"
+check "case6a (synonym ## Rules): no DECISIONS row written (already current)" \
+  bash -c "[ ! -f '$proj6a/docs/DECISIONS.md' ] || ! grep -q 'rc14 migration pass 2' '$proj6a/docs/DECISIONS.md'"
+
+# Case 6b: ## Invariants synonym for hard_rules, ## Return format synonym for output_format.
+proj6b="$tmp/proj6b"
+upstream6b="$tmp/upstream6b"
+mkdir -p "$proj6b/.claude/agents" "$proj6b/docs"
+make_upstream "$upstream6b" "synthetic-agent.md"
+
+cat > "$proj6b/.claude/agents/synthetic-agent.md" <<'EOF'
+---
+name: synthetic-agent
+description: Synonym heading test — Invariants + Return format (issue #261).
+---
+
+## Job
+
+Role overview body for synthetic-agent.
+
+## Escalation format
+
+Route all unresolved questions to tech-lead.
+
+## Invariants
+
+1. Never contact the customer directly.
+2. Never commit without reviewer approval.
+
+## Return format
+
+Return diffs with short rationale. No essays.
+EOF
+printf '.claude/agents/synthetic-agent.md\n' > "$proj6b/.template-customizations"
+
+before6b="$(cat "$proj6b/.claude/agents/synthetic-agent.md")"
+rc6b=$(run_migration "$proj6b" "$upstream6b" "$tmp/case6b.log")
+after6b="$(cat "$proj6b/.claude/agents/synthetic-agent.md")"
+
+check "case6b (## Invariants + ## Return format): migration exits 0" bash -c "[ '$rc6b' = '0' ]"
+check "case6b (## Invariants + ## Return format): file NOT modified (no double-backfill)" \
+  bash -c "[ '$before6b' = '$after6b' ]"
+check "case6b (## Invariants + ## Return format): no DECISIONS row written" \
+  bash -c "[ ! -f '$proj6b/docs/DECISIONS.md' ] || ! grep -q 'rc14 migration pass 2' '$proj6b/docs/DECISIONS.md'"
+
+# Case 6c: genuinely missing sections still get backfilled even with synonyms
+# recognised. Confirm the normal backfill path isn't broken by the synonym
+# additions — a file with NO hard_rules-family heading must still get one.
+proj6c="$tmp/proj6c"
+upstream6c="$tmp/upstream6c"
+make_project "$proj6c" "synthetic-agent.md"  # no hard_rules, no output_format
+make_upstream "$upstream6c" "synthetic-agent.md"
+
+rc6c=$(run_migration "$proj6c" "$upstream6c" "$tmp/case6c.log")
+check "case6c (genuinely missing — synonym fix doesn't suppress): migration exits 0" \
+  bash -c "[ '$rc6c' = '0' ]"
+check "case6c (genuinely missing): hard_rules inserted" \
+  grep -q "^## Hard rules" "$proj6c/.claude/agents/synthetic-agent.md"
+check "case6c (genuinely missing): output_format inserted" \
+  grep -q "^## Output format" "$proj6c/.claude/agents/synthetic-agent.md"
+check "case6c (genuinely missing): lint passes" \
+  lint_one_agent "$proj6c/.claude/agents/synthetic-agent.md"
+
+# ---------------------------------------------------------------------------
 # Additional exclusion checks
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Implements **#261** — the rc14 agent-contract-schema migration's Pass-2 backfill double-inserted `hard_rules`/`output_format` sections into preserved/customized `.claude/agents/*.md` files that used non-listed heading synonyms (e.g. `## Rules`, `## Invariants`).

## What landed
- **`migrations/v1.0.0-rc14.sh`** — `_rc14_map_section` (bash) + `_rc14_extract_section_by_slug` (awk) gain synonyms `rules`/`invariants` → `hard_rules` and `return format` → `output_format`, kept **symmetric** between detector and extractor so they can't disagree. Conservative: only unambiguous equivalents (multi-word variants like "business rules"/"code invariants" don't match). Plus `_rc14_insert_after_escalation` now uses `mktemp "${target}.tmp.XXXXXX"` (same-filesystem, atomic `mv`; no truncation on a mid-write crash).
- **tests** — Case 6 (+11 assertions): `## Rules`/`## Invariants`/`## Return format` are recognized (no double-backfill, no DECISIONS row), while genuinely-absent sections are still backfilled (no false-negative).

## Verification
- test-rc14-pass2-backfill 49/49 · rc9 17/17 · smoke 176/0 · agent-contract 0/0 · lint-routing 0/0
- code-reviewer: **APPROVED**, no findings (synonym symmetry + idempotency programmatically verified)

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)