### PR TITLE
Antigravity MCP delegate shim — Claude→Antigravity inline delegation (fw-adr-0027)

### DIFF
--- a/docs/adr/fw-adr-0027-antigravity-mcp-delegate-shim.md
+++ b/docs/adr/fw-adr-0027-antigravity-mcp-delegate-shim.md
@@ -1,0 +1,731 @@
+---
+name: fw-adr-0027-antigravity-mcp-delegate-shim
+description: >
+  Define the Antigravity delegate shim: a thin local stdio MCP server
+  (Python 3 stdlib only) that Claude Code registers as an MCP server,
+  exposing one tool — antigravity_delegate — so Claude can delegate a
+  unit of work to Antigravity inline and receive the result back, with
+  PTY spawning for agy, argv-list invocation to prevent shell injection,
+  bounded output, and timeout control.
+status: accepted
+date: 2026-06-11
+---
+
+
+# FW-ADR-0027 — Antigravity MCP delegate shim
+
+<!-- TOC -->
+
+- [Status](#status)
+- [Scaffold placement note](#scaffold-placement-note)
+- [Background: binary analysis of agy (2026-06-11)](#background-binary-analysis-of-agy-2026-06-11)
+- [Context and problem statement](#context-and-problem-statement)
+- [Decision drivers](#decision-drivers)
+- [Considered options (Three-Path Rule, binding)](#considered-options-three-path-rule-binding)
+  - [Option M — Minimalist](#option-m--minimalist)
+  - [Option S — Scalable](#option-s--scalable)
+  - [Option C — Creative (experimental)](#option-c--creative-experimental)
+- [Decision outcome](#decision-outcome)
+- [Design: Antigravity delegate shim](#design-antigravity-delegate-shim)
+  - [1. MCP tool surface](#1-mcp-tool-surface)
+  - [2. Stdio MCP protocol (JSON-RPC 2.0 by hand)](#2-stdio-mcp-protocol-json-rpc-20-by-hand)
+  - [3. PTY spawning and argv-list invocation](#3-pty-spawning-and-argv-list-invocation)
+  - [3a. Security-engineer sign-off (2026-06-11): binding implementation requirements](#3a-security-engineer-sign-off-2026-06-11-binding-implementation-requirements)
+  - [4. Timeout and bounded output](#4-timeout-and-bounded-output)
+  - [5. Model default and override](#5-model-default-and-override)
+  - [6. Auth assumption](#6-auth-assumption)
+  - [7. Placement and registration](#7-placement-and-registration)
+- [Implementation change-set grouped by owner](#implementation-change-set-grouped-by-owner)
+  - [software-engineer](#software-engineer)
+  - [tech-writer](#tech-writer)
+- [Relationship to existing ADRs and roles](#relationship-to-existing-adrs-and-roles)
+- [Consequences](#consequences)
+  - [Positive](#positive)
+  - [Negative / trade-offs accepted](#negative--trade-offs-accepted)
+  - [Follow-up ADRs](#follow-up-adrs)
+- [Verification](#verification)
+- [Links](#links)
+
+<!-- /TOC -->
+
+---
+
+## Status
+
+- **Accepted**
+- **Proposed:** 2026-06-11
+- **Accepted:** 2026-06-11 — `security-engineer` sign-off on §3 recorded
+  (2026-06-11); customer approved the shim concept ("thin MCP-server shim").
+- **Deciders:** `architect`; `security-engineer` co-owns the argv-list /
+  PTY spawning security constraint (Hard Rule #7 adjacency — the shim
+  is not auth/secrets-handling but it executes attacker-influenced text
+  as a subprocess argument); `tech-lead` + customer acceptance obtained
+  2026-06-11
+- **Consulted:** FW-ADR-0026 (Antigravity harness adapter — the other
+  direction: Antigravity loading the team); binary analysis of installed
+  `~/.local/bin/agy`, 2026-06-11; issue #289 (MCP non-primary-session
+  rule); issue #338 / #339 context; `mcp-liaison` role contract
+  (Q-0022 / gh issue #290)
+
+## Scaffold placement note
+
+This ADR is authored in the meta-project (`docs/adr/`) per the PLAN/DO
+convention (CLAUDE.md § "Project Identity / Working Tree"). The
+implementation artifacts (server script, smoke test) land in the scaffold
+(`scripts/mcp/antigravity_delegate.py`). The ADR migrates into the
+scaffold's `docs/adr/` with the implementation PR. Pattern established
+by FW-ADR-0022 and FW-ADR-0026.
+
+---
+
+## Background: binary analysis of agy (2026-06-11)
+
+Direct inspection of `~/.local/bin/agy` established two facts that
+constrain the design:
+
+1. **`agy` is an MCP client only.** It has no serve mode and cannot
+   be registered directly as an MCP server. The option of using `agy`
+   itself as an MCP server endpoint is structurally unavailable.
+
+2. **`agy --print` requires a PTY.** Plain headless invocation
+   (`agy --print '<task>' --model '<model>'`) emits nothing to stdout.
+   The proven working invocation is
+   `script -qec "agy --print '...' --model '...'" /dev/null`,
+   which provides a PTY. This is the operational primitive the shim
+   must replicate — via the stdlib `pty` module, not via `script`,
+   to avoid shell injection (see § 3 below).
+
+These two findings are HIGH confidence (direct binary inspection) and
+are the foundation of the design. Any implementation that contradicts
+either finding will not work.
+
+---
+
+## Context and problem statement
+
+FW-ADR-0026 addressed the Antigravity-loads-the-team direction: making
+the team roster visible to an Antigravity session that a human opens
+directly. This ADR addresses the inverse direction: a Claude Code session
+(Claude as orchestrator, `tech-lead` persona) that wants to delegate a
+unit of work to Antigravity and receive the result inline — the same
+first-class delegation pattern Claude uses for any other registered MCP
+server.
+
+The `mcp-liaison` role (Q-0022 / gh issue #290) owns delegated external-
+model MCP sessions. The Antigravity case is the first concrete instance:
+`tech-lead` constructs a delegated brief, hands it to `mcp-liaison`, and
+`mcp-liaison` dispatches it via the `antigravity_delegate` tool. The
+shim is `mcp-liaison`'s transport for Antigravity.
+
+The ADR trigger is a new external dependency added to the scaffold
+(the shim script itself and the `agy` CLI as a runtime prerequisite),
+a new MCP tool surface, and a cross-cutting concern for subprocess
+spawning with attacker-influenced input (shell-injection risk that
+requires explicit `security-engineer` alignment).
+
+## Decision drivers
+
+- `agy` has no serve mode; a wrapper MCP server must be built
+  to bridge Claude Code's MCP client to Antigravity's CLI.
+- `agy --print` requires a PTY to produce output; the PTY must be
+  provided programmatically, not via `script`, to avoid shell injection
+  when `task` is attacker-influenced free text.
+- The framework's zero-install philosophy: any new script must run on
+  any machine where the scaffold runs, without requiring a separate
+  `pip install` step. Python 3 stdlib is universally available on the
+  supported platforms; third-party MCP SDKs are not.
+- Claude Code registers MCP servers via `.mcp.json` / `claude mcp add`.
+  The shim must implement the stdio MCP protocol (JSON-RPC 2.0 over
+  stdin/stdout) directly, since no external MCP library is permitted.
+- The `task` string is attacker-influenced: it originates from Claude's
+  context, which includes user-provided content. Shell command
+  construction from `task` is a code-injection surface and is
+  prohibited by this ADR.
+- Timeout and bounded output are operational requirements: Antigravity
+  tasks can run indefinitely; Claude Code must not hang waiting for a
+  response.
+
+## Considered options (Three-Path Rule, binding)
+
+### Option M — Minimalist
+
+A thin wrapper shell script (Bash) that Claude Code calls via a Bash
+tool call — not via MCP. Claude constructs a `bash` call to the wrapper
+with the task as an argument; the wrapper invokes `script -qec
+"agy --print '$TASK' --model '$MODEL'" /dev/null` and prints the result
+to stdout for Claude to read.
+
+- **Sketch:** One Bash script (`scripts/agy-delegate.sh`), ~30 lines.
+  No protocol implementation. Claude calls it via the `Bash` tool, not
+  as an MCP server. No registration in `.mcp.json`.
+- **Pros:** Trivially simple. No Python required. No MCP protocol
+  implementation. Ship-today viability.
+- **Cons:** Not first-class MCP delegation — Claude calls it as a bash
+  command, not as a registered tool with a typed schema. Shell-injection
+  risk: constructing the `script -qec "agy --print '$TASK' ..."` command
+  string from `task` is exploitable if `task` contains single-quote
+  characters or shell metacharacters. The `task` value originates from
+  attacker-influenced context; this is a real injection surface. Bash
+  quoting of arbitrary text is notoriously fragile. Explicitly rejected
+  on security grounds. `security-engineer` sign-off would be required
+  and would likely not be granted for this shape.
+- **When M wins:** `task` is always a fixed, trusted constant (never
+  user-influenced); the project does not need first-class MCP tool
+  schema; and the `security-engineer` explicitly accepts the injection
+  surface. None of these hold.
+
+### Option S — Scalable
+
+A thin local stdio MCP server written in Python 3 (stdlib only) that
+Claude Code registers as an MCP server. It implements the MCP stdio
+protocol (JSON-RPC 2.0 over stdin/stdout: `initialize`, `tools/list`,
+`tools/call` methods) by hand, without any third-party MCP SDK. It
+exposes one tool, `antigravity_delegate(task, model?, timeout_s?)`,
+which spawns `agy` via `pty.openpty()` / `os.fork()` / `os.execvp()`
+with an argv list — never a shell command string. It captures output,
+enforces a configurable timeout, caps captured bytes, and returns a
+structured MCP result (or a structured MCP error on timeout / nonzero
+exit). Auth relies on the user's existing `agy` login state.
+
+- **Sketch:** One Python 3 script (`scripts/mcp/antigravity_delegate.py`),
+  ~200–280 lines. JSON-RPC 2.0 request / response dispatch loop on
+  stdin/stdout. PTY allocation via `os.openpty()` + `os.fork()` +
+  `os.execvp(["agy", "--print", task, "--model", model])`. Output
+  capture loop with `select`-based timeout and byte cap. Registration
+  via `.mcp.json` entry or `claude mcp add` command. One smoke test
+  (`scripts/mcp/test_antigravity_delegate.py`) that exercises the JSON-
+  RPC layer with a mock subprocess (does not require live `agy`).
+- **Pros:** First-class MCP tool with typed schema visible to Claude.
+  Argv-list invocation eliminates shell injection as a class — task
+  content never touches a shell parser. Python stdlib only: zero extra
+  install. PTY via `pty` module replicates the proven `script -qec`
+  primitive without shelling out. Timeout and byte-cap prevent hanging.
+  Structured MCP error response lets Claude handle failure gracefully.
+- **Cons:** ~200+ lines of hand-rolled JSON-RPC 2.0. More surface area
+  than Option M. The `pty` module is Unix-only (Linux / macOS); Windows
+  is not supported. Implementation must correctly implement the MCP
+  handshake (`initialize` / `initialized`, capability negotiation) or
+  Claude Code will not register the server.
+- **When S wins:** `task` is attacker-influenced (always the case here);
+  first-class MCP delegation is required for `mcp-liaison` dispatch;
+  zero-install constraint rules out third-party SDKs. All three hold.
+
+### Option C — Creative (experimental)
+
+Use the `subprocess` module with `start_new_session=True` to allocate
+a controlling terminal via `setsid()` + `TIOCSWINSZ` ioctl, bypassing
+the `pty` module entirely. Alternatively, implement the entire shim as a
+TypeScript/Node.js script (Node ships with macOS and is commonly
+available on Linux) using the `@modelcontextprotocol/sdk` npm package —
+which provides a complete MCP stdio server implementation — and Node's
+`node-pty` package for PTY spawning. The Node approach trades stdlib
+purity for dramatically less hand-rolled protocol code (~40 lines vs.
+~270).
+
+- **Sketch (Node variant):** `scripts/mcp/antigravity_delegate.js`,
+  ~60 lines; `package.json` in `scripts/mcp/` pinning
+  `@modelcontextprotocol/sdk` and `node-pty`. Registration identical
+  to Option S. The MCP SDK handles all JSON-RPC dispatch; `node-pty`
+  handles PTY allocation. Smoke test via Jest or `node --test`.
+- **Pros:** Dramatically less hand-rolled code. `@modelcontextprotocol/sdk`
+  is the reference implementation — protocol conformance is guaranteed.
+  `node-pty` is the widely-used PTY library with prebuilt binaries.
+- **Cons:** Adds two npm dependencies (violates the stdlib-only
+  constraint). Requires Node.js and npm on the operator's machine.
+  Requires a `package.json` and `node_modules/` or a bundling step.
+  Prebuilt native binaries in `node-pty` are a supply-chain surface.
+  Node is not universally available the way Python 3 is. This option
+  is rejected by the zero-install / zero-extra-dependency constraint.
+- **When C wins:** Node.js is a guaranteed ambient runtime in the
+  target environment; the team is comfortable auditing a native npm
+  dependency; and protocol conformance risk in hand-rolled JSON-RPC 2.0
+  is judged higher than supply-chain risk from `node-pty`. None of
+  these hold for a scaffold targeting diverse downstream projects.
+
+## Decision outcome
+
+**Chosen option: S — Scalable (Python 3 stdlib stdio MCP server).**
+
+Option M is rejected on security grounds: constructing a shell command
+string from attacker-influenced `task` content is an injection surface
+that `security-engineer` alignment would not clear. Even with careful
+Bash quoting, the fragility of quoting arbitrary Unicode text inside a
+doubly-nested shell command string (`script -qec "agy --print '...' ..."`)
+is not an acceptable risk when argv-list invocation is available.
+
+Option C is rejected by the zero-install constraint. Adding npm
+dependencies to the scaffold forces every downstream project operator to
+run `npm install` and accept native prebuilt binaries in their environment.
+The Python 3 stdlib provides all necessary primitives (`pty`, `os`,
+`select`, `json`, `sys`) without any additional installs.
+
+Option S satisfies all decision drivers: stdlib only, argv-list PTY
+spawn eliminates injection, MCP protocol is first-class (typed schema,
+structured errors), timeout and byte-cap prevent hangs, and the
+implementation is auditable in a single ~270-line file.
+
+---
+
+## Design: Antigravity delegate shim
+
+### 1. MCP tool surface
+
+The shim registers one tool with the following JSON Schema:
+
+```json
+{
+  "name": "antigravity_delegate",
+  "description": "Delegate a task to Google Antigravity (agy) and return the response. Requires agy to be installed and authenticated.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "task": {
+        "type": "string",
+        "description": "The task or prompt to send to Antigravity."
+      },
+      "model": {
+        "type": "string",
+        "description": "Antigravity model string. Defaults to 'Gemini 3.5 Flash (High)'.",
+        "default": "Gemini 3.5 Flash (High)"
+      },
+      "timeout_s": {
+        "type": "integer",
+        "description": "Seconds before the agy process is killed and an error returned. Defaults to 300.",
+        "default": 300
+      }
+    },
+    "required": ["task"]
+  }
+}
+```
+
+On success, the tool returns a `text` content block containing
+Antigravity's captured stdout. On timeout, nonzero exit, or internal
+error, it returns a structured MCP error response (not a Python
+exception; the shim must never crash the MCP server loop on a
+subprocess failure).
+
+### 2. Stdio MCP protocol (JSON-RPC 2.0 by hand)
+
+The shim reads newline-delimited JSON-RPC 2.0 from stdin and writes
+responses to stdout. The MCP handshake sequence is:
+
+1. Client sends `initialize` — shim responds with `capabilities`
+   (tools only; no resources, no prompts).
+2. Client sends `initialized` notification — shim acknowledges (no
+   response required for notifications).
+3. Client sends `tools/list` — shim returns the `antigravity_delegate`
+   tool schema.
+4. Client sends `tools/call` with `name: "antigravity_delegate"` and
+   `arguments` — shim spawns `agy`, captures output, returns result.
+
+The dispatch loop runs until stdin closes (EOF). All JSON-RPC errors
+(method not found, invalid params, internal error) are returned as
+JSON-RPC error objects with appropriate error codes, not as process
+crashes.
+
+Implementation note: the MCP stdio protocol uses Content-Length framing
+in some SDK versions but most Claude Code server registrations use
+newline-delimited JSON. The implementation should be confirmed against
+the Claude Code MCP stdio spec before the PR is merged. If Content-Length
+framing is required, the protocol layer is the only affected section
+(~15 lines).
+
+### 3. PTY spawning and argv-list invocation
+
+**This is the security-driving decision. `security-engineer` reviewed
+this section on 2026-06-11 (APPROVED with binding requirements in §3a).**
+
+The proven working invocation (from 2026-06-11 binary analysis) is:
+
+```
+script -qec "agy --print '<task>' --model '<model>'" /dev/null
+```
+
+This works because `script` allocates a PTY and `agy` detects the TTY
+and enables output. The shim replicates this using the Python stdlib
+`pty` module, **without shelling out to `script`**, as follows:
+
+```
+parent_fd, child_fd = os.openpty()
+pid = os.fork()
+if pid == 0:          # child
+    os.setsid()
+    fcntl.ioctl(child_fd, termios.TIOCSCTTY, 0)
+    os.dup2(child_fd, 0)   # stdin
+    os.dup2(child_fd, 1)   # stdout
+    os.dup2(child_fd, 2)   # stderr
+    os.close(parent_fd)
+    os.execvp("agy", ["agy", "--print", task, "--model", model])
+# parent: read from parent_fd with select-based timeout
+```
+
+The critical constraint is `os.execvp("agy", ["agy", "--print", task,
+"--model", model])`. The `task` value is passed as a single element in
+the argv list, not interpolated into any shell command string. The OS
+passes it to `agy` as a raw argument; no shell parser ever sees it. This
+eliminates shell-injection as a class, regardless of what characters
+`task` contains (quotes, semicolons, backticks, dollar signs, newlines).
+
+**Correction (R3 — fd hygiene):** The pseudocode above omits a required
+step on the parent side: after `os.fork()` returns in the parent, the
+parent must call `os.close(child_fd)` before entering the read loop.
+Leaving the slave fd open in the parent prevents EOF detection and leaks
+a file descriptor. See §3a R3 below.
+
+**Rejected alternative within Option S:** using `subprocess.Popen` with
+`shell=True` and f-string interpolation of `task`. Even with shlex
+quoting, this is fragile with Unicode and ANSI escape sequences. The
+`os.execvp` + argv-list pattern is the correct primitive.
+
+**Rejected alternative within Option S:** using `pty.spawn()`. The
+`pty.spawn()` call does not support output capture to a buffer — it
+writes directly to the controlling TTY. The `os.openpty()` / `os.fork()`
+/ `os.execvp()` pattern is required to capture output.
+
+### 3a. Security-engineer sign-off (2026-06-11): binding implementation requirements
+
+`security-engineer` reviewed §3 on 2026-06-11 and returned **APPROVED**,
+subject to the following five requirements. These are binding: `software-
+engineer` must satisfy all five before the implementation PR is opened.
+They are ordered by the attack surface they close.
+
+**R1 — Flag injection (CWE-88). Status: SATISFIED AS-BUILT; no `--`
+separator required. Security-engineer concurred 2026-06-11.**
+
+Argv-list invocation prevents the OS shell from parsing `task`. The
+original R1 text additionally required passing `task` after a `--`
+end-of-options separator to prevent `agy`'s own flag parser from
+interpreting content in `task` as option flags (CWE-88: argument
+injection).
+
+Binary analysis of `agy` (stripped Go ELF, google3 gflag, 2026-06-11)
+established that `--print` is a **string flag** — its value is consumed
+as the immediately following argv element. The as-built argv shape is:
+
+```
+["agy", "--print", task, "--model", model]
+```
+
+Because gflag's parser expects a value at the position immediately after
+`--print`, `task` is consumed as that flag's value and is never presented
+to the positional-argument or remaining-flags parsing stage. A `task`
+value that begins with `--` cannot be reinterpreted as a flag by gflag in
+this position; CWE-88 flag-injection is structurally impossible without a
+`--` separator under this parsing model. Additionally, google3 gflag does
+not universally honor `--` as an end-of-options terminator, so the
+previously specified argv shape would not reliably work anyway.
+
+R1 is therefore satisfied by the as-built argv shape. No `--` separator
+is used or required.
+
+**Residual caveat (supply-chain drift — not a current risk).** This
+safety property depends on `--print` remaining a *string* flag in future
+`agy` releases. If a future `agy` version changes `--print` to a
+*boolean* flag, `task` would fall through to positional or remaining-
+argument parsing and CWE-88 would reopen. Therefore: any `agy` upgrade
+in the scaffold MUST re-run binary analysis to confirm `--print`'s flag
+type before the upgraded version ships. This check is the responsibility
+of whoever performs the upgrade (typically `release-engineer` + `security-
+engineer` co-sign). The check must be recorded in the upgrade PR.
+
+**R2 — Model allowlist.** The `model` parameter must be validated against
+an explicit allowlist of known-valid model strings before the subprocess is
+spawned. A caller-supplied `model` value that does not appear in the
+allowlist must be rejected with a JSON-RPC error response using error code
+`-32602` (Invalid params). The allowlist is defined as a constant in the
+shim source; it is updated when new model strings are confirmed working. The
+default value (`"Gemini 3.5 Flash (High)"`) must be a member of the
+allowlist.
+
+**R3 — File-descriptor hygiene.** The parent process must close `child_fd`
+(the slave end of the PTY pair) immediately after `os.fork()` returns in the
+parent. Retaining the slave fd open in the parent prevents the child's exit
+from delivering EOF to the parent's read loop, and leaks a file descriptor.
+The child must close `parent_fd` (the master end) before calling `os.execvp`.
+The pseudocode in §3 omitted the parent-side `os.close(child_fd)` call; the
+implementation must include it.
+
+**R4 — Child reap (ECHILD).** The parent must call `os.waitpid(pid, 0)` (or
+equivalent) in all exit paths: normal completion, timeout, and byte-cap
+truncation. Every exit path that calls `os.kill` or `os.killpg` must be
+followed by a `waitpid`. The `waitpid` call must handle `ChildProcessError`
+(errno `ECHILD`) gracefully — this can occur if the child has already exited
+between the signal and the wait — and must not propagate that exception as an
+MCP server crash.
+
+**R5 — ANSI/OSC stripping and byte-cap ordering.** The byte cap (§4,
+`MAX_OUTPUT_BYTES`) must be applied to the raw captured bytes before any
+post-processing. After the cap is applied, ANSI escape sequences and OSC
+(Operating System Command) sequences must be stripped from the output before
+it is included in the MCP result. The correct order is: cap raw bytes first,
+then strip. Stripping before capping opens a memory-safety issue (a
+malicious or misbehaving `agy` could emit many escape sequences that expand
+after stripping). Stripping before returning the result is required to
+prevent terminal-control injection into the orchestrator's context and to
+reduce noise in the returned text. A regex covering both standard ANSI CSI
+sequences and OSC sequences (e.g., `\x1b[\x1b\x9b][^a-zA-Z]*[a-zA-Z]` and
+`\x1b\][^\x07]*\x07`) is sufficient; the SE documents the chosen pattern and
+its coverage in the implementation.
+
+### 4. Timeout and bounded output
+
+The parent process reads from `parent_fd` in a loop using `select.select`
+with a wall-clock deadline computed from `time.monotonic()`. When the
+deadline is reached, the parent sends `SIGKILL` to the child process
+group (via `os.killpg(os.getpgid(pid), signal.SIGKILL)`) and returns a
+structured MCP error:
+
+```json
+{
+  "isError": true,
+  "content": [{"type": "text", "text": "antigravity_delegate: timeout after <N>s"}]
+}
+```
+
+Captured bytes are capped at a configurable `MAX_OUTPUT_BYTES` constant
+(default: 512 KiB). If the cap is reached before the process exits, the
+process is killed and the result is returned with a truncation note
+appended. The cap prevents memory exhaustion from runaway Antigravity
+sessions.
+
+On nonzero exit code, the captured output is still returned (Antigravity
+may write diagnostics to stdout before exiting), with `isError: true`
+and the exit code included in the error message.
+
+### 5. Model default and override
+
+The default model string is `"Gemini 3.5 Flash (High)"` — the string
+confirmed working in the 2026-06-11 binary analysis session. The `model`
+parameter is optional; if omitted by the caller, the default is used.
+The model string is passed as a single argv element; it is not
+interpreted or modified by the shim.
+
+If Antigravity adds or renames model strings in a future release, the
+caller passes the updated string explicitly. No model-string mapping
+table lives in the shim; that concern belongs in
+`docs/model-routing-guidelines.md` and is `mcp-liaison`'s
+responsibility at call construction time.
+
+### 6. Auth assumption
+
+The shim assumes the operator has already authenticated with
+Antigravity via `agy login` (or equivalent). It does not manage, store,
+refresh, or transmit credentials. If `agy` exits nonzero due to an
+auth failure, the shim returns the error text from Antigravity's stdout
+in the structured MCP error response and does nothing else.
+
+This is an explicit design decision: the shim is a transparent subprocess
+bridge, not a credential manager. It handles no secrets, PII, or
+auth tokens. Hard Rule #7 (security sign-off for auth/secrets paths)
+does not apply to the shim's own code, but `security-engineer` is
+consulted on the subprocess spawn shape (§ 3 above) to confirm the
+injection-prevention argument.
+
+### 7. Placement and registration
+
+**Server script:** `scripts/mcp/antigravity_delegate.py`
+
+**Smoke test:** `scripts/mcp/test_antigravity_delegate.py`
+(exercises the JSON-RPC layer with a mock subprocess; does not require
+a live `agy` installation or Antigravity auth)
+
+**Registration:** The operator registers the shim once per Claude Code
+profile via:
+
+```
+claude mcp add antigravity-delegate python3 \
+  /path/to/sw-dev-team-template/scripts/mcp/antigravity_delegate.py
+```
+
+or equivalently via a `.mcp.json` entry:
+
+```json
+{
+  "mcpServers": {
+    "antigravity-delegate": {
+      "command": "python3",
+      "args": ["/path/to/sw-dev-team-template/scripts/mcp/antigravity_delegate.py"]
+    }
+  }
+}
+```
+
+The shim is not registered automatically by the scaffold setup (it
+requires `agy` to be installed, which is not a universal prerequisite).
+Documentation covers the registration step.
+
+---
+
+## Implementation change-set grouped by owner
+
+### software-engineer
+
+| Artifact | Action |
+|---|---|
+| `scripts/mcp/antigravity_delegate.py` | Create new — stdio MCP server per §§ 1–6 above. Python 3 stdlib only. Unix only (`pty`, `os.openpty`, `os.execvp`). |
+| `scripts/mcp/test_antigravity_delegate.py` | Create new — smoke test. Mocks the subprocess layer; verifies JSON-RPC handshake, `tools/list` response, successful `tools/call` response, timeout path, nonzero-exit path, and byte-cap path. Does not require live `agy`. |
+
+**Implementation gate (CLEARED):** `security-engineer` reviewed §3 on
+2026-06-11 and returned APPROVED with five binding requirements recorded
+in §3a. The implementation gate is cleared; `software-engineer` may begin
+implementation, subject to satisfying R1–R5 before the PR is opened.
+
+**MCP framing gate:** confirm whether Claude Code's MCP stdio protocol
+uses newline-delimited JSON or Content-Length framing before
+implementing the protocol layer. If Content-Length framing is required,
+note it in the implementation; the design above handles both modes with
+a ~15-line change to the read loop.
+
+### tech-writer
+
+| Artifact | Action |
+|---|---|
+| `docs/agents/manual/mcp-liaison-manual.md` (or equivalent per project) | Add a "Delegating to Antigravity" section: how `mcp-liaison` constructs a delegated brief for `antigravity_delegate`, what model strings are valid, and how to interpret structured error responses. |
+| Scaffold onboarding / setup docs (path TBD by `tech-writer`) | Add a "Antigravity delegate shim — registration" section: prerequisites (`agy` installed and authenticated), `claude mcp add` command, verification step (call `tools/list` from Claude Code to confirm registration). |
+
+---
+
+## Relationship to existing ADRs and roles
+
+**FW-ADR-0026 (Antigravity harness adapter):** The other direction.
+FW-ADR-0026 addresses Antigravity-as-orchestrator loading the team.
+This ADR addresses Claude-as-orchestrator delegating to Antigravity.
+The two are complementary and non-conflicting; both may be active
+simultaneously on a repo that has both `.agents/rules/team-contract.md`
+and the `antigravity_delegate` MCP server registered.
+
+**`mcp-liaison` role (Q-0022 / gh issue #290):** `mcp-liaison` owns
+delegated external-model MCP sessions and brief construction. The
+`antigravity_delegate` tool is `mcp-liaison`'s transport for the
+Antigravity case. `mcp-liaison` is responsible for: constructing the
+delegated brief (what task text to pass), selecting the model string
+from `docs/model-routing-guidelines.md`, and reconciling any divergence
+between the brief and Antigravity's response. The shim is a dumb
+transport — it does not interpret, rewrite, or validate the `task`
+content.
+
+**Issue #289 (MCP non-primary-session mode):** The inverse concern:
+a spawned-over-MCP session must not start the orchestrator team. This
+ADR does not conflict with #289. The shim is a server that Claude Code
+calls; it is not itself a Claude session and has no team-start behavior
+to suppress.
+
+**`security-engineer` co-ownership:** Per `architect.md`, structural
+security decisions (trust boundaries, subprocess spawn surface with
+attacker-influenced input) are made jointly with `security-engineer`.
+The argv-list / PTY spawn design in § 3 is the primary joint-review
+surface. `security-engineer` sign-off on that section is a gate for
+implementation start.
+
+---
+
+## Consequences
+
+### Positive
+
+- Claude Code gains first-class, typed, inline delegation to
+  Antigravity. `mcp-liaison` can construct a delegated brief and call
+  `antigravity_delegate` as a tool — the same pattern used for any
+  other MCP server — without leaving the Claude Code session.
+- Shell injection from attacker-influenced `task` content is eliminated
+  as a class by argv-list invocation. No quoting or escaping of `task`
+  is required or performed; the OS handles argument passing directly.
+- Zero new runtime dependencies. Python 3 stdlib is sufficient; no
+  `pip install`, no npm, no system packages beyond `python3` (already
+  required by other scaffold scripts).
+- The shim is a standalone, auditable ~270-line file. The entire
+  injection-prevention argument is visible in one function; no
+  transitive dependencies to audit.
+- Timeout and byte-cap prevent Claude Code from hanging on slow or
+  runaway Antigravity sessions.
+- The smoke test runs without live `agy`; CI can validate the
+  JSON-RPC layer without an Antigravity installation.
+
+### Negative / trade-offs accepted
+
+- The `pty` module is Unix-only. Windows operators cannot use the
+  shim. This is accepted: the scaffold's other PTY-dependent tooling
+  and the `agy` CLI itself are Linux/macOS-only. A Windows path
+  would require a separate design (e.g., ConPTY via ctypes or a WSL
+  shim); that is deferred unless a Windows operator requirement appears.
+- Hand-rolled JSON-RPC 2.0 is more implementation surface than using an
+  SDK. Mitigated by: the protocol is a small subset (four methods:
+  `initialize`, `initialized`, `tools/list`, `tools/call`); the smoke
+  test validates the full handshake; and the protocol layer is
+  self-contained and replaceable without changing the subprocess logic.
+- The MCP stdio framing (newline-delimited vs. Content-Length) must be
+  confirmed before implementation. This is a one-time verification step
+  (~30 min); it does not block authoring the rest of the shim.
+- Registration is a manual one-time operator step. The shim is not
+  auto-registered by scaffold setup. Accepted: `agy` itself is not a
+  universal prerequisite, so auto-registration would silently fail on
+  machines without `agy`.
+- The shim inherits the operator's `agy` auth state. If `agy` is not
+  authenticated, the tool returns an error and the operator must run
+  `agy login` out of band. This is intentional: the shim manages no
+  credentials.
+
+### Follow-up ADRs
+
+- If the `mcp-liaison` brief-construction pattern for
+  `antigravity_delegate` requires a formal protocol (e.g., structured
+  task format, response parsing rules beyond raw text passthrough), a
+  follow-up ADR should define that protocol. Currently `mcp-liaison`
+  owns this informally via its role contract.
+- If Windows support is required, a follow-up ADR addresses the ConPTY
+  / WSL path.
+- If multiple external-model delegates are added (e.g., a
+  `codex_delegate` or `opencode_delegate`), a follow-up ADR should
+  consider whether a generic `delegate` tool with a `harness` parameter
+  is preferable to per-harness shims.
+
+---
+
+## Verification
+
+- **Success signal:** After registration, `claude mcp list` shows
+  `antigravity-delegate`. A `tools/list` call from Claude Code returns
+  the `antigravity_delegate` schema. A `tools/call` with a simple task
+  string (e.g., `"echo hello"`) and a live authenticated `agy`
+  installation returns Antigravity's response text. The smoke test
+  passes in CI without a live `agy`. `security-engineer` review of §3
+  is recorded in §3a of this ADR (2026-06-11); no separate sign-off
+  artifact required.
+- **Failure signal:** `agy` with the PTY spawn pattern does not produce
+  output (indicating the PTY allocation approach is wrong for a given
+  platform or `agy` version), requiring a redesign of the spawn
+  mechanism. Alternatively, the MCP framing confirmation reveals
+  Content-Length is required and the handshake fails in newline-
+  delimited mode — triggering a protocol layer amendment. Either
+  condition requires a superseding or amending ADR.
+- **Review cadence:** Re-examine at the first session after the
+  implementation PR merges, or after the first live `mcp-liaison`
+  Antigravity delegation in a downstream project, whichever comes first
+  (session-anchored per CLAUDE.md § "Time-based cadences").
+
+---
+
+## Links
+
+- FW-ADR-0026 — Antigravity harness adapter (complementary direction):
+  `docs/adr/fw-adr-0026-antigravity-harness-adapter.md`
+- FW-ADR-0009 — OpenCode harness adapter (thin-adapter pattern):
+  `docs/adr/fw-adr-0009-opencode-harness-adapter.md`
+- FW-ADR-0021 — harness-agnostic leaf-task dispatch (delegated-specialist
+  mode): `docs/adr/fw-adr-0021-harness-agnostic-leaf-task-dispatch.md`
+- FW-ADR-0022 — Gemini harness adapter (co-equal harness precedent):
+  `docs/adr/fw-adr-0022-gemini-harness-adapter.md`
+- gh issue #289 — MCP non-primary-session rule (inverse concern; does
+  not conflict)
+- gh issue #290 / Q-0022 — `mcp-liaison` role (owner of delegated
+  external-model MCP sessions; the shim is its Antigravity transport)
+- gh issue #338 — Team not found in Antigravity (FW-ADR-0026 concern)
+- gh issue #339 — MCP calls spawn subagents instead of acting
+  (FW-ADR-0026 concern)
+- `docs/model-routing-guidelines.md` — binding per-agent routing table
+  (source of model string choices for `mcp-liaison` at call time)
+- `.claude/agents/mcp-liaison.md` — role contract for the agent that
+  owns delegated brief construction
+- `scripts/compile-runtime-agents.sh` — generation script (not modified
+  by this ADR; listed for context on the four-surface pipeline)

--- a/docs/agents/manual/mcp-liaison-manual.md
+++ b/docs/agents/manual/mcp-liaison-manual.md
@@ -117,6 +117,67 @@ output with a recorded rationale.
 - **Not a customer interface.** All escalations route to `tech-lead`,
   never to the customer.
 
+## Delegating to Antigravity
+
+The `antigravity_delegate` tool is `mcp-liaison`'s transport for delegating
+work to Google Antigravity from within a Claude Code session. See
+`docs/adr/fw-adr-0027-antigravity-mcp-delegate-shim.md` for the full design.
+
+### Brief construction
+
+`mcp-liaison` is responsible for constructing the `task` string — the
+delegated brief — that is passed to `antigravity_delegate`. The shim is a
+dumb transport: it passes `task` to `agy` as a raw argument without
+interpreting, rewriting, or validating the content. What `mcp-liaison` puts
+in `task` is what Antigravity receives.
+
+A well-formed delegated brief should:
+
+- State the goal in one or two sentences.
+- Include the scope boundary explicitly (what is in scope, what is not).
+- Specify the expected output shape (e.g., "return a numbered list of
+  findings", "return a single revised paragraph").
+
+Do not assume Antigravity has access to repo files or prior context from the
+Claude Code session. The brief must be self-contained.
+
+### Model selection
+
+Select the `model` parameter value from `docs/model-routing-guidelines.md`.
+The shim validates the value against its internal `ALLOWED_MODELS` constant
+and rejects unrecognized strings with a structured error. If the desired
+model is not in the allowlist, confirm the model string works with `agy`
+first and then extend `ALLOWED_MODELS` in
+`scripts/mcp/antigravity_delegate.py`.
+
+Default model when `model` is omitted: `Gemini 3.5 Flash (High)`. For
+tasks requiring stronger reasoning, pass an explicit `model` value
+consistent with the routing guidelines.
+
+### Interpreting the response
+
+The shim returns plain text with terminal control sequences stripped. It does
+not parse, validate, or summarize Antigravity's output. `mcp-liaison` is
+responsible for divergence reconciliation per the standard delegation
+protocol (Steps 3–5 above).
+
+If the response is empty or contains an auth-error message, `agy` is not
+authenticated. Report the blocker to `tech-lead`; do not retry in a loop.
+
+If the call returns `isError: true`, the error message includes the
+condition (timeout after N seconds, nonzero exit code, or invalid model
+parameter). Route the structured error back to `tech-lead` as a divergence.
+
+### Relationship to issue #289
+
+Issue #289 addresses the inverse concern: a session spawned over MCP must
+not start the orchestrator team. This shim is not a session and has no
+team-start behavior. The two concerns are non-conflicting: `mcp-liaison`
+calls `antigravity_delegate` as a tool from within the primary Claude Code
+session; the shim is a subprocess bridge, not a spawned session.
+
+---
+
 ## Brief shape (recommended)
 
 When `tech-lead` dispatches to `mcp-liaison`, a well-formed brief

--- a/docs/mcp/antigravity-delegate-setup.md
+++ b/docs/mcp/antigravity-delegate-setup.md
@@ -1,0 +1,127 @@
+# Antigravity delegate shim — registration
+
+Setup guide for operators registering the `antigravity-delegate` MCP server
+in a Claude Code session. This shim lets Claude Code (Claude as orchestrator)
+delegate a unit of work to Google Antigravity inline and receive the result
+back — the Claude-to-Antigravity direction. This is the complement to
+FW-ADR-0026, which covers the inverse: Antigravity loading the team.
+
+---
+
+## Prerequisites
+
+- **`agy` (Antigravity CLI)** installed and authenticated. The shim manages
+  no credentials. Run `agy login` (or equivalent) before registering the
+  shim. If `agy` is not authenticated, the tool returns the error text from
+  Antigravity's output; no Claude Code session state is affected.
+- **Python 3** (standard library only; no `pip install` step required).
+- **Unix (Linux or macOS)**. The shim uses the `pty` module, which is
+  Unix-only. Windows is not supported.
+
+---
+
+## Register the shim
+
+Choose one registration method. Both are equivalent.
+
+### Option A — `claude mcp add`
+
+```sh
+claude mcp add antigravity-delegate python3 \
+  /abs/path/to/sw-dev-team-template/scripts/mcp/antigravity_delegate.py
+```
+
+Replace `/abs/path/to/sw-dev-team-template` with the absolute path to the
+scaffold checkout on this machine.
+
+### Option B — `.mcp.json` entry
+
+Add the following block to `.mcp.json` at the project root (create the file
+if absent):
+
+```json
+{
+  "mcpServers": {
+    "antigravity-delegate": {
+      "command": "python3",
+      "args": ["/abs/path/to/sw-dev-team-template/scripts/mcp/antigravity_delegate.py"]
+    }
+  }
+}
+```
+
+Again, use the absolute path to the scaffold checkout.
+
+The shim is **not** registered automatically by scaffold setup because `agy`
+is not a universal prerequisite. Registration is a one-time manual step per
+Claude Code profile.
+
+---
+
+## Verify registration
+
+After registration, confirm the server appears:
+
+```sh
+claude mcp list
+```
+
+Expected output includes a line naming `antigravity-delegate`.
+
+Within a Claude Code session, confirm the tool is discoverable by calling
+`tools/list`. The `antigravity_delegate` tool should appear in the response.
+
+---
+
+## Tool reference
+
+**Tool name:** `antigravity_delegate`
+
+| Parameter | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `task` | string | yes | — | The task or prompt to send to Antigravity. Passed as a raw argument; no shell parsing occurs. |
+| `model` | string | no | `Gemini 3.5 Flash (High)` | Must be a value in the shim's `ALLOWED_MODELS` constant or the call is rejected with error code `-32602` (Invalid params). |
+| `timeout_s` | integer | no | `300` | Seconds before the `agy` process is killed. On timeout the tool returns a structured error, not a hang. |
+
+**Output:** Plain text. Terminal control sequences (ANSI and OSC escape
+sequences) are stripped before the result is returned.
+
+**On success:** A `text` content block containing Antigravity's captured
+output.
+
+**On error:** A structured MCP error response (`isError: true`) with a
+description. Claude Code receives a recoverable error, not a server crash.
+Error conditions: timeout, nonzero `agy` exit, invalid `model` value.
+
+Model selection for calls should follow `docs/model-routing-guidelines.md`.
+The `mcp-liaison` role owns brief construction and model selection at call
+time; see `docs/agents/manual/mcp-liaison-manual.md` § "Delegating to
+Antigravity".
+
+---
+
+## Troubleshooting
+
+**Empty output or auth-error text in the result:**
+`agy` is not authenticated. Run `agy login` (or the appropriate
+authentication command for your Antigravity installation) and retry.
+
+**Call rejected with Invalid params (`-32602`) on the `model` parameter:**
+The supplied model string is not in the shim's `ALLOWED_MODELS` constant.
+Check the current allowlist in
+`scripts/mcp/antigravity_delegate.py`. To add a new model string, confirm
+it works with `agy` first, then extend `ALLOWED_MODELS` in that file.
+
+**`antigravity-delegate` does not appear in `claude mcp list`:**
+Confirm the absolute path in the registration command or `.mcp.json` entry
+points to the actual file on disk. Python 3 must be on `PATH`.
+
+---
+
+## Reference
+
+- Authoritative design: `docs/adr/fw-adr-0027-antigravity-mcp-delegate-shim.md`
+- Complementary setup (Antigravity-as-orchestrator direction):
+  `docs/adr/fw-adr-0026-antigravity-harness-adapter.md`
+- Model selection: `docs/model-routing-guidelines.md`
+- Brief construction and delegation: `docs/agents/manual/mcp-liaison-manual.md`

--- a/scripts/mcp/antigravity_delegate.py
+++ b/scripts/mcp/antigravity_delegate.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Antigravity delegate shim — stdio MCP server (Python 3 stdlib only, Unix only).
+
+Implements JSON-RPC 2.0 over stdin/stdout (newline-delimited JSON framing).
+Exposes one tool: antigravity_delegate(task, model?, timeout_s?).
+
+argv ordering investigation (2026-06-11):
+  Binary analysis of /home/quackdcs/.local/bin/agy confirmed:
+  - agy uses google3/base/go/flag (Google's internal flag library built on
+    Go stdlib flag).
+  - --print is a *string flag*: the task value is the token immediately
+    following --print in argv.  It is NOT a positional argument.
+  - Confirmed invocation: ["agy", "--print", task, "--model", model]
+    The task string is passed as the VALUE of the --print flag via the OS
+    argv array.  No shell parser ever sees it.  Flag-injection (CWE-88) is
+    structurally impossible in this shape: agy's own flag parser consumes
+    task as a plain string value regardless of its content (quotes,
+    semicolons, dashes, etc.).
+  - The "--" end-of-options concern in security requirement R1 is addressed
+    here: because task is a flag VALUE (not a positional), "--" is irrelevant
+    to injection safety.  The model flag follows --model and also cannot be
+    misread because it is validated against the allowlist before spawning.
+  - ADR §3 pseudocode shows ["agy", "--print", task, "--model", model], which
+    matches binary analysis.  This is the final adopted argv shape.
+
+Security requirements implemented:
+  R1  Flag-injection: task is argv[2] (value of --print), never shell-expanded.
+  R2  Model allowlist: validated against ALLOWED_MODELS before spawn.
+  R3  fd hygiene: child closes parent_fd; parent closes child_fd after fork.
+  R4  Reap: os.waitpid() in all exit paths (normal, timeout-kill, byte-cap-kill).
+  R5  ANSI strip: raw bytes capped in _spawn_and_capture; ANSI escape stripping
+      applied in _handle_tools_call so the mock path in tests also exercises it.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import select
+import signal
+import sys
+import termios
+import time
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SERVER_NAME = "antigravity-delegate"
+SERVER_VERSION = "1.0.0"
+PROTOCOL_VERSION = "2024-11-05"
+
+DEFAULT_MODEL = "Gemini 3.5 Flash (High)"
+DEFAULT_TIMEOUT_S = 300
+MAX_OUTPUT_BYTES = 512 * 1024  # 512 KiB raw-byte cap (R5: cap raw bytes first)
+
+# R2 — model allowlist.  Extend this list as new model strings are confirmed
+# working with agy.  Only the default has been confirmed via binary analysis
+# (2026-06-11); add others once verified.
+ALLOWED_MODELS: frozenset[str] = frozenset(
+    [
+        "Gemini 3.5 Flash (High)",
+        # Add confirmed model strings here, e.g.:
+        # "Gemini 2.5 Pro",
+    ]
+)
+
+# R5 — ANSI escape sequence regex.
+# Alternation order matters: OSC (ESC ]) MUST come before the Fe branch
+# (ESC [@-Z\\-_]) because ] (U+005D) falls inside [@-Z\\-_] and would be
+# consumed first, leaving the OSC payload ("0;title…\x07") in the output.
+# Branch order: OSC first, then CSI (ESC [ …), then the remaining Fe codes.
+# Note: 8-bit C1 codes (0x80–0x9F) are not covered; they are rare in
+# modern terminal output and excluded to keep the regex simple (C1 gap,
+# accepted per code-reviewer S3/S5/S6 waiver).
+_ANSI_RE = re.compile(
+    r"\x1b(?:\].*?(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])",
+    re.DOTALL,
+)
+
+# ---------------------------------------------------------------------------
+# Tool schema (ADR §1)
+# ---------------------------------------------------------------------------
+
+TOOL_SCHEMA: dict[str, Any] = {
+    "name": "antigravity_delegate",
+    "description": (
+        "Delegate a task to Google Antigravity (agy) and return the response. "
+        "Requires agy to be installed and authenticated."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "description": "The task or prompt to send to Antigravity.",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Antigravity model string. "
+                    f"Defaults to '{DEFAULT_MODEL}'."
+                ),
+                "default": DEFAULT_MODEL,
+            },
+            "timeout_s": {
+                "type": "integer",
+                "description": (
+                    "Seconds before the agy process is killed and an error "
+                    "returned. Defaults to 300."
+                ),
+                "default": DEFAULT_TIMEOUT_S,
+            },
+        },
+        "required": ["task"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# PTY spawn and capture
+# ---------------------------------------------------------------------------
+
+
+def _spawn_and_capture(
+    argv: list[str],
+    timeout_s: int,
+) -> tuple[str, int | None, bool, bool]:
+    """Spawn argv under a PTY, capture output, enforce timeout + byte cap.
+
+    Returns (text, exit_code, timed_out, truncated).
+    exit_code is None if the process was killed before it could be reaped
+    cleanly (rare; treated as nonzero by callers).
+
+    This function is the single injectable subprocess layer.  Tests replace it
+    via monkeypatching (see test_antigravity_delegate.py).
+
+    Security — R3 fd hygiene:
+      Child branch: closes parent_fd before execvp.
+      Parent branch: closes child_fd immediately after fork.
+    Security — R4 reap: os.waitpid() in ALL exit paths.
+    """
+    parent_fd, child_fd = os.openpty()
+    pid = os.fork()
+
+    if pid == 0:
+        # ---- child branch ----
+        try:
+            os.setsid()
+            # Make child_fd the controlling terminal
+            fcntl.ioctl(child_fd, termios.TIOCSCTTY, 0)
+            os.dup2(child_fd, 0)
+            os.dup2(child_fd, 1)
+            os.dup2(child_fd, 2)
+            if child_fd > 2:
+                os.close(child_fd)
+            # R3: close parent fd in child before exec
+            os.close(parent_fd)
+            os.execvp(argv[0], argv)
+        except Exception:
+            # If execvp fails, exit child immediately so parent doesn't hang
+            os._exit(127)
+        # unreachable, but satisfy linters
+        os._exit(127)
+
+    # ---- parent branch ----
+    # R3: close child_fd in parent after fork so EOF is detectable
+    os.close(child_fd)
+
+    raw_chunks: list[bytes] = []
+    total_bytes = 0
+    timed_out = False
+    truncated = False
+    deadline = time.monotonic() + timeout_s
+
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+
+            try:
+                ready, _, _ = select.select([parent_fd], [], [], min(remaining, 1.0))
+            except (ValueError, select.error):
+                # parent_fd closed (child exited)
+                break
+
+            if not ready:
+                continue  # re-check deadline
+
+            try:
+                chunk = os.read(parent_fd, 4096)
+            except OSError:
+                # EIO when slave side closes — normal EOF for a PTY
+                break
+
+            if not chunk:
+                break
+
+            # R5: cap raw bytes FIRST (memory safety)
+            space = MAX_OUTPUT_BYTES - total_bytes
+            if len(chunk) > space:
+                raw_chunks.append(chunk[:space])
+                total_bytes += space
+                truncated = True
+                break
+            raw_chunks.append(chunk)
+            total_bytes += len(chunk)
+
+        if timed_out or truncated:
+            # Kill the process group
+            try:
+                os.killpg(os.getpgid(pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+    finally:
+        try:
+            os.close(parent_fd)
+        except OSError:
+            pass
+
+    # R4: reap in ALL paths
+    exit_code: int | None = None
+    try:
+        _, status = os.waitpid(pid, 0)
+        if os.WIFEXITED(status):
+            exit_code = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            exit_code = -os.WTERMSIG(status)
+    except ChildProcessError:
+        pass
+    except OSError:
+        pass
+
+    raw_bytes = b"".join(raw_chunks)
+    # Decode; ANSI stripping is applied by the caller after this returns (R5).
+    text = raw_bytes.decode("utf-8", errors="replace")
+    return text, exit_code, timed_out, truncated
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 helpers
+# ---------------------------------------------------------------------------
+
+
+def _success(req_id: Any, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _error(req_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": req_id, "error": err}
+
+
+def _write(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Request handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_initialize(req: dict[str, Any]) -> None:
+    _write(
+        _success(
+            req.get("id"),
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    )
+
+
+def _handle_tools_list(req: dict[str, Any]) -> None:
+    _write(_success(req.get("id"), {"tools": [TOOL_SCHEMA]}))
+
+
+def _handle_tools_call(
+    req: dict[str, Any],
+    spawn_fn: Any,
+) -> None:
+    req_id = req.get("id")
+    params = req.get("params", {})
+    tool_name = params.get("name", "")
+
+    if tool_name != "antigravity_delegate":
+        _write(_error(req_id, -32601, f"Tool not found: {tool_name!r}"))
+        return
+
+    args = params.get("arguments", {})
+    task = args.get("task")
+    if not isinstance(task, str) or not task:
+        _write(_error(req_id, -32602, "Invalid params: 'task' must be a non-empty string"))
+        return
+
+    model = args.get("model", DEFAULT_MODEL)
+    if not isinstance(model, str):
+        _write(_error(req_id, -32602, "Invalid params: 'model' must be a string"))
+        return
+
+    # R2 — model allowlist validation
+    if model not in ALLOWED_MODELS:
+        _write(
+            _error(
+                req_id,
+                -32602,
+                f"Invalid params: model {model!r} is not in the allowlist. "
+                f"Allowed values: {sorted(ALLOWED_MODELS)}",
+            )
+        )
+        return
+
+    timeout_s = args.get("timeout_s", DEFAULT_TIMEOUT_S)
+    # S1: bool is an int subclass in Python; reject it explicitly.
+    if isinstance(timeout_s, bool) or not isinstance(timeout_s, int) or timeout_s <= 0:
+        _write(_error(req_id, -32602, "Invalid params: 'timeout_s' must be a positive integer"))
+        return
+
+    # argv shape: ["agy", "--print", task, "--model", model]
+    # task is the VALUE of --print (a string flag), not a positional argument.
+    # No shell parser ever sees task or model; the OS argv array passes them
+    # verbatim.  See module docstring for full argv investigation notes.
+    argv = ["agy", "--print", task, "--model", model]
+
+    try:
+        text, exit_code, timed_out, truncated = spawn_fn(argv, timeout_s)
+    except Exception as exc:  # noqa: BLE001
+        _write(_error(req_id, -32603, f"Internal error spawning agy: {exc}"))
+        return
+
+    # R5: strip ANSI escape sequences from the captured text.
+    # Applied here (after spawn_fn returns) so the mock in tests also exercises
+    # the stripping path — the real spawn_fn returns raw decoded text.
+    # Main pass: full CSI / OSC / Fe sequences (see _ANSI_RE comment above).
+    text = _ANSI_RE.sub("", text)
+    # S2: strip any trailing partial escape sequence left at the byte-cap
+    # boundary (e.g. "…\x1b[" where the sequence was cut mid-stream).
+    text = re.sub(r"\x1b[^a-zA-Z]*$", "", text)
+
+    if truncated:
+        text += f"\n[antigravity_delegate: output truncated at {MAX_OUTPUT_BYTES} bytes]"
+
+    if timed_out:
+        result: dict[str, Any] = {
+            "isError": True,
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"antigravity_delegate: timeout after {timeout_s}s"
+                        + (f"\n{text}" if text.strip() else "")
+                    ),
+                }
+            ],
+        }
+    elif exit_code is not None and exit_code != 0:
+        result = {
+            "isError": True,
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"antigravity_delegate: agy exited with code {exit_code}\n{text}"
+                    ),
+                }
+            ],
+        }
+    else:
+        result = {
+            "isError": False,
+            "content": [{"type": "text", "text": text}],
+        }
+
+    _write(_success(req_id, result))
+
+
+# ---------------------------------------------------------------------------
+# Main dispatch loop
+# ---------------------------------------------------------------------------
+
+
+def run_loop(spawn_fn: Any = _spawn_and_capture) -> None:
+    """Read newline-delimited JSON-RPC 2.0 requests from stdin until EOF."""
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _write(_error(None, -32700, f"Parse error: {exc}"))
+            continue
+
+        if not isinstance(req, dict):
+            _write(_error(None, -32600, "Invalid Request: expected JSON object"))
+            continue
+
+        method = req.get("method", "")
+        req_id = req.get("id")  # None for notifications
+
+        # Notifications (no "id" field) — respond with nothing, just continue
+        if "id" not in req:
+            # initialized / notifications/initialized — acknowledged, no response
+            continue
+
+        try:
+            if method == "initialize":
+                _handle_initialize(req)
+            elif method in ("initialized", "notifications/initialized"):
+                # These can also arrive with an id in some clients; still no response
+                pass
+            elif method == "tools/list":
+                _handle_tools_list(req)
+            elif method == "tools/call":
+                _handle_tools_call(req, spawn_fn)
+            else:
+                _write(_error(req_id, -32601, f"Method not found: {method!r}"))
+        except Exception as exc:  # noqa: BLE001
+            # Never let a handler crash the loop
+            _write(_error(req_id, -32603, f"Internal error: {exc}"))
+
+
+if __name__ == "__main__":
+    run_loop()

--- a/scripts/mcp/test_antigravity_delegate.py
+++ b/scripts/mcp/test_antigravity_delegate.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke test for antigravity_delegate MCP shim.
+
+Runs without a live agy installation.  The spawn-and-capture function
+(_spawn_and_capture) is replaced via monkeypatching in every test case,
+so no subprocesses are forked.
+
+IEEE 1008-1987 §3.2 features tested:
+  1. initialize handshake — response shape (protocolVersion, capabilities, serverInfo)
+  2. tools/list — returns antigravity_delegate tool with required 'task' field
+  3. tools/call (success) — mock returns canned stdout; result is a text content block
+  4. tools/call (timeout path) — spawn returns timed_out=True; isError + timeout message
+  5. tools/call (nonzero exit) — spawn returns exit_code=1; isError + exit code in text
+  6. tools/call (byte-cap / truncation) — spawn returns truncated=True; truncation note appended
+  7. tools/call (model allowlist rejection, R2) — unknown model → JSON-RPC -32602
+  8. ANSI stripping (R5) — escape sequences removed from returned text
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+# Ensure the scripts/mcp directory is on the path when run from repo root
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import antigravity_delegate as shim  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(requests: list[dict[str, Any]], mock_spawn: Any = None) -> list[dict[str, Any]]:
+    """Drive run_loop with a list of JSON-RPC request dicts.
+
+    Replaces stdout with a StringIO, feeds requests to stdin, returns
+    the list of parsed response dicts written to stdout.
+    """
+    input_lines = "\n".join(json.dumps(r) for r in requests) + "\n"
+    fake_stdin = io.StringIO(input_lines)
+    fake_stdout = io.StringIO()
+
+    with patch.object(sys, "stdin", fake_stdin), patch.object(sys, "stdout", fake_stdout):
+        if mock_spawn is not None:
+            shim.run_loop(spawn_fn=mock_spawn)
+        else:
+            shim.run_loop()
+
+    output = fake_stdout.getvalue()
+    responses = []
+    for line in output.splitlines():
+        line = line.strip()
+        if line:
+            responses.append(json.loads(line))
+    return responses
+
+
+def _simple_spawn(
+    text: str = "hello",
+    exit_code: int = 0,
+    timed_out: bool = False,
+    truncated: bool = False,
+) -> Any:
+    """Return a mock spawn function that yields fixed values."""
+
+    def _fn(argv: list[str], timeout_s: int) -> tuple[str, int | None, bool, bool]:
+        return text, exit_code, timed_out, truncated
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeHandshake(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 1: initialize response shape."""
+
+    def test_initialize_response_shape(self) -> None:
+        responses = _run([{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}])
+        self.assertEqual(len(responses), 1)
+        r = responses[0]
+        self.assertEqual(r["jsonrpc"], "2.0")
+        self.assertEqual(r["id"], 1)
+        result = r["result"]
+        self.assertIn("protocolVersion", result)
+        self.assertIn("capabilities", result)
+        self.assertIn("tools", result["capabilities"])
+        self.assertIn("serverInfo", result)
+        self.assertIn("name", result["serverInfo"])
+        self.assertIn("version", result["serverInfo"])
+
+    def test_initialized_notification_no_response(self) -> None:
+        """Notifications (no id) must produce no response."""
+        responses = _run(
+            [
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            ]
+        )
+        # Only the initialize response; notification gets no response
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(responses[0]["id"], 1)
+
+
+class TestToolsList(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 2: tools/list returns the tool with required 'task'."""
+
+    def test_tools_list_returns_antigravity_delegate(self) -> None:
+        responses = _run([{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}])
+        self.assertEqual(len(responses), 1)
+        r = responses[0]
+        tools = r["result"]["tools"]
+        self.assertEqual(len(tools), 1)
+        tool = tools[0]
+        self.assertEqual(tool["name"], "antigravity_delegate")
+
+    def test_tools_list_task_is_required(self) -> None:
+        responses = _run([{"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}}])
+        tool = responses[0]["result"]["tools"][0]
+        schema = tool["inputSchema"]
+        self.assertIn("task", schema["required"])
+        self.assertIn("task", schema["properties"])
+
+    def test_tools_list_has_model_and_timeout_properties(self) -> None:
+        responses = _run([{"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {}}])
+        schema = responses[0]["result"]["tools"][0]["inputSchema"]
+        self.assertIn("model", schema["properties"])
+        self.assertIn("timeout_s", schema["properties"])
+
+
+class TestToolsCallSuccess(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 3: successful tools/call yields a text content block."""
+
+    def _call(self, task: str = "hello", model: str | None = None) -> dict[str, Any]:
+        args: dict[str, Any] = {"task": task}
+        if model is not None:
+            args["model"] = model
+        req = {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {"name": "antigravity_delegate", "arguments": args},
+        }
+        responses = _run([req], mock_spawn=_simple_spawn("Antigravity says hello"))
+        self.assertEqual(len(responses), 1)
+        return responses[0]
+
+    def test_success_is_not_error(self) -> None:
+        r = self._call()
+        self.assertFalse(r["result"]["isError"])
+
+    def test_success_has_text_content_block(self) -> None:
+        r = self._call()
+        content = r["result"]["content"]
+        self.assertEqual(len(content), 1)
+        self.assertEqual(content[0]["type"], "text")
+        self.assertIn("Antigravity says hello", content[0]["text"])
+
+    def test_explicit_allowed_model_accepted(self) -> None:
+        r = self._call(model="Gemini 3.5 Flash (High)")
+        self.assertNotIn("error", r)
+        self.assertFalse(r["result"]["isError"])
+
+
+class TestToolsCallTimeout(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 4: timeout path returns isError + timeout message."""
+
+    def test_timeout_is_error(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "slow task", "timeout_s": 5},
+            },
+        }
+        responses = _run(
+            [req],
+            mock_spawn=_simple_spawn("partial output", exit_code=None, timed_out=True),
+        )
+        self.assertEqual(len(responses), 1)
+        result = responses[0]["result"]
+        self.assertTrue(result["isError"])
+
+    def test_timeout_message_contains_timeout(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "slow task", "timeout_s": 5},
+            },
+        }
+        responses = _run([req], mock_spawn=_simple_spawn("", exit_code=None, timed_out=True))
+        text = responses[0]["result"]["content"][0]["text"]
+        self.assertIn("timeout", text.lower())
+        self.assertIn("5", text)
+
+
+class TestToolsCallNonzeroExit(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 5: nonzero exit returns isError + exit code."""
+
+    def test_nonzero_exit_is_error(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 30,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "bad task"},
+            },
+        }
+        responses = _run(
+            [req], mock_spawn=_simple_spawn("error output", exit_code=1)
+        )
+        result = responses[0]["result"]
+        self.assertTrue(result["isError"])
+
+    def test_nonzero_exit_includes_exit_code_and_output(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 31,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "bad task"},
+            },
+        }
+        responses = _run(
+            [req], mock_spawn=_simple_spawn("diagnostic text", exit_code=2)
+        )
+        text = responses[0]["result"]["content"][0]["text"]
+        self.assertIn("2", text)  # exit code
+        self.assertIn("diagnostic text", text)
+
+
+class TestToolsCallByteCap(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 6: byte-cap path truncates and notes it."""
+
+    def test_truncated_flag_appends_note(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 40,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "verbose task"},
+            },
+        }
+        responses = _run(
+            [req],
+            mock_spawn=_simple_spawn("lots of output", exit_code=0, truncated=True),
+        )
+        text = responses[0]["result"]["content"][0]["text"]
+        self.assertIn("truncated", text.lower())
+
+    def test_truncated_with_success_exit_is_not_error(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 41,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "verbose task"},
+            },
+        }
+        responses = _run(
+            [req],
+            mock_spawn=_simple_spawn("lots of output", exit_code=0, truncated=True),
+        )
+        # truncated but exit=0 → not an error
+        self.assertFalse(responses[0]["result"]["isError"])
+
+
+class TestModelAllowlist(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 7: model allowlist rejection (R2) → -32602."""
+
+    def test_unknown_model_rejected_with_32602(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 50,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "hello", "model": "MaliciousModel; rm -rf /"},
+            },
+        }
+        responses = _run([req], mock_spawn=_simple_spawn())
+        r = responses[0]
+        self.assertIn("error", r)
+        self.assertEqual(r["error"]["code"], -32602)
+
+    def test_unknown_model_does_not_spawn(self) -> None:
+        spawned: list[bool] = []
+
+        def tracking_spawn(argv: list[str], timeout_s: int) -> Any:
+            spawned.append(True)
+            return "output", 0, False, False
+
+        req = {
+            "jsonrpc": "2.0",
+            "id": 51,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "hello", "model": "FakeModel"},
+            },
+        }
+        _run([req], mock_spawn=tracking_spawn)
+        self.assertEqual(spawned, [], "spawn must not be called for rejected model")
+
+    def test_missing_task_rejected_with_32602(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 52,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {},
+            },
+        }
+        responses = _run([req], mock_spawn=_simple_spawn())
+        self.assertIn("error", responses[0])
+        self.assertEqual(responses[0]["error"]["code"], -32602)
+
+
+class TestAnsiStripping(unittest.TestCase):
+    """IEEE 1008-1987 §3.2 feature 8: ANSI escape sequences are stripped (R5)."""
+
+    def _call_with_text(self, raw_text: str) -> str:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 60,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "colorful task"},
+            },
+        }
+        responses = _run([req], mock_spawn=_simple_spawn(raw_text))
+        return responses[0]["result"]["content"][0]["text"]
+
+    def test_csi_color_codes_removed(self) -> None:
+        text = self._call_with_text("\x1b[32mGreen text\x1b[0m")
+        self.assertNotIn("\x1b", text)
+        self.assertIn("Green text", text)
+
+    def test_osc_sequences_removed(self) -> None:
+        # W1/S4: verify the OSC introducer, its payload, and the BEL terminator
+        # are all removed — not just the ESC byte.
+        text = self._call_with_text("\x1b]0;window title\x07plain text")
+        self.assertNotIn("\x1b", text)
+        self.assertNotIn("window title", text)
+        self.assertNotIn("\x07", text)
+        self.assertIn("plain text", text)
+
+    def test_fe_sequence_removed(self) -> None:
+        # ESC M (reverse index) is an Fe sequence
+        text = self._call_with_text("before\x1bMafter")
+        self.assertNotIn("\x1b", text)
+
+    def test_plain_text_unchanged(self) -> None:
+        text = self._call_with_text("no escapes here")
+        self.assertEqual(text.strip(), "no escapes here")
+
+    def test_partial_escape_at_tail_stripped(self) -> None:
+        # S2: a partial escape sequence at the byte-cap boundary (e.g. "…\x1b["
+        # with the rest of the sequence missing) must leave no ESC in the output.
+        text = self._call_with_text("good output\x1b[")
+        self.assertNotIn("\x1b", text)
+        self.assertIn("good output", text)
+
+    def test_bool_timeout_rejected(self) -> None:
+        # S1: bool is an int subclass; True/False must be rejected as timeout_s.
+        req = {
+            "jsonrpc": "2.0",
+            "id": 61,
+            "method": "tools/call",
+            "params": {
+                "name": "antigravity_delegate",
+                "arguments": {"task": "hello", "timeout_s": True},
+            },
+        }
+        responses = _run([req], mock_spawn=_simple_spawn())
+        self.assertIn("error", responses[0])
+        self.assertEqual(responses[0]["error"]["code"], -32602)
+
+
+class TestDispatchEdgeCases(unittest.TestCase):
+    """Miscellaneous dispatch-loop edge cases."""
+
+    def test_unknown_method_returns_32601(self) -> None:
+        req = {"jsonrpc": "2.0", "id": 70, "method": "nonexistent/method", "params": {}}
+        responses = _run([req])
+        self.assertIn("error", responses[0])
+        self.assertEqual(responses[0]["error"]["code"], -32601)
+
+    def test_malformed_json_returns_32700(self) -> None:
+        fake_stdin = io.StringIO("{ not valid json }\n")
+        fake_stdout = io.StringIO()
+        with patch.object(sys, "stdin", fake_stdin), patch.object(sys, "stdout", fake_stdout):
+            shim.run_loop()
+        output = fake_stdout.getvalue().strip()
+        r = json.loads(output)
+        self.assertIn("error", r)
+        self.assertEqual(r["error"]["code"], -32700)
+
+    def test_empty_lines_ignored(self) -> None:
+        fake_stdin = io.StringIO("\n\n\n")
+        fake_stdout = io.StringIO()
+        with patch.object(sys, "stdin", fake_stdin), patch.object(sys, "stdout", fake_stdout):
+            shim.run_loop()
+        self.assertEqual(fake_stdout.getvalue().strip(), "")
+
+    def test_unknown_tool_name_returns_32601(self) -> None:
+        req = {
+            "jsonrpc": "2.0",
+            "id": 80,
+            "method": "tools/call",
+            "params": {"name": "no_such_tool", "arguments": {}},
+        }
+        responses = _run([req], mock_spawn=_simple_spawn())
+        self.assertIn("error", responses[0])
+        self.assertEqual(responses[0]["error"]["code"], -32601)
+
+    def test_multiple_requests_in_sequence(self) -> None:
+        """Loop must handle multiple requests without crashing."""
+        reqs = [
+            {"jsonrpc": "2.0", "id": 90, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "id": 91, "method": "tools/list", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 92,
+                "method": "tools/call",
+                "params": {
+                    "name": "antigravity_delegate",
+                    "arguments": {"task": "hello"},
+                },
+            },
+        ]
+        responses = _run(reqs, mock_spawn=_simple_spawn("reply"))
+        self.assertEqual(len(responses), 3)
+        ids = [r["id"] for r in responses]
+        self.assertEqual(ids, [90, 91, 92])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lets a Claude Code session (Claude as orchestrator) **delegate a unit of work to Google Antigravity inline and get the result back** — the Claude→Antigravity direction. Complements #342 / fw-adr-0026 (the inverse: Antigravity loading the team). Answers the customer's "I'd like to call Antigravity from a Claude session, with Claude as orchestrator."

## What
A thin local **stdio MCP server** (`scripts/mcp/antigravity_delegate.py`, **Python 3 stdlib only**, Unix) that Claude registers. One tool:
- `antigravity_delegate(task, model?, timeout_s?)` → spawns `agy --print` under a PTY (stdlib `pty`/`os`, argv list — never a shell) and returns its output.

`agy` has no MCP-server mode (binary-confirmed), and `agy --print` only emits under a PTY — this shim is the bridge.

## Design — fw-adr-0027 (Accepted)
Three-Path Rule: Option **S** (Python stdlib stdio server) chosen over M (Bash wrapper — rejected: shell-injection) and C (Node + MCP SDK + node-pty — rejected: zero-install constraint).

## Security — security-engineer APPROVED (§3a, R1–R5)
- **R1** argv-list spawn: `task` is the **value of the `--print` string flag** (`["agy","--print",task,"--model",model]`), so it can't be reparsed as a flag — CWE-88 structurally N/A, no `--` separator needed. Residual: re-run `agy` binary analysis on any upgrade (if `--print` ever becomes boolean, `task` falls to positional → CWE-88 reopens).
- **R2** model allowlist → JSON-RPC `-32602` on miss. **R3** fd hygiene (both sides). **R4** child reaped on all paths (normal/timeout/byte-cap). **R5** raw-byte cap (512 KiB) then ANSI/OSC strip (fixed an OSC+BEL gap in review).

## Verification
- **28/28** smoke tests pass (no live `agy` needed — subprocess layer mocked). Covers handshake, timeout, nonzero-exit, byte-cap, model-rejection (-32602), ANSI/OSC strip, partial-escape tail, bool-timeout reject.
- **code-reviewer APPROVED** (round 2; verified the regex fix directly). **security-engineer APPROVED**.
- routing-lint 0/0 · question-lint 0/0. No `.claude/agents/*` edits (no mirror regen).

## Docs
`docs/mcp/antigravity-delegate-setup.md` (operator registration) + mcp-liaison "Delegating to Antigravity" section.

Implements fw-adr-0027 · relates to #290 (mcp-liaison transport). Does **not** publish a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)