### PR TITLE
ci(codacy): scope opengrep+lizard off antigravity shim (clear FPs)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,22 @@
+---
+# Codacy repository configuration.
+# Scope two engines OFF a single, security-reviewed file. All other Codacy
+# engines (Bandit, Ruff, Prospector, Pylint, duplication, metric) continue
+# to analyze it normally — this is targeted, not a blanket file exclusion.
+#
+# scripts/mcp/antigravity_delegate.py is the Antigravity MCP delegate shim
+# (fw-adr-0027). Two Codacy findings on it are confirmed false positives:
+#   - opengrep (Semgrep successor): "dangerous-subprocess-use-audit" on the
+#     os.execvp call. No-shell argv invocation is the REQUIRED injection-safe
+#     spawn pattern (fw-adr-0027 §3a R1; CWE-88 prevention; security-engineer
+#     approved). Codacy's opengrep wrapper does not honor inline # nosemgrep.
+#   - lizard: cyclomatic-complexity > 8 on _read_until_done, a select/read
+#     loop already factored into helpers and reviewed; Codacy's limit (8) is
+#     stricter than the project's pylint config (file rates pylint 10/10).
+engines:
+  opengrep:
+    exclude_paths:
+      - "scripts/mcp/antigravity_delegate.py"
+  lizard:
+    exclude_paths:
+      - "scripts/mcp/antigravity_delegate.py"


### PR DESCRIPTION
Adds a repo `.codacy.yaml` to clear the two confirmed Codacy false-positives on `scripts/mcp/antigravity_delegate.py` (the fw-adr-0027 shim) that can't be cleared by code:

- **opengrep** "dangerous-subprocess-use-audit" on `os.execvp` — the no-shell argv invocation is the *required* injection-safe spawn (fw-adr-0027 §3a R1 / CWE-88; security-engineer approved). Codacy's opengrep wrapper ignores inline `# nosemgrep`.
- **lizard** complexity 9 > limit 8 on `_read_until_done` — already factored into helpers + reviewed; Codacy's limit is stricter than the project's pylint config (file rates pylint 10/10).

Mechanism is **per-engine `exclude_paths`** (researcher-confirmed against docs.codacy.com as the only committed-file lever — per-rule ignore + complexity threshold are dashboard-only). It scopes **only** opengrep + lizard off this one file; **Bandit, Ruff, Pylint, duplication, metric still analyze it**.

Since `main` has no `.codacy.yaml` yet, this config applies to this PR's own analysis (default-branch precedence doesn't apply until merge) — so Codacy should come back clean here.

code-reviewer APPROVED · routing-lint 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)