### PR TITLE
fix(migration): v1.2.0 sidecar no-op on empty activity (release-gate unblock)

### DIFF
--- a/migrations/v1.2.0.sh
+++ b/migrations/v1.2.0.sh
@@ -4,16 +4,18 @@
 #   (fw-adr-0023 D2 Option S, schema v1.1.0)
 #
 # Walks every docs/handoffs/*.json file in the project:
-#   1. If the file carries a non-empty top-level "activity" array, exports
+#   1. If the file carries a NON-EMPTY top-level "activity" array, exports
 #      the entries to a sidecar docs/handoffs/<task_id>.activity.jsonl
 #      (one JSON object per line), then removes the "activity" key from
 #      the JSON file. Data moves; nothing is discarded.
-#   2. If the file carries an empty "activity" array (or no "activity"
-#      key at all), the "activity" key is removed (or left absent) and
-#      the sidecar is not created.
+#   2. If the file carries an EMPTY "activity" array (or no "activity" key
+#      at all), the file is left completely untouched — no rewrite, no SHA
+#      change. The deprecated-but-schema-valid empty array is inert (the
+#      hook now writes to the sidecar) and cosmetic removal is not worth
+#      the SHA churn it causes on downstream upgrade paths.
 #
-# The migration is idempotent: re-running it on an already-migrated file
-# (no "activity" key) is a no-op.
+# The migration is idempotent: re-running it on a file with no activity key
+# (or an empty array left in place) is a no-op.
 #
 # Requires python3 (already required by the hook layer).
 #
@@ -37,7 +39,6 @@ if [[ ! -d "$HANDOFFS_DIR" ]]; then
 fi
 
 migrated=0
-skipped=0
 already_done=0
 
 while IFS= read -r -d '' json_file; do
@@ -51,31 +52,35 @@ json_file = Path(sys.argv[1])
 with json_file.open(encoding="utf-8") as f:
     doc = json.load(f)
 
-if "activity" not in doc:
-    # Already migrated or never had the key.
+activity = doc.get("activity")
+
+if activity is None:
+    # Already migrated or never had the key — true no-op.
     print(f"  skip (no activity key): {json_file.name}", flush=True)
     sys.exit(2)
 
-activity = doc.pop("activity")
+if not (isinstance(activity, list) and activity):
+    # Empty array: leave the file completely untouched (no SHA change).
+    # Cosmetic removal of "activity": [] is not worth the upgrade-path
+    # conflict it causes on v1.1.0→v1.3.0 downstream upgrades.
+    print(f"  skip (empty activity array, file unchanged): {json_file.name}", flush=True)
+    sys.exit(2)
 
-# Export non-empty arrays to sidecar.
+# Non-empty array: export entries to sidecar then strip the key.
+doc.pop("activity")
 task_id = doc.get("task_id") or json_file.stem
 sidecar = json_file.parent / f"{task_id}.activity.jsonl"
 
-if isinstance(activity, list) and activity:
-    with sidecar.open("a", encoding="utf-8") as sf:
-        for entry in activity:
-            sf.write(json.dumps(entry, ensure_ascii=False) + "\n")
-    print(f"  migrated {len(activity)} entries -> {sidecar.name}", flush=True)
-    sys.exit(0)
-else:
-    print(f"  removed empty activity array: {json_file.name}", flush=True)
-    sys.exit(3)
+with sidecar.open("a", encoding="utf-8") as sf:
+    for entry in activity:
+        sf.write(json.dumps(entry, ensure_ascii=False) + "\n")
+print(f"  migrated {len(activity)} entries -> {sidecar.name}", flush=True)
+sys.exit(0)
 
 PYEOF
-  # rc=0: entries exported to sidecar; rc=3: empty array stripped; rc=2: already done.
-  # Write the stripped JSON back for rc=0 or rc=3 (activity key present and removed).
-  if [[ $rc -eq 0 || $rc -eq 3 ]]; then
+  # rc=0: non-empty activity exported to sidecar; file must be rewritten (key stripped).
+  # rc=2: no-op (absent key OR empty array) — file is left byte-identical; no rewrite.
+  if [[ $rc -eq 0 ]]; then
     rc2=0
     python3 - "$json_file" <<'PYEOF' || rc2=$?
 import json, os, sys
@@ -96,14 +101,11 @@ PYEOF
       echo "  ERROR: failed to write stripped JSON for $json_file" >&2
       exit 1
     fi
-    if [[ $rc -eq 0 ]]; then
-      migrated=$((migrated + 1))
-    else
-      skipped=$((skipped + 1))
-    fi
+    migrated=$((migrated + 1))
   else
+    # rc=2: no-op (absent or empty activity array).
     already_done=$((already_done + 1))
   fi
 done < <(find "$HANDOFFS_DIR" -maxdepth 1 -name '*.json' -not -name '*.migration-tmp' -print0 | sort -z)
 
-echo "  v1.2.0 activity-sidecar migration: migrated=$migrated empty-stripped=$skipped already-done=$already_done"
+echo "  v1.2.0 activity-sidecar migration: migrated=$migrated already-done-or-empty=$already_done"

--- a/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
+++ b/tests/upgrade/test-manifest-handoff-activity-issue-276.sh
@@ -276,6 +276,103 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# NEW-F6. Migration v1.2.0 leaves an EMPTY "activity": [] BYTE-IDENTICAL.
+#         (fix for upgrade-conflict on v1.1.0→v1.3.0 downstream paths)
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- NEW-F6: empty activity array — file left byte-identical (no SHA change) --"
+
+MIGTEST_EMPTY_RELPATH="docs/handoffs/test-empty-activity.json"
+mkdir -p "$tmp/docs/handoffs"
+
+cat > "$tmp/$MIGTEST_EMPTY_RELPATH" << 'EOF'
+{
+  "task_id": "test-empty",
+  "status": "active",
+  "activity": [],
+  "verification": {"tests": []}
+}
+EOF
+
+before_sha=$(sha256sum "$tmp/$MIGTEST_EMPTY_RELPATH" | awk '{print $1}')
+
+PROJECT_ROOT="$tmp" bash "$migration" >/dev/null
+
+after_sha=$(sha256sum "$tmp/$MIGTEST_EMPTY_RELPATH" | awk '{print $1}')
+
+if [[ "$before_sha" == "$after_sha" ]]; then
+  echo "  PASS: NEW-F6 — empty-activity file SHA unchanged (byte-identical)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F6 — SHA changed! empty-activity file was rewritten" >&2
+  echo "        before=$before_sha after=$after_sha" >&2
+  fail=$((fail + 1))
+fi
+
+# activity key must still be present (we left it in place).
+has_activity_f6=$(python3 -c "
+import json, sys
+doc = json.load(open(sys.argv[1]))
+print('yes' if 'activity' in doc else 'no')
+" "$tmp/$MIGTEST_EMPTY_RELPATH")
+
+if [[ "$has_activity_f6" == "yes" ]]; then
+  echo "  PASS: NEW-F6 — activity key still present (inert empty array left in place)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F6 — activity key was stripped (should have been left untouched)" >&2
+  fail=$((fail + 1))
+fi
+
+# No sidecar should have been created.
+empty_sidecar="$tmp/docs/handoffs/test-empty.activity.jsonl"
+if [[ ! -f "$empty_sidecar" ]]; then
+  echo "  PASS: NEW-F6 — no sidecar created for empty activity (correct)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F6 — sidecar created for empty activity (should not be)" >&2
+  fail=$((fail + 1))
+fi
+
+# Idempotency: re-run is also a no-op.
+PROJECT_ROOT="$tmp" bash "$migration" >/dev/null
+after_sha2=$(sha256sum "$tmp/$MIGTEST_EMPTY_RELPATH" | awk '{print $1}')
+if [[ "$before_sha" == "$after_sha2" ]]; then
+  echo "  PASS: NEW-F6 — idempotent re-run: file still byte-identical"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F6 — second run changed the file (not idempotent)" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# NEW-F7. Migration v1.2.0 leaves an already-absent activity key untouched.
+# ---------------------------------------------------------------------------
+echo ""
+echo "-- NEW-F7: absent activity key — file left byte-identical --"
+
+MIGTEST_ABSENT_RELPATH="docs/handoffs/test-absent-activity.json"
+cat > "$tmp/$MIGTEST_ABSENT_RELPATH" << 'EOF'
+{
+  "task_id": "test-absent",
+  "status": "active",
+  "verification": {"tests": []}
+}
+EOF
+
+before_sha_f7=$(sha256sum "$tmp/$MIGTEST_ABSENT_RELPATH" | awk '{print $1}')
+PROJECT_ROOT="$tmp" bash "$migration" >/dev/null
+after_sha_f7=$(sha256sum "$tmp/$MIGTEST_ABSENT_RELPATH" | awk '{print $1}')
+
+if [[ "$before_sha_f7" == "$after_sha_f7" ]]; then
+  echo "  PASS: NEW-F7 — absent-activity file SHA unchanged (byte-identical)"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: NEW-F7 — SHA changed! absent-activity file was rewritten" >&2
+  fail=$((fail + 1))
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Fixes the real v1.1.0→v1.3.0 upgrade conflict the v1.3.0 release-gate caught (Option B).

The activity-sidecar migration (`migrations/v1.2.0.sh`) rewrote handoff JSONs even for an empty `"activity": []` (cosmetic key removal → SHA churn). On a v1.1.0→v1.3.0 upgrade that made a downstream's `fw-012` differ from the v1.1.0 baseline, so `upgrade.sh`'s 3-SHA sync treated it as a local edit and conflicted instead of cleanly taking upstream.

**Fix:** empty-array and absent-key are now **true no-ops** (file never opened for write); only a non-empty `activity` array is exported-to-sidecar + stripped + rewritten. A v1.1.0 baseline file stays byte-identical → `proj == old` → upgrade takes upstream cleanly. Dead `rc=3` branch removed.

Tests: empty/absent byte-identity + no-sidecar + idempotency (NEW-F6/F7); 15/15. code-reviewer APPROVED.

Unblocks the v1.3.0 release-gate (`upgrade-paths` v1.1.0:clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * v1.2.0 migration now properly handles activity fields: exports non-empty arrays to separate files while preserving original files for empty or missing cases, improving efficiency and preventing unnecessary rewrites.

* **Tests**
  * Added comprehensive test coverage for migration activity field edge cases to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->